### PR TITLE
Suggest use `make -j$(nproc)` to users.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -35,7 +35,7 @@ You can do an out-of-source build using CMake:
     mkdir build
     cd build
     cmake ..
-    make -j
+    make -j$(nproc)
 
 The vineyardd target will be generated under the `bin` directory.
 

--- a/docs/notes/install.rst
+++ b/docs/notes/install.rst
@@ -126,7 +126,7 @@ Then you do a out-of-source build using CMake:
     mkdir build
     cd build
     cmake ..
-    make -j
+    make -j$(nproc)
     make install  # optionally
 
 You will see vineyard server binary under the ``bin`` directory, and static or shared linked


### PR DESCRIPTION

<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

Avoid using `make -j`, as we have recieved a lot complaints about failure in VM or docker with `make -j`.

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #345, see also #291.

