### PR TITLE
Enable pickle support for metadata.

### DIFF
--- a/python/client.cc
+++ b/python/client.cc
@@ -22,7 +22,10 @@ limitations under the License.
 #pragma GCC visibility push(default)
 #include "client/client.h"
 #include "client/ds/blob.h"
+#include "client/ds/i_object.h"
+#include "client/ds/object_meta.h"
 #include "client/rpc_client.h"
+#include "common/util/json.h"
 #include "common/util/status.h"
 #pragma GCC visibility pop
 
@@ -285,7 +288,7 @@ void bind_client(py::module& mod) {
               std::unordered_map<std::string, py::object> element;
               if (!kv.second.empty()) {
                 for (auto const& elem : json::iterator_wrapper(kv.second)) {
-                  element[elem.key()] = json_to_python(elem.value());
+                  element[elem.key()] = detail::from_json(elem.value());
                 }
               }
               meta_to_return.emplace(kv.first, std::move(element));

--- a/python/pybind11_utils.cc
+++ b/python/pybind11_utils.cc
@@ -160,8 +160,8 @@ py::object from_json(const json& j) {
       obj.append(from_json(el));
     }
     return std::move(obj);
-  } else  // Object
-  {
+  } else {
+    // Object
     py::dict obj;
     for (json::const_iterator it = j.cbegin(); it != j.cend(); ++it) {
       obj[py::str(it.key())] = from_json(it.value());

--- a/python/pybind11_utils.cc
+++ b/python/pybind11_utils.cc
@@ -23,6 +23,10 @@ limitations under the License.
 
 #include "pybind11/pybind11.h"
 
+#pragma GCC visibility push(default)
+#include "common/util/json.h"
+#pragma GCC visibility pop
+
 namespace py = pybind11;
 using namespace py::literals;  // NOLINT(build/namespaces_literals)
 
@@ -130,47 +134,102 @@ void bind_utils(py::module& mod) {
   PyModule_AddFunctions(mod.ptr(), vineyard_utils_methods);
 }
 
-py::object json_to_python(json const& value) {
-  switch (value.type()) {
-  case json::value_t::null: {
+namespace detail {
+
+/**
+ * Cast nlohmann::json to python object.
+ *
+ * Refer to https://github.com/pybind/pybind11_json
+ */
+py::object from_json(const json& j) {
+  if (j.is_null()) {
     return py::none();
-  }
-  case json::value_t::object: {
-    std::unordered_map<std::string, py::object> result;
-    for (auto const& element : json::iterator_wrapper(value)) {
-      result[element.key()] = json_to_python(element.value());
+  } else if (j.is_boolean()) {
+    return py::bool_(j.get<bool>());
+  } else if (j.is_number_integer()) {
+    return py::int_(j.get<json::number_integer_t>());
+  } else if (j.is_number_unsigned()) {
+    return py::int_(j.get<json::number_unsigned_t>());
+  } else if (j.is_number_float()) {
+    return py::float_(j.get<double>());
+  } else if (j.is_string()) {
+    return py::str(j.get<std::string>());
+  } else if (j.is_array()) {
+    py::list obj;
+    for (const auto& el : j) {
+      obj.append(from_json(el));
     }
-    return py::cast(std::move(result));
-  }
-  case json::value_t::array: {
-    py::list result;
-    for (auto const& element : value) {
-      result.append(json_to_python(element));
+    return std::move(obj);
+  } else  // Object
+  {
+    py::dict obj;
+    for (json::const_iterator it = j.cbegin(); it != j.cend(); ++it) {
+      obj[py::str(it.key())] = from_json(it.value());
     }
-    return std::move(result);
-  }
-  case json::value_t::string: {
-    return py::cast(value.get_ref<std::string const&>());
-  }
-  case json::value_t::boolean: {
-    return py::cast(value.get<bool>());
-  }
-  case json::value_t::number_integer: {
-    return py::cast(value.get<int64_t>());
-  }
-  case json::value_t::number_unsigned: {
-    return py::cast(value.get<uint64_t>());
-  }
-  case json::value_t::number_float: {
-    return py::cast(value.get<double>());
-  }
-  case json::value_t::binary: {
-    return py::cast(value.get_ref<std::string const&>());
-  }
-  default: {
-    return py::none();
-  }
+    return std::move(obj);
   }
 }
+
+/**
+ * Cast python object to nlohmann::json.
+ *
+ * Refer to https://github.com/pybind/pybind11_json
+ */
+json to_json(const py::handle& obj) {
+  if (obj.ptr() == nullptr || obj.is_none()) {
+    return nullptr;
+  }
+  if (py::isinstance<py::bool_>(obj)) {
+    return obj.cast<bool>();
+  }
+  if (py::isinstance<py::int_>(obj)) {
+    try {
+      json::number_integer_t s = obj.cast<json::number_integer_t>();
+      if (py::int_(s).equal(obj)) {
+        return s;
+      }
+    } catch (...) {}
+    try {
+      json::number_unsigned_t u = obj.cast<json::number_unsigned_t>();
+      if (py::int_(u).equal(obj)) {
+        return u;
+      }
+    } catch (...) {}
+    throw std::runtime_error(
+        "to_json received an integer out of range for both "
+        "json::number_integer_t and json::number_unsigned_t type: " +
+        py::repr(obj).cast<std::string>());
+  }
+  if (py::isinstance<py::float_>(obj)) {
+    return obj.cast<double>();
+  }
+  if (py::isinstance<py::bytes>(obj)) {
+    py::module base64 = py::module::import("base64");
+    return base64.attr("b64encode")(obj)
+        .attr("decode")("utf-8")
+        .cast<std::string>();
+  }
+  if (py::isinstance<py::str>(obj)) {
+    return obj.cast<std::string>();
+  }
+  if (py::isinstance<py::tuple>(obj) || py::isinstance<py::list>(obj)) {
+    auto out = json::array();
+    for (const py::handle value : obj) {
+      out.push_back(to_json(value));
+    }
+    return out;
+  }
+  if (py::isinstance<py::dict>(obj)) {
+    auto out = json::object();
+    for (const py::handle key : obj) {
+      out[py::str(key).cast<std::string>()] = to_json(obj[key]);
+    }
+    return out;
+  }
+  throw std::runtime_error("to_json not implemented for this type of object: " +
+                           py::repr(obj).cast<std::string>());
+}
+
+}  // namespace detail
 
 }  // namespace vineyard

--- a/python/pybind11_utils.h
+++ b/python/pybind11_utils.h
@@ -29,6 +29,8 @@ limitations under the License.
 #include "common/util/uuid.h"
 #pragma GCC visibility pop
 
+namespace py = pybind11;
+
 namespace vineyard {
 
 // Wrap ObjectID to makes pybind11 work.
@@ -117,7 +119,10 @@ namespace vineyard {
 
 void throw_on_error(Status const& status);
 
-pybind11::object json_to_python(json const& value);
+namespace detail {
+py::object from_json(const json& value);
+json to_json(const py::handle& obj);
+}  // namespace detail
 
 }  // namespace vineyard
 

--- a/src/client/ds/object_meta.cc
+++ b/src/client/ds/object_meta.cc
@@ -74,7 +74,11 @@ bool const ObjectMeta::IsLocal() const {
     // it is a newly created metadata
     return true;
   } else {
-    return client_->instance_id() == instance_id.get<InstanceID>();
+    if (client_) {
+      return client_->instance_id() == instance_id.get<InstanceID>();
+    } else {
+      return false;
+    }
   }
 }
 
@@ -204,7 +208,7 @@ const std::shared_ptr<BufferSet>& ObjectMeta::GetBufferSet() const {
 }
 
 void ObjectMeta::findAllBlobs(const json& tree) {
-  if (tree.empty()) {
+  if (tree.empty() && client_ != nullptr) {
     return;
   }
   ObjectID member_id =


### PR DESCRIPTION


What do these changes do?
-------------------------

<!-- Please give a short brief about these changes. -->

+ Enable `py::pickle` for `vineyard::ObjectMeta`
+ Refer tools `{to,from}_json` to support casting between python value and nlohmann::json. Vineyard cannot directly depends on pybind11_json, due to the visibility issue.

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #352.

