### PR TITLE
Install shared-memory38 as deps for python<=3.7 as well.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,6 +117,7 @@ setup(
         'pickle5; python_version<="3.7"',
         'pyarrow',
         'setuptools',
+        'shared-memory38; python_version<="3.7"',
         'sortedcontainers',
     ],
     extras_require={


### PR DESCRIPTION
Followup work for #329, and fixes #327.

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #327

