### PR TITLE
Revise the install instruction for apache-arrow.

### DIFF
--- a/.github/workflows/build-compatibility.yml
+++ b/.github/workflows/build-compatibility.yml
@@ -99,8 +99,8 @@ jobs:
                               wget
 
           # install apache-arrow
-          wget https://apache.bintray.com/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb
-          sudo apt install -y -V ./apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb
+          wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+          sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
           sudo apt update
           sudo apt install -y libarrow-dev=${{ matrix.arrow }}
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -83,8 +83,8 @@ jobs:
           sudo mv etcd-v3.4.13-linux-amd64/etcdctl /usr/local/bin/
 
           # install apache-arrow
-          wget https://apache.bintray.com/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb
-          sudo apt install -y -V ./apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb
+          wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+          sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
           sudo apt update
           sudo apt install -y libarrow-dev=3.0.0-1 libarrow-python-dev=3.0.0-1
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -107,8 +107,8 @@ jobs:
                             wget
 
         # install apache-arrow
-        wget https://apache.bintray.com/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb
-        sudo apt install -y -V ./apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb
+        wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+        sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
         sudo apt update
         sudo apt install -y libarrow-dev=3.0.0-1
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -70,8 +70,8 @@ jobs:
                               wget
 
           # install apache-arrow
-          wget https://apache.bintray.com/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb
-          sudo apt install -y -V ./apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb
+          wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+          sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
           sudo apt update
           sudo apt install -y libarrow-dev=3.0.0-1 libarrow-python-dev=3.0.0-1
 

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -42,8 +42,8 @@ RUN export DEBIAN_FRONTEND="noninteractive" && \
         unzip \
         wget && \
     cd /tmp && \
-    wget https://apache.bintray.com/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb && \
-    apt install -y -V ./apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb && \
+    wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
+    apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
     apt update && \
     apt install -y libarrow-dev=1.0.1-1 libarrow-python-dev=1.0.1-1 && \
     rm -rf /tmp/apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb && \

--- a/docs/notes/install.rst
+++ b/docs/notes/install.rst
@@ -88,13 +88,13 @@ Vineyard has been fully tested on Ubuntu 20.04. The dependencies can be installe
                        python3-pip \
                        wget
 
-Then install the apache-arrow:
+Then install the apache-arrow (see also `https://arrow.apache.org/install <https://arrow.apache.org/install/>`_):
 
 .. code:: shell
 
-    wget https://bintray.com/apache/arrow/download_file?file_path=ubuntu%2Fapache-arrow-archive-keyring-latest-disco.deb \
-        -O /tmp/apache-arrow-archive-keyring-latest-disco.deb
-    apt install -y /tmp/apache-arrow-archive-keyring-latest-disco.deb
+    wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb \
+        -O /tmp/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+    apt install -y -V /tmp/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
     apt update -y
     apt install -y libarrow-dev
 
@@ -110,8 +110,7 @@ Vineyard has been tests on MacOS as well, the dependencies can be installed usin
 Install from source
 -------------------
 
-Vineyard is open source on Github: `https://github.com/v6d-io/v6d
-<https://github.com/v6d-io/v6d>`_.
+Vineyard is open source on Github: `https://github.com/v6d-io/v6d <https://github.com/v6d-io/v6d>`_.
 You can obtain the source code using ``git``:
 
 .. code:: console


### PR DESCRIPTION
What do these changes do?
-------------------------

The bintray download site has been deprecated and apache-arrow has moved to jfrog. This pull request updates related installation instructions to avoid misleading information to end users.

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #339

