### PR TITLE
Fixes issues in deploying vineyardd using python interface.

### DIFF
--- a/python/vineyard/deploy/__init__.py
+++ b/python/vineyard/deploy/__init__.py
@@ -16,6 +16,10 @@
 # limitations under the License.
 #
 
-from . import distributed
-from . import kubernetes
 from . import local
+from . import distributed
+
+try:
+    from . import kubernetes
+except ImportError:
+    pass

--- a/python/vineyard/deploy/distributed.py
+++ b/python/vineyard/deploy/distributed.py
@@ -122,3 +122,6 @@ def start_vineyardd(hosts=None,
                 proc.kill()
         if etcd_ctx is not None:
             etcd_ctx.__exit__(None, None, None)  # pylint: disable=no-member
+
+
+__all__ = ['start_vineyardd']

--- a/python/vineyard/deploy/kubernetes.py
+++ b/python/vineyard/deploy/kubernetes.py
@@ -26,7 +26,7 @@ import textwrap
 import time
 import yaml
 
-from .utils import start_etcd_k8s
+from .etcd import start_etcd_k8s
 
 logger = logging.getLogger('vineyard')
 
@@ -76,3 +76,6 @@ def start_vineyardd(namespace='vineyard', size='256Mi', socket='/var/run/vineyar
         return kubernetes.utils.create_from_yaml(k8s_client, rendered.name, namespace=namespace)
     finally:
         os.unlink(rendered.name)
+
+
+__all__ = ['start_vineyardd']

--- a/python/vineyard/io/core.py
+++ b/python/vineyard/io/core.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env python
+#! /usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright 2020 Alibaba Group Holding Limited.
+# Copyright 2020-2021 Alibaba Group Holding Limited.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-from . import distributed
-from . import kubernetes
-from . import local


### PR DESCRIPTION
## What do these changes do?

This pull request starts to support deploy multiple vineyardd instances, by specifying a generated unique "--socket" argument, as well as unique data dir for standalone etcd.

The RPC service can be disabled when launching from vineyard (launching multiple worker on the same single host) from python interface as well.

## Related issue number

Related to #317 .
