### PR TITLE
Initialize the "handled_rev_" with a proper value.

### DIFF
--- a/src/server/services/etcd_meta_service.cc
+++ b/src/server/services/etcd_meta_service.cc
@@ -241,6 +241,7 @@ void EtcdMetaService::startDaemonWatch(
     const std::string& prefix, unsigned since_rev,
     callback_t<const std::vector<op_t>&, unsigned> callback) {
   try {
+    this->handled_rev_.store(since_rev);
     this->watcher_.reset(new etcd::Watcher(
         *etcd_, prefix_ + prefix, since_rev + 1,
         EtcdWatchHandler(server_ptr_->GetMetaContext(), callback, prefix_,


### PR DESCRIPTION

What do these changes do?
-------------------------

Otherwise when there's no incoming events and we still want to register
a callback on current watcher with HEAD revision (since_rev), the callback
won't be called immediately as expected.

The bug can be reproduced when there's only one instance.

As it is a "daemon watcher", we assume there's only one running backend
watcher.

Related issue number
--------------------

N/A, but related to #313.

