### PR TITLE
Enhancement on vineyard resolver/builder for better support for native types.

### DIFF
--- a/python/vineyard/__init__.py
+++ b/python/vineyard/__init__.py
@@ -91,6 +91,13 @@ from ._C import ArrowErrorException, \
 from . import _vineyard_docs
 del _vineyard_docs
 
+from . import core
+from . import data
+from . import deploy
+from . import io
+from . import launcher
+from . import shared_memory
+
 from .core import default_builder_context, default_resolver_context, default_driver_context
 from .data import register_builtin_types
 from .data.graph import Graph

--- a/python/vineyard/data/__init__.py
+++ b/python/vineyard/data/__init__.py
@@ -16,6 +16,16 @@
 # limitations under the License.
 #
 
+from . import arrow
+from . import base
+from . import dataframe
+from . import default
+from . import graph
+from . import index
+from . import pickle
+from . import series
+from . import tensor
+
 from vineyard.core.builder import default_builder_context
 from vineyard.core.resolver import default_resolver_context
 from vineyard.data.default import register_default_types

--- a/python/vineyard/data/base.py
+++ b/python/vineyard/data/base.py
@@ -59,7 +59,7 @@ def bytes_builder(client, value, **kwargs):
 
 def memoryview_builder(client, value, **kwargs):
     buffer = client.create_blob(len(value))
-    buffer.copy(0, id(value), len(value))
+    buffer.copy(0, bytes(value))
     return buffer.seal(client).id
 
 

--- a/python/vineyard/data/base.py
+++ b/python/vineyard/data/base.py
@@ -51,6 +51,18 @@ def string_builder(client, value, **kwargs):
     return client.create_metadata(meta)
 
 
+def bytes_builder(client, value, **kwargs):
+    buffer = client.create_blob(len(value))
+    buffer.copy(0, value)
+    return buffer.seal(client).id
+
+
+def memoryview_builder(client, value, **kwargs):
+    buffer = client.create_blob(len(value))
+    buffer.copy(0, id(value), len(value))
+    return buffer.seal(client).id
+
+
 def tuple_builder(client, value, builder, **kwargs):
     if len(value) == 2:
         # use pair
@@ -90,6 +102,10 @@ def scalar_resolver(obj):
     return None
 
 
+def bytes_resolver(obj):
+    return memoryview(obj)
+
+
 def pair_resolver(obj, resolver):
     fst = obj.member('first_')
     snd = obj.member('second_')
@@ -116,8 +132,11 @@ def register_base_types(builder_ctx=None, resolver_ctx=None):
         builder_ctx.register(float, double_builder)
         builder_ctx.register(str, string_builder)
         builder_ctx.register(tuple, tuple_builder)
+        builder_ctx.register(bytes, bytes_builder)
+        builder_ctx.register(memoryview, memoryview_builder)
 
     if resolver_ctx is not None:
+        resolver_ctx.register('vineyard::Blob', bytes_resolver)
         resolver_ctx.register('vineyard::Scalar', scalar_resolver)
         resolver_ctx.register('vineyard::Pair', pair_resolver)
         resolver_ctx.register('vineyard::Tuple', tuple_resolver)

--- a/python/vineyard/data/default.py
+++ b/python/vineyard/data/default.py
@@ -21,19 +21,26 @@ import pickle
 if pickle.HIGHEST_PROTOCOL < 5:
     import pickle5 as pickle
 
+from vineyard._C import ObjectMeta
 
-def default_builder(client, value):
+
+def default_builder(client, value, **kwargs):
     ''' Default builder: pickle (version 5), then build a blob object for it.
     '''
     payload = pickle.dumps(value, protocol=5)
-
     buffer = client.create_blob(len(payload))
     buffer.copy(0, payload)
-    return buffer.seal(client).id
+
+    meta = ObjectMeta(**kwargs)
+    meta['typename'] = 'vineyard::PickleBuffer'
+    meta['nbytes'] = len(payload)
+    meta['size_'] = len(payload)
+    meta.add_member('buffer_', buffer.seal(client))
+    return client.create_metadata(meta)
 
 
 def default_resolver(obj):
-    view = memoryview(obj)
+    view = memoryview(obj.member('buffer_'))[0:int(obj.meta['size_'])]
     return pickle.loads(view, fix_imports=True)
 
 
@@ -42,4 +49,4 @@ def register_default_types(builder_ctx=None, resolver_ctx=None):
         builder_ctx.register(object, default_builder)
 
     if resolver_ctx is not None:
-        resolver_ctx.register('vineyard::Blob', default_resolver)
+        resolver_ctx.register('vineyard::PickleBuffer', default_resolver)

--- a/python/vineyard/data/tests/test_base.py
+++ b/python/vineyard/data/tests/test_base.py
@@ -40,6 +40,18 @@ def test_string(vineyard_client):
     assert vineyard_client.get(object_id) == 'abcde'
 
 
+def test_bytes(vineyard_client):
+    bs = b'abcde'
+    object_id = vineyard_client.put(bs)
+    assert vineyard_client.get(object_id) == memoryview(bs)
+
+
+def test_memoryview(vineyard_client):
+    bs = memoryview(b'abcde')
+    object_id = vineyard_client.put(bs)
+    assert vineyard_client.get(object_id) == bs
+
+
 def test_pair(vineyard_client):
     object_id = vineyard_client.put((1, "2"))
     assert vineyard_client.get(object_id) == (1, "2")

--- a/python/vineyard/data/tests/test_default.py
+++ b/python/vineyard/data/tests/test_default.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 #
 
+import numpy as np
 import pytest
 
 import vineyard
@@ -23,6 +24,26 @@ from vineyard.core import default_builder_context, default_resolver_context
 from vineyard.data import register_builtin_types
 
 register_builtin_types(default_builder_context, default_resolver_context)
+
+
+def test_bool(vineyard_client):
+    value = True
+    object_id = vineyard_client.put(value)
+    assert vineyard_client.get(object_id) == value
+
+    value = False
+    object_id = vineyard_client.put(value)
+    assert vineyard_client.get(object_id) == value
+
+
+def test_np_bool(vineyard_client):
+    value = np.bool_(True)
+    object_id = vineyard_client.put(value)
+    assert vineyard_client.get(object_id) == value
+
+    value = np.bool_(False)
+    object_id = vineyard_client.put(value)
+    assert vineyard_client.get(object_id) == value
 
 
 def test_list(vineyard_client):

--- a/python/vineyard/data/tests/test_pickle.py
+++ b/python/vineyard/data/tests/test_pickle.py
@@ -29,12 +29,23 @@ b128m = 128 * 1024 * 1024
 
 values = [
     (b1m, 1),
+    (b1m, True),
+    (b1m, False),
+    (b1m, (True, False)),
+    (b1m, [True, False]),
     (b1m, (1, 2, 3)),
     (b1m, [1, 2, 3, 4]),
     (b1m, "dsdfsdf"),
     (b1m, (1, "sdfsdfs")),
+    (b1m, b"dsdfsdf"),
+    (b1m, memoryview(b"sdfsdfs")),
     (b1m, [1] * 100000000),
+    (b1m, np.bool_(True)),
+    (b1m, np.bool_(False)),
+    (b1m, (np.bool_(True), np.bool_(False))),
+    (b1m, [np.bool_(True), np.bool_(False)]),
     (b1m, np.arange(1024 * 1024 * 400)),
+    (b16m, np.zeros((1024, 1024, 48), dtype='bool')),
     (b16m, np.zeros((1024, 1024, 48))),
     (b64m, np.zeros((1024, 1024, 512))),
     (b1m, pd.DataFrame({


### PR DESCRIPTION
## What do these changes do?

+ Enhance support for `bytes`, `memoryview` and `numpy.bool_` types.
+ Introduce a `vineyard::PickleBuffer` type to represent things that fall back to default builder, and differ it from raw bytes/memoryviews (which are `vineyard::Blob`).

## Related issue number

N/A.
