### PR TITLE
Enhance the support for migration + deletion.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,6 +230,7 @@ endmacro(find_libunwind)
 macro(find_nlohmann_json)
     # include nlohmann/json
     set(JSON_BuildTests OFF CACHE INTERNAL "")
+    set(JSON_Diagnostics ON CACHE INTERNAL "")
     set(JSON_Install ON CACHE INTERNAL "")
     set(JSON_MultipleHeaders ON CACHE INTERNAL "")
     set(JSON_ImplicitConversions OFF CACHE INTERNAL "")

--- a/python/client.cc
+++ b/python/client.cc
@@ -14,6 +14,7 @@ limitations under the License.
 */
 
 #include <memory>
+#include <sstream>
 
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"

--- a/python/pybind11_utils.h
+++ b/python/pybind11_utils.h
@@ -17,6 +17,7 @@ limitations under the License.
 #define PYBIND_11_UTILS_H__
 
 #include <functional>
+#include <sstream>
 
 #include "pybind11/pybind11.h"
 

--- a/python/vineyard/deploy/tests/test_migration.py
+++ b/python/vineyard/deploy/tests/test_migration.py
@@ -39,7 +39,7 @@ def test_migration(vineyard_ipc_sockets):
     client1 = vineyard.connect(vineyard_ipc_sockets[0])
     client2 = vineyard.connect(vineyard_ipc_sockets[1])
 
-    # test it metadata of remote object available
+    # test if metadata of remote object available
     data = np.ones((1, 2, 3, 4, 5))
     o = client1.put(data)
     client1.persist(o)
@@ -49,10 +49,89 @@ def test_migration(vineyard_ipc_sockets):
     # migrate local to local: do nothing.
     o1 = client1.migrate(o)
     assert o == o1
-    logger.info('------- finish round 1 --------')
+    logger.info('------- finish migrate local --------')
 
     # migrate remote to local: do nothing.
     o2 = client2.migrate(o)
     assert o != o2
     np.testing.assert_allclose(client1.get(o1), client2.get(o2))
-    logger.info('------- finish round 2 --------')
+    logger.info('------- finish migrate remote --------')
+
+
+@pytest.mark.skip_without_migration()
+def test_migration_and_deletion(vineyard_ipc_sockets):
+    vineyard_ipc_sockets = list(itertools.islice(itertools.cycle(vineyard_ipc_sockets), 2))
+
+    client1 = vineyard.connect(vineyard_ipc_sockets[0])
+    client2 = vineyard.connect(vineyard_ipc_sockets[1])
+
+    data1 = np.ones((1, 2, 3, 4, 5))
+    o1 = client1.put(data1)
+    client1.persist(o1)
+    meta1 = client2.get_meta(o1, sync_remote=True)
+    assert data1.shape == tuple(json.loads(meta1['shape_']))
+
+    data2 = np.zeros((1, 2, 3, 4, 5))
+    o2 = client2.put(data2)
+    client2.persist(o2)
+    meta2 = client1.get_meta(o2, sync_remote=True)
+    assert data2.shape == tuple(json.loads(meta2['shape_']))
+
+    # make the global object
+    o = client1.put((o1, o2), global_=True)
+    gmeta = client1.get_meta(o, sync_remote=True)
+    client1.persist(o)
+    assert not gmeta.islocal
+    assert gmeta.isglobal
+
+    # migrate o2 to h1, as o3
+    o3 = client1.migrate(o2)
+    assert o3 != o1
+    assert o3 != o2
+    logger.info('------- finish migrate remote --------')
+
+    # delete the o2
+    client1.sync_meta()
+    client1.delete(o2, force=False, deep=True)
+    logger.info('------- finish delete original chunk --------')
+
+    client1.sync_meta()
+    assert client1.exists(o)
+    assert client1.exists(o1)
+    assert client1.exists(o3)
+    assert not client1.exists(o2)
+
+    with pytest.raises(vineyard.ObjectNotExistsException):
+        print(client1.get_meta(o2))
+
+    client2.sync_meta()
+    assert client2.exists(o)
+    assert client2.exists(o1)
+    assert client2.exists(o3)
+    assert not client2.exists(o2)
+
+    with pytest.raises(vineyard.ObjectNotExistsException):
+        print(client2.get_meta(o2))
+
+    # delete the o3
+    client2.sync_meta()
+    client2.delete(o3, force=False, deep=True)
+    logger.info('------- finish delete migrated chunk --------')
+
+    client1.sync_meta()
+    assert client1.exists(o)
+    assert client1.exists(o1)
+    assert client1.exists(o3)
+    assert not client1.exists(o2)
+
+    with pytest.raises(vineyard.ObjectNotExistsException):
+        print(client1.get_meta(o2))
+
+    client2.sync_meta()
+    assert client2.exists(o)
+    assert client2.exists(o1)
+    assert client2.exists(o3)
+    assert not client2.exists(o2)
+
+    with pytest.raises(vineyard.ObjectNotExistsException):
+        print(client2.get_meta(o2))

--- a/src/server/server/vineyard_server.h
+++ b/src/server/server/vineyard_server.h
@@ -149,7 +149,11 @@ class VineyardServer : public std::enable_shared_from_this<VineyardServer> {
   Status ProcessDeferred(const json& meta);
 
   inline InstanceID instance_id() { return instance_id_; }
-  inline void set_instance_id(InstanceID id) { instance_id_ = id; }
+  inline std::string instance_name() { return instance_name_; }
+  inline void set_instance_id(InstanceID id) {
+    instance_id_ = id;
+    instance_name_ = "i" + std::to_string(instance_id_);
+  }
 
   inline std::string const& hostname() { return hostname_; }
   inline void set_hostname(std::string const& hostname) {
@@ -214,6 +218,7 @@ class VineyardServer : public std::enable_shared_from_this<VineyardServer> {
   std::atomic_bool stopped_;  // avoid invoke Stop() twice.
 
   InstanceID instance_id_;
+  std::string instance_name_;
   std::string hostname_;
   std::string nodename_;
 };

--- a/src/server/services/etcd_meta_service.cc
+++ b/src/server/services/etcd_meta_service.cc
@@ -88,8 +88,9 @@ void EtcdWatchHandler::operator()(etcd::Response const& resp) {
     // handle registered callbacks
     while (!registered_callbacks_.empty()) {
       auto iter = registered_callbacks_.front();
-      if (iter.first > (unsigned) resp.index())
+      if (iter.first > static_cast<unsigned>(resp.index())) {
         break;
+      }
       ctx_.post(boost::bind(iter.second, status, ops, resp.index()));
       registered_callbacks_.pop();
     }

--- a/src/server/util/etcd_launcher.cc
+++ b/src/server/util/etcd_launcher.cc
@@ -140,6 +140,11 @@ Status EtcdLauncher::LaunchEtcdServer(
   args.emplace_back("--initial-advertise-peer-urls");
   args.emplace_back(peer_endpoint);
 
+  if (VLOG_IS_ON(10)) {
+    args.emplace_back("--log-level");
+    args.emplace_back("debug");
+  }
+
   auto env = boost::this_process::environment();
   std::error_code ec;
   etcd_proc = std::make_unique<boost::process::child>(

--- a/src/server/util/meta_tree.h
+++ b/src/server/util/meta_tree.h
@@ -33,21 +33,25 @@ enum class NodeType {
   InvalidType = 15,
 };
 
-Status GetData(const json& tree, const ObjectID id, json& sub_tree,
+Status GetData(const json& tree, const std::string& instance_name,
+               const ObjectID id, json& sub_tree,
                InstanceID const& current_instance_id = UnspecifiedInstanceID());
-Status GetData(const json& tree, const std::string& name, json& sub_tree,
+Status GetData(const json& tree, const std::string& instance_name,
+               const std::string& name, json& sub_tree,
                InstanceID const& current_instance_id = UnspecifiedInstanceID());
-Status ListData(const json& tree, const std::string& pattern, bool const regex,
+Status ListData(const json& tree, const std::string& instance_name,
+                const std::string& pattern, bool const regex,
                 size_t const limit, json& tree_group);
 Status IfPersist(const json& tree, const ObjectID id, bool& persist);
 Status Exists(const json& tree, const ObjectID id, bool& exists);
 
-Status PutDataOps(const json& tree, const ObjectID id, const json& sub_tree,
+Status PutDataOps(const json& tree, const std::string& instance_name,
+                  const ObjectID id, const json& sub_tree,
                   std::vector<IMetaService::op_t>& ops,
                   InstanceID& computed_instance_id);
 
-Status PersistOps(const json& tree, const ObjectID id,
-                  std::vector<IMetaService::op_t>& ops);
+Status PersistOps(const json& tree, const std::string& instance_name,
+                  const ObjectID id, std::vector<IMetaService::op_t>& ops);
 
 Status DelDataOps(const json& tree, const ObjectID id,
                   std::vector<IMetaService::op_t>& ops, bool& sync_remote);
@@ -68,8 +72,11 @@ Status ShallowCopyOps(const json& tree, const ObjectID id,
 Status FilterAtInstance(const json& tree, const InstanceID& instance_id,
                         std::vector<ObjectID>& objects);
 
-Status DecodeObjectID(const json& tree, const std::string& value,
-                      ObjectID& object_id);
+Status DecodeObjectID(const json& tree, const std::string& instance_name,
+                      const std::string& value, ObjectID& object_id);
+
+bool HasEquivalent(const json& tree, ObjectID const object_id,
+                   ObjectID& equivalent);
 
 }  // namespace meta_tree
 

--- a/test/runner.py
+++ b/test/runner.py
@@ -300,6 +300,7 @@ def run_python_tests(etcd_endpoints, with_migration):
                          default_ipc_socket=VINEYARD_CI_IPC_SOCKET) as (_, rpc_socket_port):
         start_time = time.time()
         subprocess.check_call(['pytest', '-s', '-vvv', '--durations=0',
+                               '--log-cli-level', 'DEBUG',
                                'python/vineyard/core',
                                'python/vineyard/data',
                                'python/vineyard/shared_memory',
@@ -324,6 +325,7 @@ def run_python_deploy_tests(etcd_endpoints, with_migration):
         vineyard_ipc_sockets = ','.join(['%s.%d' % (ipc_socket_tpl, i) for i in range(instance_size)])
         start_time = time.time()
         subprocess.check_call(['pytest', '-s', '-vvv', '--durations=0',
+                               '--log-cli-level', 'DEBUG',
                                'python/vineyard/deploy/tests',
                                '--vineyard-ipc-sockets=%s' % vineyard_ipc_sockets] + extra_args,
                                cwd=os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
@@ -338,6 +340,7 @@ def run_io_adaptor_tests(etcd_endpoints, with_migration):
                          default_ipc_socket=VINEYARD_CI_IPC_SOCKET) as (_, rpc_socket_port):
         start_time = time.time()
         subprocess.check_call(['pytest', '-s', '-vvv', '--durations=0',
+                               '--log-cli-level', 'DEBUG',
                                'modules/io/python/drivers/io/tests',
                                '--vineyard-ipc-socket=%s' % VINEYARD_CI_IPC_SOCKET,
                                '--vineyard-endpoint=localhost:%s' % rpc_socket_port,
@@ -363,6 +366,7 @@ def run_io_adaptor_distributed_tests(etcd_endpoints, with_migration):
         rpc_socket_port = instances[0][1]
         start_time = time.time()
         subprocess.check_call(['pytest', '-s', '-vvv', '--durations=0',
+                               '--log-cli-level', 'DEBUG',
                                'modules/io/python/drivers/io/tests/test_migrate_stream.py',
                                '--vineyard-endpoint=localhost:%s' % rpc_socket_port,
                                '--vineyard-ipc-sockets=%s' % vineyard_ipc_sockets] + extra_args,


### PR DESCRIPTION
What do these changes do?
-------------------------

This PR overhaul the implementation of "signatures". We previously store signatures as

```
/signatures
     /sig -> object_id
```

Now we have

```
/signatures
    /instance_name
        /sig -> object_id
```

Such a change allow us to differ the replica for a object after migration, and do things correctly when deleting the migrated chunk or the original chunk after migration. The global object will be still kept complete and the deleted chunk could be freed as expected.

See also test case `test_migration_and_deletion` and `Note [Deleting global object and members]` for the detail about how we handle the use-ref in such cases.

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #212.

