### PR TITLE
Add a version string to vineyardd by gflags::SetVersionString.

### DIFF
--- a/src/server/vineyardd.cc
+++ b/src/server/vineyardd.cc
@@ -28,6 +28,7 @@ limitations under the License.
 #include "common/util/env.h"
 #include "common/util/flags.h"
 #include "common/util/logging.h"
+#include "common/util/version.h"
 #include "server/server/vineyard_server.h"
 #include "server/util/spec_resolvers.h"
 
@@ -74,6 +75,7 @@ int main(int argc, char* argv[]) {
   vineyard::logging::InstallFailureSignalHandler();
 
   vineyard::flags::SetUsageMessage("Usage: vineyardd [options]");
+  vineyard::flags::SetVersionString(vineyard::vineyard_version());
   vineyard::flags::ParseCommandLineNonHelpFlags(&argc, &argv, false);
   if (FLAGS_help) {
     FLAGS_help = false;


### PR DESCRIPTION

What do these changes do?
-------------------------

Now `vineyardd --version` prints

```bash
vineyardd version 0.2.6
```

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #385 

