### PR TITLE
Add a command-line option to vineyardd for disabling the RPC service.

### DIFF
--- a/src/server/util/spec_resolvers.cc
+++ b/src/server/util/spec_resolvers.cc
@@ -36,6 +36,7 @@ DEFINE_int64(stream_threshold, 80,
 // ipc
 DEFINE_string(socket, "/var/run/vineyard.sock", "IPC socket file location");
 // rpc
+DEFINE_bool(rpc, true, "Enable RPC service by default");
 DEFINE_int32(rpc_socket_port, 9600, "port to listen in rpc server");
 // Kubernetes
 DEFINE_bool(sync_crds, false, "Synchronize CRDs when persisting objects");
@@ -132,6 +133,7 @@ json IpcSpecResolver::resolve() const {
 
 json RpcSpecResolver::resolve() const {
   json spec;
+  spec["rpc"] = FLAGS_rpc;
   spec["port"] = FLAGS_rpc_socket_port;
   return spec;
 }


### PR DESCRIPTION
## What do these changes do?

Add a command line argument `rpc` to vineyardd, with default value `True`, and can be disabled by `-norpc`, to allow the RPC service been disabled when necessary.

That will help cases where we won't to launch multiple vineyardd instances but we are not willing to specify different RPC port for them.

This pull request bump the etcd-cpp-apiv3 submodule as well.

## Related issue number

Resolves #317.
