### PR TITLE
Add object stream which transfers object ids between consecutive workloads

### DIFF
--- a/modules/basic/stream/object_stream.h
+++ b/modules/basic/stream/object_stream.h
@@ -1,0 +1,63 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef MODULES_BASIC_STREAM_OBJECT_STREAM_H_
+#define MODULES_BASIC_STREAM_OBJECT_STREAM_H_
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "basic/stream/object_stream.vineyard.h"
+#include "client/client.h"
+
+namespace vineyard {
+
+/**
+ * @brief ObjectStreamBuilder is used for initiating object streams
+ *
+ */
+class ObjectStreamBuilder : public ObjectStreamBaseBuilder {
+ public:
+  explicit ObjectStreamBuilder(Client& client)
+      : ObjectStreamBaseBuilder(client) {}
+
+  void SetParam(std::string const& key, std::string const& value) {
+    this->params_.emplace(key, value);
+  }
+
+  void SetParams(
+      const std::unordered_multimap<std::string, std::string>& params) {
+    for (auto const& kv : params) {
+      this->params_.emplace(kv.first, kv.second);
+    }
+  }
+
+  void SetParams(const std::unordered_map<std::string, std::string>& params) {
+    for (auto const& kv : params) {
+      this->params_.emplace(kv.first, kv.second);
+    }
+  }
+
+  std::shared_ptr<Object> Seal(Client& client) {
+    auto object_stream = ObjectStreamBaseBuilder::Seal(client);
+    VINEYARD_CHECK_OK(client.CreateObjectStream(object_stream->id()));
+    return std::static_pointer_cast<Object>(object_stream);
+  }
+};
+
+}  // namespace vineyard
+
+#endif  // MODULES_BASIC_STREAM_OBJECT_STREAM_H_

--- a/modules/basic/stream/object_stream.vineyard-mod
+++ b/modules/basic/stream/object_stream.vineyard-mod
@@ -1,0 +1,171 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef MODULES_BASIC_STREAM_OBJECT_STREAM_MOD_H_
+#define MODULES_BASIC_STREAM_OBJECT_STREAM_MOD_H_
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "arrow/builder.h"
+#include "arrow/status.h"
+
+#include "basic/ds/arrow_utils.h"
+#include "basic/stream/stream_utils.h"
+#include "client/client.h"
+#include "client/ds/blob.h"
+#include "client/ds/i_object.h"
+#include "common/util/uuid.h"
+
+namespace vineyard {
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
+#endif
+
+class Client;
+
+class __attribute__((annotate("no-vineyard"))) ObjectStreamWriter {
+ public:
+  const size_t MaximumChunkSize() const { return -1; }
+
+  Status PutObject(ObjectID const object_id, const std::vector<int>& index) {
+    return client_.PutObjectStreamObject(id_, object_id, index);
+  }
+
+  Status PutNext(ObjectID const object_id) {
+    // the default index is sequantial
+    ++index_;
+    return client_.PutObjectStreamObject(id_, object_id, {index_});
+  }
+
+  Status Abort() {
+    if (stoped_) {
+      return Status::OK();
+    }
+    stoped_ = true;
+    return client_.StopObjectStream(id_, true);
+  }
+
+  Status Finish() {
+    if (stoped_) {
+      return Status::OK();
+    }
+    stoped_ = true;
+    return client_.StopObjectStream(id_, false);
+  }
+
+  Status PersistToObject(ObjectID& object_id) {
+    if (!stoped_) {
+      RETURN_ON_ERROR(Finish());
+    }
+    return client_.PersistObjectStream(id_, meta_.MetaData(), object_id);
+  }
+
+  ObjectStreamWriter(Client& client, ObjectID const& id, ObjectMeta const& meta)
+      : client_(client), id_(id), meta_(meta), stoped_(false), index_(0) {}
+
+ private:
+  Client& client_;
+  ObjectID id_;
+  ObjectMeta meta_;
+  bool stoped_;  // an optimization: avoid repeated idempotent requests.
+  int index_;
+
+  friend class Client;
+};
+
+class __attribute__((annotate("no-vineyard"))) ObjectStreamReader {
+ public:
+  Status GetObject(ObjectID& object_id, const std::vector<int>& index) {
+    return client_.GetObjectStreamObject(id_, index, object_id);
+  }
+
+  Status GetNext(ObjectID& object_id) {
+    // the default index is sequential
+    ++index_;
+    return client_.GetObjectStreamObject(id_, {index_}, object_id);
+  }
+
+  ObjectStreamReader(Client& client, ObjectID const& id, ObjectMeta const& meta)
+      : client_(client), id_(id), meta_(meta), index_(0){};
+
+ private:
+  Client& client_;
+  ObjectID id_;
+  ObjectMeta meta_;
+  int index_;
+
+  friend class Client;
+};
+
+class ObjectStreamBaseBuilder;
+
+/**
+ * @brief The object stream which represents a sequence of local objects
+ *
+ */
+class ObjectStream : public Registered<ObjectStream> {
+ public:
+  /**
+   * @brief Open a reader to consume object IDs from the object stream
+   *
+   * @param client The client connected to the vineyard server
+   * @param The unique pointer to the reader
+   */
+  Status OpenReader(Client& client,
+                    std::unique_ptr<ObjectStreamReader>& reader) {
+    RETURN_ON_ERROR(client.OpenObjectStream(id_, OpenStreamMode::read));
+    reader = std::unique_ptr<ObjectStreamReader>(
+        new ObjectStreamReader(client, id_, meta_));
+    return Status::OK();
+  }
+
+  /**
+   * @brief Open a writer to put object IDs to the object stream
+   *
+   * @param client The client connected to the vineyard server
+   * @param The unique pointer to the writer
+   */
+  Status OpenWriter(Client& client,
+                    std::unique_ptr<ObjectStreamWriter>& writer) {
+    RETURN_ON_ERROR(client.OpenObjectStream(id_, OpenStreamMode::write));
+    writer = std::unique_ptr<ObjectStreamWriter>(
+        new ObjectStreamWriter(client, id_, meta_));
+    return Status::OK();
+  }
+
+  std::unordered_map<std::string, std::string> GetParams() { return params_; }
+
+ private:
+  __attribute__((annotate("codegen")))
+  std::unordered_map<std::string, std::string>
+      params_;
+
+  friend class Client;
+  friend class ObjectStreamBaseBuilder;
+  friend class ObjectStreamBuilder;
+};
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+}  // namespace vineyard
+
+#endif  // MODULES_BASIC_STREAM_OBJECT_STREAM_MOD_H_

--- a/python/vineyard/io/object.py
+++ b/python/vineyard/io/object.py
@@ -1,0 +1,54 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020 Alibaba Group Holding Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+''' This module exposes support for ObjectStream, that use can used like:
+
+.. code:: python
+
+    # create a builder, then seal it as stream
+    >>> builder = ObjectStreamBuilder(client)
+    >>> stream = builder.seal(client)
+    >>> stream
+    >>> <vineyard._C.ObjectStream at 0x13b3d7ef0>
+
+    # use write to put ObjectIDs
+    >>> writer = stream.open_writer(client)
+    >>> df_id = client.put(pd.DataFrame(...))
+    >>> writer.put_next(df_id)
+
+    # mark the stream as finished
+    >>> writer.finish()
+
+    # open a reader
+    >>> reader = stream.open_reader(client)
+    >>> df_id = reader.get_next()
+    >>> df_id
+    ObjectID <"o00a5b58da21565a2">
+
+    # the reader reaches the end of the stream
+    >>> chunk = reader.get_next()
+    ---------------------------------------------------------------------------
+    StreamDrainedException                    Traceback (most recent call last)
+    <ipython-input-20-d8809de11870> in <module>
+    ----> 1 chunk = reader.next()
+
+    StreamDrainedException: Stream drained: no more chunks
+'''
+
+from vineyard._C import ObjectStream, ObjectStreamBuilder, \
+    ObjectStreamReader, ObjectStreamWriter

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -221,6 +221,79 @@ Status Client::StopStream(ObjectID const id, const bool failed) {
   return Status::OK();
 }
 
+Status Client::CreateObjectStream(const ObjectID& id) {
+  ENSURE_CONNECTED(this);
+  std::string message_out;
+  WriteCreateObjectStreamRequest(id, message_out);
+  RETURN_ON_ERROR(doWrite(message_out));
+  json message_in;
+  RETURN_ON_ERROR(doRead(message_in));
+  RETURN_ON_ERROR(ReadCreateObjectStreamReply(message_in));
+  return Status::OK();
+}
+
+Status Client::OpenObjectStream(const ObjectID& id, OpenStreamMode mode) {
+  ENSURE_CONNECTED(this);
+  std::string message_out;
+  WriteOpenObjectStreamRequest(id, static_cast<int64_t>(mode), message_out);
+  RETURN_ON_ERROR(doWrite(message_out));
+  json message_in;
+  RETURN_ON_ERROR(doRead(message_in));
+  RETURN_ON_ERROR(ReadOpenObjectStreamReply(message_in));
+  return Status::OK();
+}
+
+Status Client::GetObjectStreamObject(ObjectID const id,
+                                     std::vector<int> const index,
+                                     ObjectID& object_id) {
+  ENSURE_CONNECTED(this);
+  std::string message_out;
+  WriteGetObjectStreamObjectRequest(id, index, message_out);
+  RETURN_ON_ERROR(doWrite(message_out));
+  json message_in;
+  RETURN_ON_ERROR(doRead(message_in));
+  Payload object;
+  RETURN_ON_ERROR(ReadGetObjectStreamObjectReply(message_in, object_id));
+  return Status::OK();
+}
+
+Status Client::PutObjectStreamObject(ObjectID const id,
+                                     ObjectID const object_id,
+                                     std::vector<int> const index) {
+  ENSURE_CONNECTED(this);
+  std::string message_out;
+  WritePutObjectStreamObjectRequest(id, object_id, index, message_out);
+  RETURN_ON_ERROR(doWrite(message_out));
+  json message_in;
+  RETURN_ON_ERROR(doRead(message_in));
+  Payload object;
+  RETURN_ON_ERROR(ReadPutObjectStreamObjectReply(message_in));
+  return Status::OK();
+}
+
+Status Client::StopObjectStream(ObjectID const id, const bool failed) {
+  ENSURE_CONNECTED(this);
+  std::string message_out;
+  WriteStopObjectStreamRequest(id, failed, message_out);
+  RETURN_ON_ERROR(doWrite(message_out));
+  json message_in;
+  RETURN_ON_ERROR(doRead(message_in));
+  RETURN_ON_ERROR(ReadStopObjectStreamReply(message_in));
+  return Status::OK();
+}
+
+Status Client::PersistObjectStream(ObjectID const id, const json& meta,
+                                   ObjectID& object_id) {
+  ENSURE_CONNECTED(this);
+  std::string message_out;
+  WritePersistObjectStreamRequest(id, meta, message_out);
+  RETURN_ON_ERROR(doWrite(message_out));
+  json message_in;
+  RETURN_ON_ERROR(doRead(message_in));
+  RETURN_ON_ERROR(ReadPersistObjectStreamReply(message_in, object_id));
+  return Status::OK();
+}
+
 std::shared_ptr<Object> Client::GetObject(const ObjectID id) {
   ObjectMeta meta;
   VINEYARD_CHECK_OK(this->GetMetaData(id, meta, true));

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -288,6 +288,78 @@ class Client : public ClientBase {
   Status StopStream(ObjectID const id, bool failed);
 
   /**
+   * @brief Allocate an object stream on vineyard. The metadata of parameter
+   * `id` must has already been created on vineyard.
+   *
+   * @param id The id of metadata that will be used to create stream.
+   *
+   * @return Status that indicates whether the create action has succeeded.
+   */
+  Status CreateObjectStream(const ObjectID& id);
+
+  /**
+   * @brief open an object stream on vineyard. Failed if the stream is already
+   * opened on the given mode.
+   *
+   * @param id The id of stream to mark.
+   * @param mode The mode, OpenStreamMode::read or OpenStreamMode::write.
+   *
+   * @return Status that indicates whether the open action has succeeded.
+   */
+  Status OpenObjectStream(const ObjectID& id, OpenStreamMode mode);
+
+  /**
+   * @brief get the object_id at a certain index. It will wait until the object
+   * at the index is put into the server if it's not present.
+   *
+   * @param id The id of the object stream.
+   * @param index The given index.
+   * @param object_id The returned ObjectID at the given index.
+   *
+   * @return Status that indicates whether the get action has succeeded.
+   */
+  Status GetObjectStreamObject(ObjectID const id, std::vector<int> const index,
+                               ObjectID& object_id);
+
+  /**
+   * @brief put the object_id at a certain index. It will return an error
+   * if the given index is already associated with an object.
+   *
+   * @param id The id of the object stream.
+   * @param object_id The ObjectID to be associated with the index.
+   * @param index The given index.
+   *
+   * @return Status that indicates whether the put action has succeeded.
+   */
+  Status PutObjectStreamObject(ObjectID const id, ObjectID const object_id,
+                               std::vector<int> const index);
+
+  /**
+   * @brief Stop an object stream, mark it as finished or aborted.
+   *
+   * @param id The id of the stream.
+   * @param failed Whether the stream is stoped at a successful state. True
+   * means the stream has been exited normally, otherwise false.
+   *
+   * @return Status that indicates whether the request has succeeded.
+   */
+  Status StopObjectStream(ObjectID const id, const bool failed);
+
+  /**
+   * @brief Persist an object stream into an object.
+   * Each object at a certain index will be recorded under the key '_osi_' +
+   * index
+   *
+   * @param id The id of the stream.
+   * @param meta The original metadata of the stream.
+   * @param object_id The id of the persisted object.
+   *
+   * @return Status that indicates whether the request has succeeded.
+   */
+  Status PersistObjectStream(ObjectID const id, const json& meta,
+                             ObjectID& object_id);
+
+  /**
    * @brief Get an object from vineyard. The ObjectFactory will be used to
    * resolve the constructor of the object.
    *

--- a/src/common/util/protocols.cc
+++ b/src/common/util/protocols.cc
@@ -74,6 +74,18 @@ CommandType ParseCommandType(const std::string& str_type) {
     return CommandType::PullNextStreamChunkRequest;
   } else if (str_type == "stop_stream_request") {
     return CommandType::StopStreamRequest;
+  } else if (str_type == "create_object_stream_request") {
+    return CommandType::CreateObjectStreamRequest;
+  } else if (str_type == "open_object_stream_request") {
+    return CommandType::OpenObjectStreamRequest;
+  } else if (str_type == "get_object_stream_object_request") {
+    return CommandType::GetObjectStreamObjectRequest;
+  } else if (str_type == "put_object_stream_object_request") {
+    return CommandType::PutObjectStreamObjectRequest;
+  } else if (str_type == "stop_object_stream_request") {
+    return CommandType::StopObjectStreamRequest;
+  } else if (str_type == "persist_object_stream_request") {
+    return CommandType::PersistObjectStreamRequest;
   } else if (str_type == "put_name_request") {
     return CommandType::PutNameRequest;
   } else if (str_type == "get_name_request") {
@@ -978,6 +990,202 @@ void WriteFinalizeArenaReply(std::string& msg) {
 
 Status ReadFinalizeArenaReply(const json& root) {
   CHECK_IPC_ERROR(root, "finalize_arena_reply");
+  return Status::OK();
+}
+
+void WriteCreateObjectStreamRequest(const ObjectID& object_id,
+                                    std::string& msg) {
+  json root;
+  root["type"] = "create_object_stream_request";
+  root["object_id"] = object_id;
+
+  encode_msg(root, msg);
+}
+
+Status ReadCreateObjectStreamRequest(const json& root, ObjectID& object_id) {
+  RETURN_ON_ASSERT(root["type"] == "create_object_stream_request");
+  object_id = root["object_id"].get<ObjectID>();
+  return Status::OK();
+}
+
+void WriteCreateObjectStreamReply(std::string& msg) {
+  json root;
+  root["type"] = "create_object_stream_reply";
+
+  encode_msg(root, msg);
+}
+
+Status ReadCreateObjectStreamReply(const json& root) {
+  CHECK_IPC_ERROR(root, "create_object_stream_reply");
+  return Status::OK();
+}
+
+void WriteOpenObjectStreamRequest(const ObjectID& object_id,
+                                  const int64_t& mode, std::string& msg) {
+  json root;
+  root["type"] = "open_object_stream_request";
+  root["object_id"] = object_id;
+  root["mode"] = mode;
+
+  encode_msg(root, msg);
+}
+
+Status ReadOpenObjectStreamRequest(const json& root, ObjectID& object_id,
+                                   int64_t& mode) {
+  RETURN_ON_ASSERT(root["type"] == "open_object_stream_request");
+  object_id = root["object_id"].get<ObjectID>();
+  mode = root["mode"].get<int64_t>();
+  return Status::OK();
+}
+
+void WriteOpenObjectStreamReply(std::string& msg) {
+  json root;
+  root["type"] = "open_object_stream_reply";
+
+  encode_msg(root, msg);
+}
+
+Status ReadOpenObjectStreamReply(const json& root) {
+  CHECK_IPC_ERROR(root, "open_object_stream_reply");
+  return Status::OK();
+}
+
+void WriteGetObjectStreamObjectRequest(const ObjectID stream_id,
+                                       const std::vector<int> index,
+                                       std::string& msg) {
+  json root;
+  root["type"] = "get_object_stream_object_request";
+  root["id"] = stream_id;
+  std::string str_index;
+  for (size_t i = 0; i < index.size(); ++i) {
+    str_index += std::to_string(index[i]) + ",";
+  }
+  root["index"] = str_index;
+
+  encode_msg(root, msg);
+}
+
+Status ReadGetObjectStreamObjectRequest(const json& root, ObjectID& stream_id,
+                                        std::string& str_index) {
+  RETURN_ON_ASSERT(root["type"] == "get_object_stream_object_request");
+  stream_id = root["id"].get<ObjectID>();
+  str_index = root["index"].get<std::string>();
+  return Status::OK();
+}
+
+void WriteGetObjectStreamObjectReply(const ObjectID object_id,
+                                     std::string& msg) {
+  json root;
+  root["type"] = "get_object_stream_object_reply";
+  root["object_id"] = object_id;
+
+  encode_msg(root, msg);
+}
+
+Status ReadGetObjectStreamObjectReply(const json& root, ObjectID& object_id) {
+  CHECK_IPC_ERROR(root, "get_object_stream_object_reply");
+  object_id = root["object_id"].get<ObjectID>();
+  return Status::OK();
+}
+
+void WritePutObjectStreamObjectRequest(const ObjectID stream_id,
+                                       const ObjectID next_object,
+                                       const std::vector<int> index,
+                                       std::string& msg) {
+  json root;
+  root["type"] = "put_object_stream_object_request";
+  root["id"] = stream_id;
+  root["next_object"] = next_object;
+  std::string str_index;
+  for (size_t i = 0; i < index.size(); ++i) {
+    str_index += std::to_string(index[i]) + ",";
+  }
+  root["index"] = str_index;
+
+  encode_msg(root, msg);
+}
+
+Status ReadPutObjectStreamObjectRequest(const json& root, ObjectID& stream_id,
+                                        ObjectID& next_object,
+                                        std::string& str_index) {
+  RETURN_ON_ASSERT(root["type"] == "put_object_stream_object_request");
+  stream_id = root["id"].get<ObjectID>();
+  next_object = root["next_object"].get<ObjectID>();
+  str_index = root["index"].get<std::string>();
+  return Status::OK();
+}
+
+void WritePutObjectStreamObjectReply(std::string& msg) {
+  json root;
+  root["type"] = "put_object_stream_object_reply";
+
+  encode_msg(root, msg);
+}
+
+Status ReadPutObjectStreamObjectReply(const json& root) {
+  CHECK_IPC_ERROR(root, "put_object_stream_object_reply");
+  return Status::OK();
+}
+
+void WriteStopObjectStreamRequest(const ObjectID stream_id, const bool failed,
+                                  std::string& msg) {
+  json root;
+  root["type"] = "stop_object_stream_request";
+  root["id"] = stream_id;
+  root["failed"] = failed;
+
+  encode_msg(root, msg);
+}
+
+Status ReadStopObjectStreamRequest(const json& root, ObjectID& stream_id,
+                                   bool& failed) {
+  RETURN_ON_ASSERT(root["type"] == "stop_object_stream_request");
+  stream_id = root["id"].get<ObjectID>();
+  failed = root["failed"].get<bool>();
+  return Status::OK();
+}
+
+void WriteStopObjectStreamReply(std::string& msg) {
+  json root;
+  root["type"] = "stop_object_stream_reply";
+
+  encode_msg(root, msg);
+}
+
+Status ReadStopObjectStreamReply(const json& root) {
+  CHECK_IPC_ERROR(root, "stop_object_stream_reply");
+  return Status::OK();
+}
+
+void WritePersistObjectStreamRequest(const ObjectID stream_id, const json& meta,
+                                     std::string& msg) {
+  json root;
+  root["type"] = "persist_object_stream_request";
+  root["id"] = stream_id;
+  root["meta"] = meta;
+
+  encode_msg(root, msg);
+}
+
+Status ReadPersistObjectStreamRequest(const json& root, ObjectID& stream_id,
+                                      json& meta) {
+  RETURN_ON_ASSERT(root["type"] == "persist_object_stream_request");
+  stream_id = root["id"].get<ObjectID>();
+  meta = root["meta"];
+  return Status::OK();
+}
+
+void WritePersistObjectStreamReply(const ObjectID object_id, std::string& msg) {
+  json root;
+  root["type"] = "persist_object_stream_reply";
+  root["object_id"] = object_id;
+
+  encode_msg(root, msg);
+}
+
+Status ReadPersistObjectStreamReply(const json& root, ObjectID& object_id) {
+  CHECK_IPC_ERROR(root, "persist_object_stream_reply");
+  object_id = root["object_id"].get<ObjectID>();
   return Status::OK();
 }
 

--- a/src/common/util/protocols.h
+++ b/src/common/util/protocols.h
@@ -65,6 +65,12 @@ enum class CommandType {
   DropBufferRequest = 32,
   MakeArenaRequest = 33,
   FinalizeArenaRequest = 34,
+  CreateObjectStreamRequest = 35,
+  OpenObjectStreamRequest = 36,
+  GetObjectStreamObjectRequest = 37,
+  PutObjectStreamObjectRequest = 38,
+  StopObjectStreamRequest = 39,
+  PersistObjectStreamRequest = 40,
 };
 
 CommandType ParseCommandType(const std::string& str_type);
@@ -298,6 +304,70 @@ Status ReadStopStreamRequest(const json& root, ObjectID& stream_id,
 void WriteStopStreamReply(std::string& msg);
 
 Status ReadStopStreamReply(const json& root);
+
+void WriteCreateObjectStreamRequest(const ObjectID& object_id,
+                                    std::string& msg);
+
+Status ReadCreateObjectStreamRequest(const json& root, ObjectID& object_id);
+
+void WriteCreateObjectStreamReply(std::string& msg);
+
+Status ReadCreateObjectStreamReply(const json& root);
+
+void WriteOpenObjectStreamRequest(const ObjectID& object_id,
+                                  const int64_t& mode, std::string& msg);
+
+Status ReadOpenObjectStreamRequest(const json& root, ObjectID& object_id,
+                                   int64_t& mode);
+
+void WriteOpenObjectStreamReply(std::string& msg);
+
+Status ReadOpenObjectStreamReply(const json& root);
+
+void WriteGetObjectStreamObjectRequest(const ObjectID stream_id,
+                                       const std::vector<int> index,
+                                       std::string& msg);
+
+Status ReadGetObjectStreamObjectRequest(const json& root, ObjectID& stream_id,
+                                        std::string& str_index);
+
+void WriteGetObjectStreamObjectReply(const ObjectID object_id,
+                                     std::string& msg);
+
+Status ReadGetObjectStreamObjectReply(const json& root, ObjectID& object_id);
+
+void WritePutObjectStreamObjectRequest(const ObjectID stream_id,
+                                       const ObjectID next_object,
+                                       const std::vector<int> index,
+                                       std::string& msg);
+
+Status ReadPutObjectStreamObjectRequest(const json& root, ObjectID& stream_id,
+                                        ObjectID& next_object,
+                                        std::string& str_index);
+
+void WritePutObjectStreamObjectReply(std::string& msg);
+
+Status ReadPutObjectStreamObjectReply(const json& root);
+
+void WriteStopObjectStreamRequest(const ObjectID stream_id, const bool failed,
+                                  std::string& msg);
+
+Status ReadStopObjectStreamRequest(const json& root, ObjectID& stream_id,
+                                   bool& failed);
+
+void WriteStopObjectStreamReply(std::string& msg);
+
+Status ReadStopObjectStreamReply(const json& root);
+
+void WritePersistObjectStreamRequest(const ObjectID stream_id, const json& meta,
+                                     std::string& msg);
+
+Status ReadPersistObjectStreamRequest(const json& root, ObjectID& stream_id,
+                                      json& meta);
+
+void WritePersistObjectStreamReply(const ObjectID object_id, std::string& msg);
+
+Status ReadPersistObjectStreamReply(const json& root, ObjectID& object_id);
 
 void WriteShallowCopyRequest(const ObjectID id, std::string& msg);
 

--- a/src/server/async/socket_server.h
+++ b/src/server/async/socket_server.h
@@ -103,6 +103,18 @@ class SocketConnection : public std::enable_shared_from_this<SocketConnection> {
 
   bool doStopStream(const json& root);
 
+  bool doCreateObjectStream(const json& root);
+
+  bool doOpenObjectStream(const json& root);
+
+  bool doGetObjectStreamObject(const json& root);
+
+  bool doPutObjectStreamObject(const json& root);
+
+  bool doStopObjectStream(const json& root);
+
+  bool doPersistObjectStream(const json& root);
+
   bool doPutName(const json& root);
 
   bool doGetName(const json& root);

--- a/test/object_stream_test.cc
+++ b/test/object_stream_test.cc
@@ -1,0 +1,158 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <memory>
+#include <string>
+#include <thread>
+#include <unordered_map>
+
+#include "arrow/status.h"
+#include "arrow/util/io_util.h"
+#include "arrow/util/logging.h"
+#include "glog/logging.h"
+
+#include "basic/ds/dataframe.h"
+#include "basic/stream/object_stream.h"
+#include "client/client.h"
+#include "client/ds/object_meta.h"
+
+using namespace vineyard;  // NOLINT(build/namespaces)
+
+int main(int argc, char** argv) {
+  if (argc < 2) {
+    printf("usage ./object_stream_test <ipc_socket>");
+    return 1;
+  }
+  std::string ipc_socket = std::string(argv[1]);
+
+  Client client;
+  VINEYARD_CHECK_OK(client.Connect(ipc_socket));
+  LOG(INFO) << "Connected to IPCServer: " << ipc_socket;
+
+  ObjectID stream_id = InvalidObjectID();
+  {
+    ObjectStreamBuilder builder(client);
+    builder.SetParams(std::unordered_map<std::string, std::string>{
+        {"kind", "test"}, {"test_name", "stream_test"}});
+    auto object_stream =
+        std::dynamic_pointer_cast<ObjectStream>(builder.Seal(client));
+    stream_id = object_stream->id();
+    CHECK(stream_id != InvalidObjectID());
+  }
+
+  std::thread recv_thrd([&]() {
+    Client reader_client;
+    VINEYARD_CHECK_OK(reader_client.Connect(ipc_socket));
+
+    auto object_stream = reader_client.GetObject<ObjectStream>(stream_id);
+    CHECK(object_stream != nullptr);
+
+    std::unique_ptr<ObjectStreamReader> reader;
+    VINEYARD_CHECK_OK(object_stream->OpenReader(reader_client, reader));
+
+    std::unique_ptr<ObjectStreamReader> failed_reader;
+    auto status1 = object_stream->OpenReader(reader_client, failed_reader);
+    CHECK(status1.IsStreamOpened());
+
+    for (size_t i = 1; true; ++i) {
+      ObjectID next_object;
+      auto status = reader->GetNext(next_object);
+      if (status.ok()) {
+        auto df = reader_client.GetObject<DataFrame>(next_object);
+        auto column_b =
+            std::dynamic_pointer_cast<Tensor<int64_t>>(df->Column("b"));
+        CHECK_EQ(column_b->shape()[0], 100 * i);
+      } else {
+        CHECK(status.IsStreamDrained());
+        break;
+      }
+    }
+  });
+
+  std::thread send_thrd([&]() {
+    Client writer_client;
+    VINEYARD_CHECK_OK(writer_client.Connect(ipc_socket));
+
+    auto object_stream = writer_client.GetObject<ObjectStream>(stream_id);
+    CHECK(object_stream != nullptr);
+
+    std::unique_ptr<ObjectStreamWriter> writer;
+    VINEYARD_CHECK_OK(object_stream->OpenWriter(writer_client, writer));
+
+    std::unique_ptr<ObjectStreamWriter> failed_writer;
+    auto status1 = object_stream->OpenWriter(writer_client, failed_writer);
+    CHECK(status1.IsStreamOpened());
+
+    CHECK(writer != nullptr);
+    for (int64_t idx = 1; idx <= 11; ++idx) {
+      DataFrameBuilder builder(client);
+
+      auto tb = std::make_shared<TensorBuilder<int64_t>>(
+          client, std::vector<int64_t>{idx * 100});
+      builder.AddColumn("b", tb);
+
+      auto column_b = std::dynamic_pointer_cast<TensorBuilder<int64_t>>(
+          builder.Column("b"));
+      auto data = column_b->data();
+      for (int64_t i = 0; i < idx * 100; ++i) {
+        data[i] = i * i * i;
+      }
+      auto seal_df = builder.Seal(client);
+      VINEYARD_CHECK_OK(client.Persist(seal_df->id()));
+
+      writer->PutNext(seal_df->id());
+      sleep(1);
+    }
+    VINEYARD_CHECK_OK(writer->Finish());
+
+    ObjectID po;
+    VINEYARD_CHECK_OK(writer->PersistToObject(po));
+    CHECK(po != stream_id);
+  });
+
+  send_thrd.join();
+  recv_thrd.join();
+
+  // when stream fail
+  {
+    ObjectStreamBuilder builder(client);
+    builder.SetParams(std::unordered_map<std::string, std::string>{
+        {"kind", "test"}, {"test_name", "stream_test"}});
+    auto object_stream =
+        std::dynamic_pointer_cast<ObjectStream>(builder.Seal(client));
+    stream_id = object_stream->id();
+    CHECK(stream_id != InvalidObjectID());
+  }
+
+  auto failed_object_stream = client.GetObject<ObjectStream>(stream_id);
+
+  std::unique_ptr<ObjectStreamReader> reader = nullptr;
+  std::unique_ptr<ObjectStreamWriter> writer = nullptr;
+  VINEYARD_CHECK_OK(failed_object_stream->OpenReader(client, reader));
+  VINEYARD_CHECK_OK(failed_object_stream->OpenWriter(client, writer));
+  CHECK(reader != nullptr);
+  CHECK(writer != nullptr);
+  VINEYARD_CHECK_OK(writer->Abort());
+
+  ObjectID next_object;
+  auto status = reader->GetNext(next_object);
+  CHECK(status.IsStreamFailed());
+
+  LOG(INFO) << "Passed object stream tests...";
+
+  client.Disconnect();
+
+  return 0;
+}


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------
Add object stream to vineyard in parallel to byte/dataframe streams. The future plan is to replace byte/dataframe streams
with object streams of blob ids and dataframe ids.

This will potentially solve the dataframe copy issue indicated in Issue 220.

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #220.

