### PR TITLE
Improve the implementation of `create_metadata`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -567,10 +567,12 @@ endif()
 
 file(GLOB_RECURSE FILES_NEED_FORMAT "src/*.cc" "src/*.h" "src/*.hpp" "src/*.vineyard-mod"
                                     "modules/*.cc" "modules/*.h" "modules/*.vineyard-mod"
+                                    "python/*.cc" "python/*.h"
                                     "test/*.cc"
 )
 file(GLOB_RECURSE FILES_NEED_LINT "src/*.cc" "src/*.h" "src/*.hpp"
                                   "modules/*.cc" "modules/*.h"
+                                  "python/*.cc" "python/*.h"
                                   "test/*.cc"
 )
 

--- a/modules/io/python/drivers/io/stream.py
+++ b/modules/io/python/drivers/io/stream.py
@@ -156,9 +156,9 @@ class ParallelStreamLauncher(ScriptLauncher):
         for idx, partition_id in enumerate(partial_ids):
             meta.add_member("stream_%d" % idx, partition_id)
         vineyard_rpc_client = vineyard.connect(self.vineyard_endpoint)
-        ret_id = vineyard_rpc_client.create_metadata(meta)
-        vineyard_rpc_client.persist(ret_id)
-        return ret_id
+        ret_meta = vineyard_rpc_client.create_metadata(meta)
+        vineyard_rpc_client.persist(ret_meta.id)
+        return ret_meta.id
 
     def wait_all(self, func=None, **kwargs):
         results = []
@@ -479,9 +479,9 @@ def deserialize_from_stream(stream, vineyard_socket, *args, **kwargs):
             else:
                 new_meta[key] = value
         vineyard_rpc_client = vineyard.connect(vineyard_endpoint)
-        ret_id = vineyard_rpc_client.create_metadata(new_meta)
-        vineyard_rpc_client.persist(ret_id)
-        return ret_id
+        ret_meta = vineyard_rpc_client.create_metadata(new_meta)
+        vineyard_rpc_client.persist(ret_meta)
+        return ret_meta.id
 
     return launcher.wait_all(func=func)
 

--- a/modules/io/python/drivers/io/tests/test_migrate_stream.py
+++ b/modules/io/python/drivers/io/tests/test_migrate_stream.py
@@ -59,13 +59,13 @@ def test_migrate_stream(vineyard_ipc_sockets, vineyard_endpoint, test_dataset, t
     meta.set_global(True)
     meta['size_'] = 1
     meta.add_member("stream_0", new_stream)
-    ret_id = client2.create_metadata(meta)
-    client2.persist(ret_id)
+    ret_meta = client2.create_metadata(meta)
+    client2.persist(ret_meta)
 
     # output the global stream
     vineyard.io.open(
         "file://%s/p2p-31.out" % test_dataset_tmp,
-        ret_id,
+        ret_meta.id,
         mode="w",
         vineyard_ipc_socket=vineyard_ipc_sockets[1],
         vineyard_endpoint=vineyard_endpoint,

--- a/modules/io/python/drivers/io/tests/test_serialize.py
+++ b/modules/io/python/drivers/io/tests/test_serialize.py
@@ -53,9 +53,9 @@ def global_obj(vineyard_ipc_socket):
     meta.add_member('__elements_-2', o3)
     meta.add_member('__elements_-3', o4)
     meta['__elements_-size'] = 4
-    tupid = client1.create_metadata(meta)
-    client1.persist(tupid)
-    return tupid
+    tup = client1.create_metadata(meta)
+    client1.persist(tup)
+    return tup.id
 
 
 def test_seriarialize_round_trip(vineyard_ipc_socket, vineyard_endpoint, global_obj):

--- a/python/client.cc
+++ b/python/client.cc
@@ -26,10 +26,10 @@ limitations under the License.
 #include "common/util/status.h"
 #pragma GCC visibility pop
 
-#include "pybind11_utils.h"  // NOLINT(build/include)
+#include "pybind11_utils.h"  // NOLINT(build/include_subdir)
 
 namespace py = pybind11;
-using namespace py::literals;  // NOLINT(build/namespaces)
+using namespace py::literals;  // NOLINT(build/namespaces_literals)
 
 namespace vineyard {
 
@@ -132,15 +132,15 @@ void bind_client(py::module& mod) {
           "object_ids"_a, py::arg("force") = false, py::arg("deep") = true)
       .def(
           "delete",
-          [](ClientBase* self, const ObjectMeta &meta,
-             const bool force, const bool deep) {
+          [](ClientBase* self, const ObjectMeta& meta, const bool force,
+             const bool deep) {
             throw_on_error(self->DelData(meta.GetId(), force, deep));
           },
           "object_meta"_a, py::arg("force") = false, py::arg("deep") = true)
       .def(
           "delete",
-          [](ClientBase* self, const Object *object,
-             const bool force, const bool deep) {
+          [](ClientBase* self, const Object* object, const bool force,
+             const bool deep) {
             throw_on_error(self->DelData(object->id(), force, deep));
           },
           "object"_a, py::arg("force") = false, py::arg("deep") = true)
@@ -152,7 +152,7 @@ void bind_client(py::module& mod) {
           "object_id"_a)
       .def(
           "persist",
-          [](ClientBase* self, const ObjectMeta & meta) {
+          [](ClientBase* self, const ObjectMeta& meta) {
             throw_on_error(self->Persist(meta.GetId()));
           },
           "object_meta"_a)
@@ -195,22 +195,21 @@ void bind_client(py::module& mod) {
           "object_id"_a, "name"_a)
       .def(
           "put_name",
-          [](ClientBase* self, const ObjectMeta &meta,
+          [](ClientBase* self, const ObjectMeta& meta,
              std::string const& name) {
             throw_on_error(self->PutName(meta.GetId(), name));
           },
           "object_meta"_a, "name"_a)
       .def(
           "put_name",
-          [](ClientBase* self, const ObjectMeta &meta,
+          [](ClientBase* self, const ObjectMeta& meta,
              ObjectNameWrapper const& name) {
             throw_on_error(self->PutName(meta.GetId(), name));
           },
           "object_meta"_a, "name"_a)
       .def(
           "put_name",
-          [](ClientBase* self, const Object* object,
-             std::string const& name) {
+          [](ClientBase* self, const Object* object, std::string const& name) {
             throw_on_error(self->PutName(object->id(), name));
           },
           "object"_a, "name"_a)
@@ -251,11 +250,10 @@ void bind_client(py::module& mod) {
             throw_on_error(self->DropName(name));
           },
           "name"_a)
-      .def(
-          "sync_meta",
-          [](ClientBase *self) -> void {
-            VINEYARD_DISCARD(self->SyncMetaData());
-          })
+      .def("sync_meta",
+           [](ClientBase* self) -> void {
+             VINEYARD_DISCARD(self->SyncMetaData());
+           })
       .def(
           "migrate",
           [](ClientBase* self, const ObjectID object_id) -> ObjectIDWrapper {
@@ -406,28 +404,35 @@ void bind_client(py::module& mod) {
           "object_ids"_a, py::arg("sync_remote") = false)
       .def("list_objects", &Client::ListObjects, "pattern"_a,
            py::arg("regex") = false, py::arg("limit") = 5)
-      .def("allocated_size", [](Client *self, const ObjectID id) -> size_t {
-          size_t size = 0;
-          throw_on_error(self->AllocatedSize(id, size));
-          return size;
-      }, "target"_a)
-      .def("allocated_size", [](Client *self, const Object *target) -> size_t {
-          size_t size = 0;
-          if (target) {
-            throw_on_error(self->AllocatedSize(target->id(), size));
-          }
-          return size;
-      }, "target"_a)
+      .def(
+          "allocated_size",
+          [](Client* self, const ObjectID id) -> size_t {
+            size_t size = 0;
+            throw_on_error(self->AllocatedSize(id, size));
+            return size;
+          },
+          "target"_a)
+      .def(
+          "allocated_size",
+          [](Client* self, const Object* target) -> size_t {
+            size_t size = 0;
+            if (target) {
+              throw_on_error(self->AllocatedSize(target->id(), size));
+            }
+            return size;
+          },
+          "target"_a)
       .def("close",
            [](Client* self) {
              return ClientManager<Client>::GetManager()->Disconnect(
                  self->IPCSocket());
            })
-      .def("fork", [](Client *self) {
-        std::shared_ptr<Client> client(new Client());
-        throw_on_error(self->Fork(*client));
-        return client;
-      })
+      .def("fork",
+           [](Client* self) {
+             std::shared_ptr<Client> client(new Client());
+             throw_on_error(self->Fork(*client));
+             return client;
+           })
       .def("__enter__", [](Client* self) { return self; })
       .def("__exit__", [](Client* self, py::object, py::object, py::object) {
         // DO NOTHING
@@ -484,12 +489,14 @@ void bind_client(py::module& mod) {
              return ClientManager<RPCClient>::GetManager()->Disconnect(
                  self->RPCEndpoint());
            })
-      .def("fork", [](Client *self) {
-        std::shared_ptr<Client> client(new Client());
-        throw_on_error(self->Fork(*client));
-        return client;
-      })
-      .def_property_readonly("remote_instance_id", &RPCClient::remote_instance_id)
+      .def("fork",
+           [](Client* self) {
+             std::shared_ptr<Client> client(new Client());
+             throw_on_error(self->Fork(*client));
+             return client;
+           })
+      .def_property_readonly("remote_instance_id",
+                             &RPCClient::remote_instance_id)
       .def("__enter__", [](RPCClient* self) { return self; })
       .def("__exit__", [](RPCClient* self, py::object, py::object, py::object) {
         // DO NOTHING

--- a/python/client.cc
+++ b/python/client.cc
@@ -106,10 +106,10 @@ void bind_client(py::module& mod) {
   py::class_<ClientBase, std::shared_ptr<ClientBase>>(mod, "ClientBase")
       .def(
           "create_metadata",
-          [](ClientBase* self, ObjectMeta& metadata) -> ObjectIDWrapper {
+          [](ClientBase* self, ObjectMeta& metadata) -> ObjectMeta& {
             ObjectID object_id;
             throw_on_error(self->CreateMetaData(metadata, object_id));
-            return object_id;
+            return metadata;
           },
           "metadata"_a)
       .def(
@@ -131,11 +131,31 @@ void bind_client(py::module& mod) {
           },
           "object_ids"_a, py::arg("force") = false, py::arg("deep") = true)
       .def(
+          "delete",
+          [](ClientBase* self, const ObjectMeta &meta,
+             const bool force, const bool deep) {
+            throw_on_error(self->DelData(meta.GetId(), force, deep));
+          },
+          "object_meta"_a, py::arg("force") = false, py::arg("deep") = true)
+      .def(
+          "delete",
+          [](ClientBase* self, const Object *object,
+             const bool force, const bool deep) {
+            throw_on_error(self->DelData(object->id(), force, deep));
+          },
+          "object"_a, py::arg("force") = false, py::arg("deep") = true)
+      .def(
           "persist",
           [](ClientBase* self, const ObjectIDWrapper object_id) {
             throw_on_error(self->Persist(object_id));
           },
           "object_id"_a)
+      .def(
+          "persist",
+          [](ClientBase* self, const ObjectMeta & meta) {
+            throw_on_error(self->Persist(meta.GetId()));
+          },
+          "object_meta"_a)
       .def(
           "persist",
           [](ClientBase* self, const Object* object) {
@@ -173,6 +193,34 @@ void bind_client(py::module& mod) {
             throw_on_error(self->PutName(object_id, name));
           },
           "object_id"_a, "name"_a)
+      .def(
+          "put_name",
+          [](ClientBase* self, const ObjectMeta &meta,
+             std::string const& name) {
+            throw_on_error(self->PutName(meta.GetId(), name));
+          },
+          "object_meta"_a, "name"_a)
+      .def(
+          "put_name",
+          [](ClientBase* self, const ObjectMeta &meta,
+             ObjectNameWrapper const& name) {
+            throw_on_error(self->PutName(meta.GetId(), name));
+          },
+          "object_meta"_a, "name"_a)
+      .def(
+          "put_name",
+          [](ClientBase* self, const Object* object,
+             std::string const& name) {
+            throw_on_error(self->PutName(object->id(), name));
+          },
+          "object"_a, "name"_a)
+      .def(
+          "put_name",
+          [](ClientBase* self, const Object* object,
+             ObjectNameWrapper const& name) {
+            throw_on_error(self->PutName(object->id(), name));
+          },
+          "object"_a, "name"_a)
       .def(
           "get_name",
           [](ClientBase* self, std::string const& name,

--- a/python/core.cc
+++ b/python/core.cc
@@ -147,6 +147,10 @@ void bind_core(py::module& mod) {
              self->AddMember(key, member);
            })
       .def("__setitem__",
+           [](ObjectMeta* self, std::string const& key, ObjectMeta const& member) {
+             self->AddMember(key, member);
+           })
+      .def("__setitem__",
            [](ObjectMeta* self, std::string const& key,
               ObjectIDWrapper const member) { self->AddMember(key, member); })
       .def("add_member",

--- a/python/core.cc
+++ b/python/core.cc
@@ -396,7 +396,7 @@ void bind_core(py::module& mod) {
       .def(
           "copy",
           [](BlobWriter* self, size_t offset, py::bytes bs) {
-            char *buffer = nullptr;
+            char* buffer = nullptr;
             ssize_t length = 0;
             if (PYBIND11_BYTES_AS_STRING_AND_SIZE(bs.ptr(), &buffer, &length)) {
               py::pybind11_fail("Unable to extract bytes contents!");

--- a/python/core.cc
+++ b/python/core.cc
@@ -28,10 +28,10 @@ limitations under the License.
 #include "common/util/status.h"
 #pragma GCC visibility pop
 
-#include "pybind11_utils.h"  // NOLINT(build/include)
+#include "pybind11_utils.h"  // NOLINT(build/include_subdir)
 
 namespace py = pybind11;
-using namespace py::literals;  // NOLINT(build/namespaces)
+using namespace py::literals;  // NOLINT(build/namespaces_literals)
 
 namespace vineyard {
 
@@ -147,9 +147,8 @@ void bind_core(py::module& mod) {
              self->AddMember(key, member);
            })
       .def("__setitem__",
-           [](ObjectMeta* self, std::string const& key, ObjectMeta const& member) {
-             self->AddMember(key, member);
-           })
+           [](ObjectMeta* self, std::string const& key,
+              ObjectMeta const& member) { self->AddMember(key, member); })
       .def("__setitem__",
            [](ObjectMeta* self, std::string const& key,
               ObjectIDWrapper const member) { self->AddMember(key, member); })
@@ -158,9 +157,8 @@ void bind_core(py::module& mod) {
              self->AddMember(key, member);
            })
       .def("add_member",
-           [](ObjectMeta* self, std::string const& key, ObjectMeta const &member) {
-             self->AddMember(key, member);
-           })
+           [](ObjectMeta* self, std::string const& key,
+              ObjectMeta const& member) { self->AddMember(key, member); })
       .def("add_member",
            [](ObjectMeta* self, std::string const& key,
               ObjectIDWrapper const member) { self->AddMember(key, member); })

--- a/python/error.cc
+++ b/python/error.cc
@@ -22,7 +22,7 @@ limitations under the License.
 #include "common/util/status.h"
 #pragma GCC visibility pop
 
-#include "pybind11_utils.h"  // NOLINT(build/include)
+#include "pybind11_utils.h"  // NOLINT(build/include_subdir)
 
 namespace py = pybind11;
 

--- a/python/pybind11_utils.h
+++ b/python/pybind11_utils.h
@@ -13,11 +13,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef PYBIND_11_UTILS_H__
-#define PYBIND_11_UTILS_H__
+#ifndef PYTHON_PYBIND11_UTILS_H_
+#define PYTHON_PYBIND11_UTILS_H_
 
 #include <functional>
 #include <sstream>
+#include <string>
+#include <utility>
 
 #include "pybind11/pybind11.h"
 
@@ -32,7 +34,7 @@ namespace vineyard {
 // Wrap ObjectID to makes pybind11 work.
 struct ObjectIDWrapper {
   ObjectIDWrapper() : internal_id(InvalidObjectID()) {}
-  ObjectIDWrapper(ObjectID id) : internal_id(id) {}
+  explicit ObjectIDWrapper(ObjectID id) : internal_id(id) {}
   explicit ObjectIDWrapper(std::string const& id)
       : internal_id(VYObjectIDFromString(id)) {}
   explicit ObjectIDWrapper(const char* id)
@@ -119,4 +121,4 @@ pybind11::object json_to_python(json const& value);
 
 }  // namespace vineyard
 
-#endif  // PYBIND_11_UTILS_H__
+#endif  // PYTHON_PYBIND11_UTILS_H_

--- a/python/pybind11_utils.h
+++ b/python/pybind11_utils.h
@@ -34,7 +34,7 @@ namespace vineyard {
 // Wrap ObjectID to makes pybind11 work.
 struct ObjectIDWrapper {
   ObjectIDWrapper() : internal_id(InvalidObjectID()) {}
-  explicit ObjectIDWrapper(ObjectID id) : internal_id(id) {}
+  ObjectIDWrapper(ObjectID id) : internal_id(id) {}  // NOLINT(runtime/explicit)
   explicit ObjectIDWrapper(std::string const& id)
       : internal_id(VYObjectIDFromString(id)) {}
   explicit ObjectIDWrapper(const char* id)

--- a/python/stream.cc
+++ b/python/stream.cc
@@ -28,10 +28,10 @@ limitations under the License.
 #include "client/client.h"
 #pragma GCC visibility pop
 
-#include "pybind11_utils.h"  // NOLINT(build/include)
+#include "pybind11_utils.h"  // NOLINT(build/include_subdir)
 
 namespace py = pybind11;
-using namespace py::literals;  // NOLINT(build/namespaces)
+using namespace py::literals;  // NOLINT(build/namespaces_literals)
 
 namespace vineyard {
 
@@ -45,8 +45,8 @@ void bind_stream(py::module& mod) {
             std::unique_ptr<arrow::MutableBuffer> chunk = nullptr;
             throw_on_error(self->GetNext(size, chunk));
             auto chunk_ptr = chunk.release();
-            return py::memoryview::from_memory(
-                chunk_ptr->mutable_data(), chunk_ptr->size(), false);
+            return py::memoryview::from_memory(chunk_ptr->mutable_data(),
+                                               chunk_ptr->size(), false);
           },
           "size"_a)
       .def("finish",
@@ -62,7 +62,7 @@ void bind_stream(py::module& mod) {
         throw_on_error(self->GetNext(chunk));
         auto chunk_ptr = chunk.release();
         return py::memoryview::from_memory(
-            const_cast<uint8_t *>(chunk_ptr->data()), chunk_ptr->size(), true);
+            const_cast<uint8_t*>(chunk_ptr->data()), chunk_ptr->size(), true);
       });
 
   // ByteStream
@@ -123,8 +123,8 @@ void bind_stream(py::module& mod) {
             std::unique_ptr<arrow::MutableBuffer> chunk = nullptr;
             throw_on_error(self->GetNext(size, chunk));
             auto chunk_ptr = chunk.release();
-            return py::memoryview::from_memory(
-                chunk_ptr->mutable_data(), chunk_ptr->size(), false);
+            return py::memoryview::from_memory(chunk_ptr->mutable_data(),
+                                               chunk_ptr->size(), false);
           },
           "size"_a)
       .def("finish",
@@ -140,7 +140,7 @@ void bind_stream(py::module& mod) {
         throw_on_error(self->GetNext(chunk));
         auto chunk_ptr = chunk.release();
         return py::memoryview::from_memory(
-            const_cast<uint8_t *>(chunk_ptr->data()), chunk_ptr->size(), true);
+            const_cast<uint8_t*>(chunk_ptr->data()), chunk_ptr->size(), true);
       });
 
   // DataFrameStream

--- a/python/vineyard/_vineyard_docs.py
+++ b/python/vineyard/_vineyard_docs.py
@@ -284,8 +284,7 @@ Parameters:
         The name of the member object.
     object: :class:`Object`, :class:`ObjectID` or :class:`ObjectMeta`
         The reference to the member object or the object id of the member object.
-'''
-)
+''')
 
 add_doc(
     ObjectID, r'''

--- a/python/vineyard/_vineyard_docs.py
+++ b/python/vineyard/_vineyard_docs.py
@@ -260,7 +260,7 @@ Parameters:
         +  When the value is a list of str, int or float, it will be first dumpped as string
            using :code:`json.dumps`.
 
-.. method:: __setitem__(self, key: str, object) -> None
+.. method:: __setitem__(self, key: str, ObjectID, Object or ObjectMeta) -> None
     :noindex:
 
 Add a member object.
@@ -268,9 +268,24 @@ Add a member object.
 Parameters:
     key: str
         The name of the member object.
-    object: :class:`Object` or :class:`ObjectID`
+    object: :class:`Object`, :class:`ObjectID` or :class:`ObjectMeta`
         The reference to the member object or the object id of the member object.
 ''')
+
+add_doc(
+    ObjectMeta.add_member, r'''
+.. method:: add_member(self, key: str, ObjectID, Object or ObjectMeta) -> None
+    :noindex:
+
+Add a member object.
+
+Parameters:
+    key: str
+        The name of the member object.
+    object: :class:`Object`, :class:`ObjectID` or :class:`ObjectMeta`
+        The reference to the member object or the object id of the member object.
+'''
+)
 
 add_doc(
     ObjectID, r'''

--- a/python/vineyard/_vineyard_docs.py
+++ b/python/vineyard/_vineyard_docs.py
@@ -412,7 +412,7 @@ Parameters:
         :class:`ObjectID`.
     force: bool
         Forcedly delete an object means the member will be recursively deleted even if the
-        member object is also refereed by others. The default value is :code:`True`.
+        member object is also referred by others. The default value is :code:`True`.
     deep: bool
         Deeply delete an object means we will deleting the members recursively. The default
         value is :code:`True`.

--- a/python/vineyard/_vineyard_docs.py
+++ b/python/vineyard/_vineyard_docs.py
@@ -73,7 +73,7 @@ add_doc(
     exception.
 
     In rare cases, user may be not sure about if the IPC socket or RPC endpoint
-    is avaiable, i.e., the varaible might be :code:`None`. In such cases this method
+    is available, i.e., the variable might be :code:`None`. In such cases this method
     can accept a `None` as arguments, and do resolution as described above.
 
     Raises:
@@ -85,7 +85,7 @@ add_doc(
 :class:`ObjectMeta` is the type for metadata of an :class:`Object`.
 The :class:`ObjectMeta` can be treat as a *dict-like* type. If the the metadata if
 the metadata obtained from vineyard, the metadata is readonly. Otherwise *key-value*
-attributes or object members could be assoicated with the metadata to construct a
+attributes or object members could be associated with the metadata to construct a
 new vineyard object.
 
 We can inspect the *key-value* attributes and members of an :class:`ObjectMeta`:
@@ -228,7 +228,7 @@ add_doc(
     :noindex:
 
 Get member object from metadata, return None if the given key is not presented, and raise exception
-RuntimeError if the given key is associcated with a plain metadata, rather than member object.
+RuntimeError if the given key is associated with a plain metadata, rather than member object.
 
 Parameters:
     key: str
@@ -372,7 +372,7 @@ Base class for vineyard object builders.
 
 add_doc(
     ClientBase.create_metadata, r'''
-.. method:: create_metadata(metadata: ObjectMeta) -> None
+.. method:: create_metadata(metadata: ObjectMeta) -> ObjectMeta
     :noindex:
 
 Create metadata in vineyardd.
@@ -380,6 +380,9 @@ Create metadata in vineyardd.
 Parameters:
     metadata: ObjectMeta
         The metadata that will be created on vineyardd.
+
+Returns:
+    The result created metadata.
 ''')
 
 add_doc(
@@ -394,14 +397,30 @@ Parameters:
         Objects that will be deleted. The :code:`object_id` can be a single :class:`ObjectID`, or a list of
         :class:`ObjectID`.
     force: bool
-        Forcely delete an object means the member will be recursively deleted even if the
-        member object is also refered by others. The default value is :code:`True`.
+        Forcedly delete an object means the member will be recursively deleted even if the
+        member object is also refereed by others. The default value is :code:`True`.
     deep: bool
         Deeply delete an object means we will deleting the members recursively. The default
         value is :code:`True`.
 
         Note that when deleting objects which have *direct* blob members, the
         processing on those blobs yields a "deep" behavior.
+
+.. method:: delete(object_meta: ObjectMeta, force: bool = false, deep: bool = true) -> None
+    :noindex:
+
+Delete the specific vineyard object.
+
+Parameters:
+    object_meta: The corresponding object meta to delete.
+
+.. method:: delete(object: Object, force: bool = false, deep: bool = true) -> None
+    :noindex:
+
+Delete the specific vineyard object.
+
+Parameters:
+    object: The corresponding object meta to delete.
 ''')
 
 add_doc(
@@ -409,11 +428,20 @@ add_doc(
 .. method:: persist(object_id: ObjectID) -> None
     :noindex:
 
-Persist the object of the given object id. After persisting, the object will be visiable by clients that
+Persist the object of the given object id. After persisting, the object will be visible by clients that
 connect to other vineyard server instances.
 
 Parameters:
     object_id: ObjectID
+        The object that will be persist.
+
+.. method:: persist(object_meta: ObjectMeta) -> None
+    :noindex:
+
+Persist the given object.
+
+Parameters:
+    object_meta: ObjectMeta
         The object that will be persist.
 
 .. method:: persist(object: Object) -> None
@@ -458,10 +486,11 @@ Returns:
 
 add_doc(
     ClientBase.put_name, r'''
-.. method:: put_name(object_id: ObjectID, name: str or ObjectName) -> None
+.. method:: put_name(object: ObjectID or ObjectMeta or Object,
+                     name: str or ObjectName) -> None
     :noindex:
 
-Associate the given object id with a name. An :class:`ObjectID` can be assoicated with more
+Associate the given object id with a name. An :class:`ObjectID` can be associated with more
 than one names.
 
 Parameters:
@@ -484,7 +513,7 @@ Parameters:
         until the name been registered.
 
 Return:
-    ObjectID: The assoicated object id with the name.
+    ObjectID: The associated object id with the name.
 ''')
 
 add_doc(
@@ -492,7 +521,7 @@ add_doc(
 .. method:: drop_name(name: str or ObjectName) -> None
     :noindex:
 
-Remove the assoication of the given name.
+Remove the association of the given name.
 
 Parameters:
     name: str
@@ -516,7 +545,7 @@ The instance id of the connected vineyard server.
 
 add_doc(
     ClientBase.meta, r'''
-The metadata information of the vineyard server. The value is a  nested dict, the frist-level
+The metadata information of the vineyard server. The value is a  nested dict, the first-level
 key is the instance id, and the second-level key is the cluster metadata fields.
 
 .. code:: python

--- a/python/vineyard/core/builder.py
+++ b/python/vineyard/core/builder.py
@@ -88,8 +88,7 @@ def put(client, value, builder=None, **kw):
         value:
             The python value that will be put to vineyard. Supported python value types are
             decided by modules that registered to vineyard. By default, python value can be
-            put to vineyard after serialized as a bytes buffer using pickle, or pyarrow, when
-            apache-arrow is installed.
+            put to vineyard after serialized as a bytes buffer using pickle.
         builder:
             When putting python value to vineyard, an optional *builder* can be specified to
             tell vineyard how to construct the corresponding vineyard :class:`Object`. If not
@@ -102,7 +101,12 @@ def put(client, value, builder=None, **kw):
     '''
     if builder is not None:
         return builder(client, value, **kw)
-    return default_builder_context.run(client, value, **kw)
+    meta = default_builder_context.run(client, value, **kw)
+
+    # the builders is expected to return an :class:`ObjectMeta`, or an :class:`Object` (in
+    # the `bytes_builder` and `memoryview` builder).
+    if meta:
+        return meta.id
 
 
 setattr(IPCClient, 'put', put)

--- a/python/vineyard/core/builder.py
+++ b/python/vineyard/core/builder.py
@@ -54,6 +54,12 @@ class BuilderContext():
               builder that serialization the python value, the parameter will be serialized
               and be put into a blob.
         '''
+
+        # if the python value comes from a vineyard object, we choose to just reuse it.
+        base = getattr(value, '__vineyard_ref', None)
+        if base:
+            return base.meta
+
         for ty in type(value).__mro__:
             if ty in self.__factory:
                 builder_func_sig = inspect.getfullargspec(self.__factory[ty])

--- a/python/vineyard/core/tests/test_client.py
+++ b/python/vineyard/core/tests/test_client.py
@@ -33,8 +33,8 @@ def test_metadata(vineyard_client):
     meta.add_member('first_', xid)
     meta.add_member('second_', yid)
     meta.set_global(True)
-    rid = vineyard_client.create_metadata(meta)
-    vineyard_client.persist(rid)
+    rmeta = vineyard_client.create_metadata(meta)
+    vineyard_client.persist(rmeta)
 
     def go(meta):
         for k, v in meta.items():
@@ -43,7 +43,7 @@ def test_metadata(vineyard_client):
             else:
                 print('k-v in meta: ', k, v)
 
-    meta = vineyard_client.get_meta(rid)
+    meta = vineyard_client.get_meta(rmeta.id)
     go(meta)
     go(meta)
     go(meta)
@@ -58,8 +58,8 @@ def test_persist(vineyard_client):
     meta.add_member('first_', xid)
     meta.add_member('second_', yid)
     meta.set_global(True)
-    rid = vineyard_client.create_metadata(meta)
-    vineyard_client.persist(rid)
+    rmeta = vineyard_client.create_metadata(meta)
+    vineyard_client.persist(rmeta)
 
 
 def test_persist_multiref(vineyard_client):
@@ -69,5 +69,5 @@ def test_persist_multiref(vineyard_client):
     meta.add_member('first_', xid)
     meta.add_member('second_', xid)
     meta.set_global(True)
-    rid = vineyard_client.create_metadata(meta)
-    vineyard_client.persist(rid)
+    rmeta = vineyard_client.create_metadata(meta)
+    vineyard_client.persist(rmeta)

--- a/python/vineyard/data/base.py
+++ b/python/vineyard/data/base.py
@@ -54,13 +54,13 @@ def string_builder(client, value, **kwargs):
 def bytes_builder(client, value, **kwargs):
     buffer = client.create_blob(len(value))
     buffer.copy(0, value)
-    return buffer.seal(client).id
+    return buffer.seal(client)
 
 
 def memoryview_builder(client, value, **kwargs):
     buffer = client.create_blob(len(value))
     buffer.copy(0, bytes(value))
-    return buffer.seal(client).id
+    return buffer.seal(client)
 
 
 def tuple_builder(client, value, builder, **kwargs):

--- a/python/vineyard/deploy/tests/test_distributed.py
+++ b/python/vineyard/deploy/tests/test_distributed.py
@@ -83,10 +83,10 @@ def test_add_remote_placeholder(vineyard_ipc_sockets):
     meta.add_member('__elements_-2', o3)
     meta.add_member('__elements_-3', o4)
     meta['__elements_-size'] = 4
-    tupid = client1.create_metadata(meta)
-    client1.persist(tupid)
+    tup = client1.create_metadata(meta)
+    client1.persist(tup)
 
-    meta = client2.get_meta(tupid, True)
+    meta = client2.get_meta(tup.id, True)
     assert meta['__elements_-size'] == 4
 
 


### PR DESCRIPTION

What do these changes do?
-------------------------

Returns `metadata` rather than `id` in `client.create_metadata` to avoid  a indirect remote sync/update to bump up performance when creating **nested** python objects to vineyard.

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Related to #298 and is the subsequential work of #346.

