### PR TITLE
Compatible with pandas==1.3.0.

### DIFF
--- a/python/vineyard/data/dataframe.py
+++ b/python/vineyard/data/dataframe.py
@@ -18,7 +18,12 @@
 
 import numpy as np
 import pandas as pd
-from pandas.core.internals.blocks import Block
+try:
+    from pandas.core.internals.blocks import BlockPlacement, NumpyBlock as Block
+except:
+    BlockPlacement = None
+    NDArrayBacked = None
+    from pandas.core.internals.blocks import Block
 from pandas.core.internals.managers import BlockManager
 
 from vineyard._C import ObjectMeta
@@ -54,12 +59,17 @@ def pandas_dataframe_resolver(obj, resolver):
         np_value = resolver.run(obj.member('__values_-value-%d' % idx))
         index_size = len(np_value)
         # ndim: 1 for SingleBlockManager/Series, 2 for BlockManager/DataFrame
-        blocks.append(Block(np.expand_dims(np_value, 0), slice(idx, idx + 1, 1), ndim=2))
+        if BlockPlacement:
+            palcement = BlockPlacement(slice(idx, idx + 1, 1))
+        else:
+            palcement = slice(idx, idx + 1, 1)
+        values = np.expand_dims(np_value, 0)
+        blocks.append(Block(values, palcement, ndim=2))
     if 'index_' in meta:
         index = resolver.run(obj.member('index_'))
     else:
         index = np.arange(index_size)
-    return pd.DataFrame(BlockManager(blocks, [columns, index]))
+    return pd.DataFrame(BlockManager(blocks, [pd.Index(columns), index]))
 
 
 def pandas_sparse_array_builder(client, value, builder, **kw):

--- a/python/vineyard/data/dataframe.py
+++ b/python/vineyard/data/dataframe.py
@@ -22,7 +22,6 @@ try:
     from pandas.core.internals.blocks import BlockPlacement, NumpyBlock as Block
 except:
     BlockPlacement = None
-    NDArrayBacked = None
     from pandas.core.internals.blocks import Block
 from pandas.core.internals.managers import BlockManager
 
@@ -60,11 +59,11 @@ def pandas_dataframe_resolver(obj, resolver):
         index_size = len(np_value)
         # ndim: 1 for SingleBlockManager/Series, 2 for BlockManager/DataFrame
         if BlockPlacement:
-            palcement = BlockPlacement(slice(idx, idx + 1, 1))
+            placement = BlockPlacement(slice(idx, idx + 1, 1))
         else:
-            palcement = slice(idx, idx + 1, 1)
+            placement = slice(idx, idx + 1, 1)
         values = np.expand_dims(np_value, 0)
-        blocks.append(Block(values, palcement, ndim=2))
+        blocks.append(Block(values, placement, ndim=2))
     if 'index_' in meta:
         index = resolver.run(obj.member('index_'))
     else:

--- a/python/vineyard/data/tests/test_pickle.py
+++ b/python/vineyard/data/tests/test_pickle.py
@@ -204,3 +204,10 @@ def test_bytes_io_pandas_dataframe_mixed_columns(vineyard_client):
     object_id = vineyard_client.put(df)
     target = read_and_build(b1m, vineyard_client.get(object_id))
     pd.testing.assert_frame_equal(df, target)
+
+
+def test_bytes_io_pandas_series(vineyard_client):
+    s = pd.Series([1, 3, 5, np.nan, 6, 8], name='foo')
+    object_id = vineyard_client.put(s)
+    target = read_and_build(b1m, vineyard_client.get(object_id))
+    pd.testing.assert_series_equal(s, target)

--- a/python/vineyard/data/tests/test_pickle.py
+++ b/python/vineyard/data/tests/test_pickle.py
@@ -67,8 +67,7 @@ values = [
 ]
 
 
-@pytest.mark.parametrize("block_size, value", values)
-def test_bytes_io_roundtrip(block_size, value):
+def read_and_build(block_size, value):
     reader = PickledReader(value)
     bs, nlen = [], 0
     while True:
@@ -86,7 +85,12 @@ def test_bytes_io_roundtrip(block_size, value):
     assert writer.value is None
     writer.close()
     assert writer.value is not None
-    target = writer.value
+    return writer.value
+
+
+@pytest.mark.parametrize("block_size, value", values)
+def test_bytes_io_roundtrip(block_size, value):
+    target = read_and_build(block_size, value)
 
     # compare values
     if isinstance(value, np.ndarray):
@@ -103,3 +107,100 @@ def test_bytes_io_roundtrip(block_size, value):
         pd.testing.assert_series_equal(target, value)
     else:
         assert target == value
+
+
+def test_bytes_io_numpy_ndarray(vineyard_client):
+    arr = np.random.rand(4, 5, 6)
+    object_id = vineyard_client.put(arr)
+    target = read_and_build(b1m, vineyard_client.get(object_id))
+    np.testing.assert_allclose(arr, target)
+
+
+def test_bytes_io_empty_ndarray(vineyard_client):
+    arr = np.ones(())
+    object_id = vineyard_client.put(arr)
+    target = read_and_build(b1m, vineyard_client.get(object_id))
+    np.testing.assert_allclose(arr, target)
+
+    arr = np.ones((0, 1))
+    object_id = vineyard_client.put(arr)
+    target = read_and_build(b1m, vineyard_client.get(object_id))
+    np.testing.assert_allclose(arr, target)
+
+    arr = np.ones((0, 1, 2))
+    object_id = vineyard_client.put(arr)
+    target = read_and_build(b1m, vineyard_client.get(object_id))
+    np.testing.assert_allclose(arr, target)
+
+    arr = np.ones((0, 1, 2, 3))
+    object_id = vineyard_client.put(arr)
+    target = read_and_build(b1m, vineyard_client.get(object_id))
+    np.testing.assert_allclose(arr, target)
+
+    arr = np.zeros((), dtype='int')
+    object_id = vineyard_client.put(arr)
+    target = read_and_build(b1m, vineyard_client.get(object_id))
+    np.testing.assert_allclose(arr, target)
+
+    arr = np.zeros((0, 1), dtype='int')
+    object_id = vineyard_client.put(arr)
+    target = read_and_build(b1m, vineyard_client.get(object_id))
+    np.testing.assert_allclose(arr, target)
+
+    arr = np.zeros((0, 1, 2), dtype='int')
+    object_id = vineyard_client.put(arr)
+    target = read_and_build(b1m, vineyard_client.get(object_id))
+    np.testing.assert_allclose(arr, target)
+
+    arr = np.zeros((0, 1, 2, 3), dtype='int')
+    object_id = vineyard_client.put(arr)
+    target = read_and_build(b1m, vineyard_client.get(object_id))
+    np.testing.assert_allclose(arr, target)
+
+
+def test_bytes_io_str_ndarray(vineyard_client):
+    arr = np.array(['', 'x', 'yz', 'uvw'])
+    object_id = vineyard_client.put(arr)
+    target = read_and_build(b1m, vineyard_client.get(object_id))
+    np.testing.assert_equal(arr, target)
+
+
+def test_object_ndarray(vineyard_client):
+    arr = np.array([1, 'x', 3.14, (1, 4)], dtype=object)
+    object_id = vineyard_client.put(arr)
+    target = read_and_build(b1m, vineyard_client.get(object_id))
+    np.testing.assert_equal(arr, target)
+
+    arr = np.ones((), dtype='object')
+    object_id = vineyard_client.put(arr)
+    target = read_and_build(b1m, vineyard_client.get(object_id))
+    np.testing.assert_equal(arr, target)
+
+
+def test_bytes_io_tensor_order(vineyard_client):
+    arr = np.asfortranarray(np.random.rand(10, 7))
+    object_id = vineyard_client.put(arr)
+    res = read_and_build(b1m, vineyard_client.get(object_id))
+    assert res.flags['C_CONTIGUOUS'] == arr.flags['C_CONTIGUOUS']
+    assert res.flags['F_CONTIGUOUS'] == arr.flags['F_CONTIGUOUS']
+
+
+def test_bytes_io_pandas_dataframe(vineyard_client):
+    df = pd.DataFrame({'a': [1, 2, 3, 4], 'b': [5, 6, 7, 8]})
+    object_id = vineyard_client.put(df)
+    target = read_and_build(b1m, vineyard_client.get(object_id))
+    pd.testing.assert_frame_equal(df, target)
+
+
+def test_bytes_io_pandas_dataframe_int_columns(vineyard_client):
+    df = pd.DataFrame({1: [1, 2, 3, 4], 2: [5, 6, 7, 8]})
+    object_id = vineyard_client.put(df)
+    target = read_and_build(b1m, vineyard_client.get(object_id))
+    pd.testing.assert_frame_equal(df, target)
+
+
+def test_bytes_io_pandas_dataframe_mixed_columns(vineyard_client):
+    df = pd.DataFrame({'a': [1, 2, 3, 4], 'b': [5, 6, 7, 8], 1: [9, 10, 11, 12], 2: [13, 14, 15, 16]})
+    object_id = vineyard_client.put(df)
+    target = read_and_build(b1m, vineyard_client.get(object_id))
+    pd.testing.assert_frame_equal(df, target)

--- a/python/vineyard/data/utils.py
+++ b/python/vineyard/data/utils.py
@@ -27,17 +27,6 @@ if pickle.HIGHEST_PROTOCOL < 5:
     import pickle5 as pickle
 
 
-def wrap_type(ty):
-    class T(ty):
-        pass
-
-    T.__module__ = ty.__module__
-    T.__name__ = ty.__name__
-    T.__qualname__ = ty.__qualname__
-    T.__doc__ = ty.__doc__
-    return T
-
-
 def normalize_dtype(dtype, dtype_meta=None):
     ''' Normalize a descriptive C++ type to numpy.dtype.
     '''

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ setup(
         'numpy',
         'pandas<1.0.0; python_version<"3.6"',
         'pandas<1.2.0; python_version<"3.7"',
-        'pandas>=1.0.0,<1.3.0; python_version>="3.7"',
+        'pandas>=1.0.0; python_version>="3.7"',
         'pickle5; python_version<="3.7"',
         'pyarrow',
         'setuptools',


### PR DESCRIPTION

What do these changes do?
-------------------------

Adapt to `BlockManager` API of pandas v1.3.0.

Related issue number
--------------------

Fixes #361.

