### PR TITLE
RPC & IPC service depends on the meta & bulk only.

### DIFF
--- a/src/server/async/ipc_server.cc
+++ b/src/server/async/ipc_server.cc
@@ -41,9 +41,9 @@ IPCServer::~IPCServer() {
 }
 
 void IPCServer::Start() {
+  vs_ptr_->IPCReady();
   SocketServer::Start();
   LOG(INFO) << "Vineyard will listen on " << ipc_spec_["socket"] << " for IPC";
-  vs_ptr_->IPCReady();
 }
 
 #if BOOST_VERSION >= 106600

--- a/src/server/async/rpc_server.cc
+++ b/src/server/async/rpc_server.cc
@@ -47,10 +47,10 @@ RPCServer::~RPCServer() {
 }
 
 void RPCServer::Start() {
+  vs_ptr_->RPCReady();
   SocketServer::Start();
   LOG(INFO) << "Vineyard will listen on 0.0.0.0:"
             << rpc_spec_["port"].get<uint32_t>() << " for RPC";
-  vs_ptr_->RPCReady();
 }
 
 #if BOOST_VERSION >= 106600

--- a/src/server/server/vineyard_server.cc
+++ b/src/server/server/vineyard_server.cc
@@ -36,18 +36,16 @@ limitations under the License.
 namespace vineyard {
 
 #ifndef ENSURE_VINEYARDD_READY
-#define ENSURE_VINEYARDD_READY()                                      \
-  do {                                                                \
-    if (!((ready_ & kMeta) && (ready_ & kIPC) && (ready_ & kBulk))) { \
-      std::stringstream ss;                                           \
-      ss << "{";                                                      \
-      ss << "meta: " << (ready_ & kMeta) << ", ";                     \
-      ss << "ipc: " << (ready_ & kIPC) << ", ";                       \
-      ss << "rpc: " << (ready_ & kRPC) << ", ";                       \
-      ss << "bulk store: " << (ready_ & kBulk);                       \
-      ss << "}";                                                      \
-      return Status::VineyardServerNotReady(ss.str());                \
-    }                                                                 \
+#define ENSURE_VINEYARDD_READY()                       \
+  do {                                                 \
+    if (!((ready_ & kMeta) && (ready_ & kBulk))) {     \
+      std::stringstream ss;                            \
+      ss << "{";                                       \
+      ss << "meta: " << (ready_ & kMeta) << ", ";      \
+      ss << "bulk store: " << (ready_ & kBulk);        \
+      ss << "}";                                       \
+      return Status::VineyardServerNotReady(ss.str()); \
+    }                                                  \
   } while (0)
 #endif  // ENSURE_VINEYARDD_READY
 


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

The `IPCReady()` callback shouldn't be in front of `ipc_service_start`.

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #378
