### PR TITLE
Fixs issues in associate a backtrace to erroneous status.(v6d-io#326)

### DIFF
--- a/src/common/util/status.cc
+++ b/src/common/util/status.cc
@@ -36,9 +36,13 @@ Status::Status(StatusCode code, const std::string& msg) {
   state_ = new State;
   state_->code = code;
   state_->msg = msg;
-  std::stringstream ss;
-  vineyard::backtrace_info::backtrace(ss, true);
-  backtrace_ = ss.str();
+#ifndef NDEBUG
+  if (VLOG_IS_ON(11) && code != StatusCode::kOK) {
+    std::stringstream ss;
+    vineyard::backtrace_info::backtrace(ss, true);
+    backtrace_ = ss.str();
+  }
+#endif
 }
 
 void Status::CopyFrom(const Status& s) {

--- a/src/common/util/status.cc
+++ b/src/common/util/status.cc
@@ -41,14 +41,6 @@ Status::Status(StatusCode code, const std::string& msg) {
   backtrace_ = ss.str();
 }
 
-Status::Status(StatusCode code, const std::string& msg, const std::string& bt)
-    : backtrace_(bt) {
-  CHECK_NE(code, StatusCode::kOK) << "Cannot construct ok status with message";
-  state_ = new State;
-  state_->code = code;
-  state_->msg = msg;
-}
-
 void Status::CopyFrom(const Status& s) {
   delete state_;
   if (s.state_ == nullptr) {

--- a/src/common/util/status.cc
+++ b/src/common/util/status.cc
@@ -26,11 +26,23 @@
 #include <iostream>
 #include <string>
 
+#include "common/backtrace/backtrace.hpp"
 #include "common/util/logging.h"
 
 namespace vineyard {
 
 Status::Status(StatusCode code, const std::string& msg) {
+  CHECK_NE(code, StatusCode::kOK) << "Cannot construct ok status with message";
+  state_ = new State;
+  state_->code = code;
+  state_->msg = msg;
+  std::stringstream ss;
+  vineyard::backtrace_info::backtrace(ss, true);
+  backtrace_ = ss.str();
+}
+
+Status::Status(StatusCode code, const std::string& msg, const std::string& bt)
+    : backtrace_(bt) {
   CHECK_NE(code, StatusCode::kOK) << "Cannot construct ok status with message";
   state_ = new State;
   state_->code = code;

--- a/src/common/util/status.h
+++ b/src/common/util/status.h
@@ -235,7 +235,6 @@ class VINEYARD_MUST_USE_TYPE Status {
     }
   }
   Status(StatusCode, const std::string& msg);
-  Status(StatusCode, const std::string& msg, const std::string& bt);
   // Copy the specified status.
   inline Status(const Status& s);
   inline Status& operator=(const Status& s);

--- a/src/common/util/status.h
+++ b/src/common/util/status.h
@@ -235,6 +235,7 @@ class VINEYARD_MUST_USE_TYPE Status {
     }
   }
   Status(StatusCode, const std::string& msg);
+  Status(StatusCode, const std::string& msg, const std::string& bt);
   // Copy the specified status.
   inline Status(const Status& s);
   inline Status& operator=(const Status& s);
@@ -551,6 +552,7 @@ class VINEYARD_MUST_USE_TYPE Status {
 
   template <typename T>
   Status& operator<<(const T& s);
+  const std::string Backtrace() const { return backtrace_; }
 
  private:
   struct State {
@@ -560,6 +562,8 @@ class VINEYARD_MUST_USE_TYPE Status {
   // OK status has a `NULL` state_.  Otherwise, `state_` points to
   // a `State` structure containing the error code and message(s)
   State* state_;
+  // OK status has a `NULL` backtrace_.
+  std::string backtrace_;
 
   void DeleteState() {
     delete state_;


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------
Associate a backtrace to erroneous Status.
1. Add a `std::string backtrace_` field into the `class Status`
2. Add a getter `const std::string Status::Backtrace() const {}` to `class Status`
3. In constructor of `Status`, when the status code is not “OK", initialize the `backtrace_` field by calling `vineyard::backtrace_info::backtrace()`.


Related issue number
--------------------
Fixes #326

