### PR TITLE
Fixes data-race in delete (local) metadata, and start heartbeat when previous round finished.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -288,6 +288,7 @@ jobs:
           export TMPDIR="${TMPDIR:-$(dirname $(mktemp))}"
 
           rm -rf default.etcd
+          rm -rf /dev/shm/etcd*
           python3 test/runner.py --with-cpp
 
       - name: Setup tmate session
@@ -298,6 +299,9 @@ jobs:
         uses: sighingnow/action-tmate@master
         with:
           script-to-run: |
+            # enable coredump for debugging
+            ulimit -c unlimited
+
             export VINEYARD_DEV=TRUE
 
             export VINEYARD_DATA_DIR=`pwd`/gstest
@@ -305,6 +309,7 @@ jobs:
             export TMPDIR="${TMPDIR:-$(dirname $(mktemp))}"
 
             rm -rf default.etcd
+            rm -rf /dev/shm/etcd*
             python3 test/runner.py --with-python --with-migration
 
       - name: Setup tmate session
@@ -320,6 +325,7 @@ jobs:
           export TMPDIR="${TMPDIR:-$(dirname $(mktemp))}"
 
           rm -rf default.etcd
+          rm -rf /dev/shm/etcd*
           python3 test/runner.py --with-io --with-migration
 
       - name: Setup tmate session

--- a/python/client.cc
+++ b/python/client.cc
@@ -375,6 +375,11 @@ void bind_client(py::module& mod) {
              return ClientManager<Client>::GetManager()->Disconnect(
                  self->IPCSocket());
            })
+      .def("fork", [](Client *self) {
+        std::shared_ptr<Client> client(new Client());
+        throw_on_error(self->Fork(*client));
+        return client;
+      })
       .def("__enter__", [](Client* self) { return self; })
       .def("__exit__", [](Client* self, py::object, py::object, py::object) {
         // DO NOTHING
@@ -431,6 +436,11 @@ void bind_client(py::module& mod) {
              return ClientManager<RPCClient>::GetManager()->Disconnect(
                  self->RPCEndpoint());
            })
+      .def("fork", [](Client *self) {
+        std::shared_ptr<Client> client(new Client());
+        throw_on_error(self->Fork(*client));
+        return client;
+      })
       .def_property_readonly("remote_instance_id", &RPCClient::remote_instance_id)
       .def("__enter__", [](RPCClient* self) { return self; })
       .def("__exit__", [](RPCClient* self, py::object, py::object, py::object) {

--- a/python/error.cc
+++ b/python/error.cc
@@ -45,7 +45,7 @@ namespace vineyard {
 #ifndef THROW_ON_ERROR_OF
 #define THROW_ON_ERROR_OF(name) \
   case StatusCode::k##name:     \
-    throw name##Exception(status.message())
+    throw name##Exception(status.ToString())
 #endif
 
 DEFINE_PYBIND_EXCEPTION(Invalid);

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -383,7 +383,8 @@ Status Client::GetBuffer(const ObjectID id,
   std::map<ObjectID, std::shared_ptr<arrow::Buffer>> buffers;
   RETURN_ON_ERROR(GetBuffers({id}, buffers));
   if (buffers.empty()) {
-    return Status::ObjectNotExists();
+    return Status::ObjectNotExists("buffer not exists: " +
+                                   ObjectIDToString(id));
   }
   buffer = buffers.at(id);
   return Status::OK();

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -349,7 +349,8 @@ class Client : public ClientBase {
   Status GetObject(const ObjectID id, std::shared_ptr<T>& object) {
     object = std::dynamic_pointer_cast<T>(GetObject(id));
     if (object == nullptr) {
-      return Status::ObjectNotExists();
+      return Status::ObjectNotExists("object not exists: " +
+                                     ObjectIDToString(id));
     } else {
       return Status::OK();
     }

--- a/src/client/rpc_client.h
+++ b/src/client/rpc_client.h
@@ -172,7 +172,8 @@ class RPCClient : public ClientBase {
   Status GetObject(const ObjectID id, std::shared_ptr<T>& object) {
     object = std::dynamic_pointer_cast<T>(GetObject(id));
     if (object == nullptr) {
-      return Status::ObjectNotExists();
+      return Status::ObjectNotExists("object not exists: " +
+                                     ObjectIDToString(id));
     } else {
       return Status::OK();
     }

--- a/src/common/util/protocols.cc
+++ b/src/common/util/protocols.cc
@@ -208,7 +208,8 @@ Status ReadGetDataReply(const json& root, json& content) {
   // should be only one item
   auto content_group = root["content"];
   if (content_group.size() != 1) {
-    return Status::ObjectNotExists();
+    return Status::ObjectNotExists("failed to parse get_data reply: " +
+                                   root.dump());
   }
   content = *content_group.begin();
   return Status::OK();

--- a/src/server/memory/memory.cc
+++ b/src/server/memory/memory.cc
@@ -313,7 +313,7 @@ Status BulkStore::FinalizeArena(const int fd,
   VLOG(2) << "finalizing arena (fd) " << fd << "...";
   auto arena = arenas_.find(fd);
   if (arena == arenas_.end()) {
-    return Status::ObjectNotExists("Arena for fd " + std::to_string(fd) +
+    return Status::ObjectNotExists("arena for fd " + std::to_string(fd) +
                                    " cannot be found");
   }
   if (offsets.size() != sizes.size()) {

--- a/src/server/memory/stream_store.cc
+++ b/src/server/memory/stream_store.cc
@@ -47,7 +47,8 @@ Status StreamStore::Create(ObjectID const stream_id) {
 
 Status StreamStore::Open(ObjectID const stream_id, int64_t const mode) {
   if (streams_.find(stream_id) == streams_.end()) {
-    return Status::ObjectNotExists();
+    return Status::ObjectNotExists("stream cannot be open: " +
+                                   ObjectIDToString(stream_id));
   }
   if (streams_[stream_id]->open_mark & mode) {
     return Status::StreamOpened();
@@ -61,7 +62,8 @@ Status StreamStore::Open(ObjectID const stream_id, int64_t const mode) {
 Status StreamStore::Get(ObjectID const stream_id, size_t const size,
                         callback_t<const ObjectID> callback) {
   if (streams_.find(stream_id) == streams_.end()) {
-    return callback(Status::ObjectNotExists(), InvalidObjectID());
+    return callback(Status::ObjectNotExists("failed to pull from stream"),
+                    InvalidObjectID());
   }
   auto stream = streams_.at(stream_id);
 
@@ -109,7 +111,8 @@ Status StreamStore::Get(ObjectID const stream_id, size_t const size,
 Status StreamStore::Pull(ObjectID const stream_id,
                          callback_t<const ObjectID> callback) {
   if (streams_.find(stream_id) == streams_.end()) {
-    return callback(Status::ObjectNotExists(), InvalidObjectID());
+    return callback(Status::ObjectNotExists("failed to put to stream"),
+                    InvalidObjectID());
   }
   auto stream = streams_.at(stream_id);
 
@@ -164,7 +167,8 @@ Status StreamStore::Pull(ObjectID const stream_id,
 
 Status StreamStore::Stop(ObjectID const stream_id, bool failed) {
   if (streams_.find(stream_id) == streams_.end()) {
-    return Status::ObjectNotExists();
+    return Status::ObjectNotExists("failed to stop stream: " +
+                                   ObjectIDToString(stream_id));
   }
   auto stream = streams_.at(stream_id);
   // the stream is still running
@@ -219,7 +223,8 @@ Status StreamStore::Stop(ObjectID const stream_id, bool failed) {
 
 Status StreamStore::Drop(ObjectID const stream_id) {
   if (streams_.find(stream_id) == streams_.end()) {
-    return Status::ObjectNotExists();
+    return Status::ObjectNotExists("failed to drop stream: " +
+                                   ObjectIDToString(stream_id));
   }
   auto stream = streams_.at(stream_id);
   stream->failed = true;

--- a/src/server/util/meta_tree.cc
+++ b/src/server/util/meta_tree.cc
@@ -162,7 +162,7 @@ static Status get_sub_tree(const json& tree, const std::string& prefix,
       return Status::OK();
     }
   }
-  return Status::MetaTreeSubtreeNotExists(name);
+  return Status::MetaTreeSubtreeNotExists("get subtree failed: " + name);
 }
 
 static bool has_sub_tree(const json& tree, const std::string& prefix,
@@ -413,7 +413,7 @@ Status DelDataOps(const json& tree, const std::string& name,
       return Status::OK();
     }
   }
-  return Status::MetaTreeSubtreeNotExists(name);
+  return Status::MetaTreeSubtreeNotExists("delete subtree failed: " + name);
 }
 
 static void generate_put_ops(const json& meta, const json& diff,


### PR DESCRIPTION
The later part will helps to reduce the traffic between etcd server, more specifically,

+ fixes a data-race bug in deletion
+ fixes a "pass-by-ref" bug in `RequestToGetData`, which leads to many bugs when contention is high.
+ start hearbeat after the previous round finishes
+ improve the error message for "ObjectNotExistsException" in Python SDK.

Fixes #294.