### PR TITLE
Enhance the helm charts implementation.

### DIFF
--- a/charts/vineyard/README.md
+++ b/charts/vineyard/README.md
@@ -1,11 +1,9 @@
 vineyard charts
 ===============
 
-![Vineyard](https://v6d.io/_static/vineyard-logo.png)
-
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/vineyard)](https://artifacthub.io/packages/helm/vineyard/vineyard)
 
-Vineyard is an in-memory immutable data manager that provides **out-of-box high-level**
+[Vineyard][3] is an in-memory immutable data manager that provides **out-of-box high-level**
 abstraction and **zero-copy in-memory** sharing for distributed data in big data tasks,
 such as numerical computing, machine learning, and graph analytics.
 
@@ -39,3 +37,4 @@ Please note that third-party libraries may not have the same license as vineyard
 
 [1]: https://artifacthub.io/packages/helm/vineyard/vineyard
 [2]: https://github.com/v6d-io/v6d/blob/main/charts/vineyard/values.yaml
+[3]: https://github.com/v6d-io/v6d

--- a/charts/vineyard/README.md
+++ b/charts/vineyard/README.md
@@ -1,6 +1,8 @@
 vineyard charts
 ===============
 
+![Vineyard](https://v6d.io/_static/vineyard-logo.png)
+
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/vineyard)](https://artifacthub.io/packages/helm/vineyard/vineyard)
 
 Vineyard is an in-memory immutable data manager that provides **out-of-box high-level**
@@ -13,15 +15,27 @@ Install
 Vineyard is an has been integrated with [Helm](https://helm.sh/). Deploy vineyard as
 a `DaemonSet` using `helm`:
 
-```bash
+```console
 helm repo add vineyard https://vineyard.oss-ap-southeast-1.aliyuncs.com/charts/
 helm install vineyard vineyard/vineyard
 ```
 
-More information about the helm chart could be found at [artifacthub](https://artifacthub.io/packages/helm/vineyard/vineyard).
+Uninstall
+---------
+
+The installed charts can be removed with
+
+```console
+helm uninstall vineyard
+```
+
+More information about the helm chart could be found at [artifacthub][1] and [parameters][2].
 
 License
 -------
 
 **vineyard** is distributed under [Apache License 2.0](https://github.com/v6d-io/v6d/blob/main/LICENSE).
 Please note that third-party libraries may not have the same license as vineyard.
+
+[1]: https://artifacthub.io/packages/helm/vineyard/vineyard
+[2]: https://github.com/v6d-io/v6d/blob/main/charts/vineyard/values.yaml

--- a/charts/vineyard/templates/NOTES.txt
+++ b/charts/vineyard/templates/NOTES.txt
@@ -1,8 +1,22 @@
 It works! Vineyard has been deployed in your kubernetes.
 
+{{- if eq .Values.vineyard.volumeType "persistentVolumeClaim" }}
+
+The UNIX-domain socket is placed on persistVolumeClaim at:
+
+    {{ .Values.vineyard.persistVolumeClaimName }}
+
+on every hosts.
+
+{{- end }}
+
+{{- if eq .Values.vineyard.volumeType "hostPath" }}
+
 The UNIX-domain socket is placed on hosts at:
 
     /var/run/vineyard-{{ .Release.Namespace }}-{{ include "vineyard.fullname" . }}
+
+{{- end }}
 
 The vineyard RPC service could be found by:
 

--- a/charts/vineyard/templates/daemonset.yaml
+++ b/charts/vineyard/templates/daemonset.yaml
@@ -105,9 +105,20 @@ spec:
             mountPath: /dev/shm
 
       volumes:
+      {{- if eq .Values.vineyard.volumeType "hostPath" }}
       - name: run
         hostPath:
+          {{- if .Values.vineyard.hostPath }}
+          path: {{ .Values.vineyard.hostPath }}
+          {{- else }}
           path: /var/run/vineyard-{{ .Release.Namespace }}-{{ include "vineyard.fullname" . }}
+          {{- end }}
+      {{- end }}
+      {{- if eq .Values.vineyard.volumeType "persistentVolumeClaim" }}
+      - name: run
+        persistentVolumeClaim:
+          claimName: "{{ .Values.vineyard.persistVolumeClaimName }}"
+      {{- end }}
       - name: shm
         emptyDir:
           medium: Memory

--- a/charts/vineyard/templates/domain-socket-pvc.yaml
+++ b/charts/vineyard/templates/domain-socket-pvc.yaml
@@ -1,0 +1,21 @@
+{{- if eq .Values.vineyard.volumeType "persistentVolumeClaim" }}
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.vineyard.persistVolumeClaimName }}
+  labels:
+    {{- include "vineyard.labels" . | nindent 4 }}
+spec:
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: {{ .Values.vineyard.size }}
+  storageClassName: {{ .Values.vineyard.storageClass }}
+  accessModes:
+{{ toYaml .Values.vineyard.accessModes | trim | indent 4 }}
+  selector:
+    matchLabels:
+      {{- include "vineyard.selectorLabels" . | nindent 6 }}
+
+{{- end }}

--- a/charts/vineyard/templates/tests/test-rpc.yaml
+++ b/charts/vineyard/templates/tests/test-rpc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{ include "vineyard.fullname" . }}-test-ipc-service"
+  name: "{{ include "vineyard.fullname" . }}-test-rpc-service"
   labels:
     {{- include "vineyard.labels" . | nindent 4 }}
   annotations:
@@ -10,6 +10,6 @@ spec:
   containers:
     - name: wget
       image: busybox
-      command: ['bash', '-c']
-      args: ['true']
+      command: ['wget']
+      args: ['{{ include "vineyard.fullname" . }}:{{ .Values.service.port }}']
   restartPolicy: Never

--- a/charts/vineyard/values.yaml
+++ b/charts/vineyard/values.yaml
@@ -39,6 +39,22 @@ affinity: {}
 vineyard:
   sharedMemorySize: ""
 
+  # volumeType controls the type of UNIX-domain socket volume, can
+  # be either "persistentVolumeClaim" or "hostPath"
+  volumeType: hostPath
+  size: 1Mi
+
+  # PVC name if volume type is persistentVolumeClaim
+  persistVolumeClaimName: "vineyard-domain-socket"
+  accessModes:
+    - ReadWriteOnce
+  storageClass: standard
+
+  # host path if volume type is "hostPath", the default value will be
+  #
+  #   /var/run/vineyard-{{ .Release.Namespace }}-{{ include "vineyard.fullname" . }}
+  hostPath: ""
+
 serviceAccountName: ""
 
 tolerations: {}


### PR DESCRIPTION

## What do these changes do?

The unix-domain socket for vineyardd can be placed on a PVC now.

## Related issue number

Fixes #274
