### PR TITLE
Enhance the tensor builder to return a customized subclass.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -128,6 +128,11 @@ jobs:
 
       - name: Setup SSH environment
         run: |
+          # avoid access node by DNS hostnames
+          r=`cat /etc/hosts | grep $(hostname) || true`
+          if [ -z "${r}" ];then export hn=$(hostname); sudo -E bash -c 'echo "127.0.0.1 ${hn}" >> /etc/hosts'; fi
+          cat /etc/hosts
+
           # setup SSH server to allow login without password
           cat > sshd_config <<EOF
             SyslogFacility AUTHPRIV

--- a/python/core.cc
+++ b/python/core.cc
@@ -154,6 +154,10 @@ void bind_core(py::module& mod) {
              self->AddMember(key, member);
            })
       .def("add_member",
+           [](ObjectMeta* self, std::string const& key, ObjectMeta const &member) {
+             self->AddMember(key, member);
+           })
+      .def("add_member",
            [](ObjectMeta* self, std::string const& key,
               ObjectIDWrapper const member) { self->AddMember(key, member); })
       .def("reset", [](ObjectMeta& meta) { meta.Reset(); })

--- a/python/vineyard/data/tensor.py
+++ b/python/vineyard/data/tensor.py
@@ -33,6 +33,12 @@ from vineyard._C import ObjectMeta
 from .utils import from_json, to_json, build_numpy_buffer, normalize_dtype, normalize_cpptype
 
 
+class ndarray(np.ndarray):
+    ''' To enable dynamic attribute on numpy.ndarray.
+    '''
+    pass
+
+
 def numpy_ndarray_builder(client, value, **kw):
     meta = ObjectMeta()
     meta['typename'] = 'vineyard::Tensor<%s>' % normalize_cpptype(value.dtype)
@@ -63,7 +69,8 @@ def numpy_ndarray_resolver(obj):
         return np.zeros(shape, dtype=value_type)
     c_array = np.frombuffer(memoryview(obj.member('buffer_')), dtype=value_type).reshape(shape)
     # TODO: revise the memory copy of asfortranarray
-    return (c_array if order == 'C' else np.asfortranarray(c_array))
+    array = (c_array if order == 'C' else np.asfortranarray(c_array))
+    return array.view(ndarray)
 
 
 def bsr_matrix_builder(client, value, builder, **kw):

--- a/python/vineyard/data/tensor.py
+++ b/python/vineyard/data/tensor.py
@@ -30,13 +30,10 @@ if pickle.HIGHEST_PROTOCOL < 5:
     import pickle5 as pickle
 
 from vineyard._C import ObjectMeta
-from .utils import from_json, to_json, build_numpy_buffer, normalize_dtype, normalize_cpptype
+from .utils import from_json, to_json, build_numpy_buffer, normalize_dtype, normalize_cpptype, wrap_type
 
-
-class ndarray(np.ndarray):
-    ''' To enable dynamic attribute on numpy.ndarray.
-    '''
-    pass
+# Enable dynamic attribute on numpy.ndarray.
+ndarray_wrapped = wrap_type(np.ndarray)
 
 
 def numpy_ndarray_builder(client, value, **kw):
@@ -70,7 +67,7 @@ def numpy_ndarray_resolver(obj):
     c_array = np.frombuffer(memoryview(obj.member('buffer_')), dtype=value_type).reshape(shape)
     # TODO: revise the memory copy of asfortranarray
     array = (c_array if order == 'C' else np.asfortranarray(c_array))
-    return array.view(ndarray)
+    return array.view(ndarray_wrapped)
 
 
 def bsr_matrix_builder(client, value, builder, **kw):

--- a/python/vineyard/data/utils.py
+++ b/python/vineyard/data/utils.py
@@ -27,6 +27,17 @@ if pickle.HIGHEST_PROTOCOL < 5:
     import pickle5 as pickle
 
 
+def wrap_type(ty):
+    class T(ty):
+        pass
+
+    T.__module__ = ty.__module__
+    T.__name__ = ty.__name__
+    T.__qualname__ = ty.__qualname__
+    T.__doc__ = ty.__doc__
+    return T
+
+
 def normalize_dtype(dtype, dtype_meta=None):
     ''' Normalize a descriptive C++ type to numpy.dtype.
     '''


### PR DESCRIPTION


What do these changes do?
-------------------------

Return a view of subclass of ndarray to support attach `__vineyard_ref` to the ndarray. 

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Related to #298.

