### PR TITLE
Add DMatrix resolvers and tests for better integration with xgboost 

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -325,7 +325,7 @@ jobs:
 
             rm -rf default.etcd
             rm -rf /dev/shm/etcd*
-            python3 test/runner.py --with-python --with-migration
+            python3 test/runner.py --with-python --with-migration --with-contrib-ml
 
       - name: Run Python Tests
         if: ${{ github.event_name == 'pull_request' }}

--- a/python/vineyard/contrib/ml/tests/test_xgboost.py
+++ b/python/vineyard/contrib/ml/tests/test_xgboost.py
@@ -1,0 +1,81 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020-2021 Alibaba Group Holding Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import numpy as np
+import pandas as pd
+
+import pyarrow as pa
+import pytest
+
+import vineyard
+from vineyard.core import default_builder_context, default_resolver_context
+from vineyard.contrib.ml.xgboost import register_xgb_types
+
+register_xgb_types(default_builder_context, default_resolver_context)
+
+
+def test_numpy_ndarray(vineyard_client):
+    arr = np.random.rand(4, 5)
+    object_id = vineyard_client.put(arr)
+    dtrain = vineyard_client.get(object_id)
+    assert dtrain.num_col() == 5
+    assert dtrain.num_row() == 4
+
+
+def test_pandas_dataframe_specify_label(vineyard_client):
+    df = pd.DataFrame({'a': [1, 2, 3, 4], 'b': [5, 6, 7, 8], 'c': [1.0, 2.0, 3.0, 4.0]})
+    object_id = vineyard_client.put(df)
+    dtrain = vineyard_client.get(object_id, label='a')
+    assert dtrain.num_col() == 2
+    assert dtrain.num_row() == 4
+    arr = np.array([1, 2, 3, 4])
+    assert np.allclose(arr, dtrain.get_label())
+
+
+def test_pandas_dataframe_specify_data(vineyard_client):
+    df = pd.DataFrame({'a': [1, 2, 3, 4], 'b': [[5, 1.0], [6, 2.0], [7, 3.0], [8, 9.0]]})
+    object_id = vineyard_client.put(df)
+    dtrain = vineyard_client.get(object_id, data='b', label='a')
+    assert dtrain.num_col() == 2
+    assert dtrain.num_row() == 4
+    arr = np.array([1, 2, 3, 4])
+    assert np.allclose(arr, dtrain.get_label())
+
+
+def test_record_batch_xgb_resolver(vineyard_client):
+    arrays = [pa.array([1, 2, 3, 4]), pa.array([3.0, 4.0, 5.0, 6.0]), pa.array([0, 1, 0, 1])]
+    batch = pa.RecordBatch.from_arrays(arrays, ['f0', 'f1', 'target'])
+    object_id = vineyard_client.put(batch)
+    dtrain = vineyard_client.get(object_id, label='target')
+    assert dtrain.num_col() == 2
+    assert dtrain.num_row() == 4
+    arr = np.array([0, 1, 0, 1])
+    assert np.allclose(arr, dtrain.get_label())
+
+
+def test_table_xgb_resolver(vineyard_client):
+    arrays = [pa.array([1, 2]), pa.array([0, 1]), pa.array([0.1, 0.2])]
+    batch = pa.RecordBatch.from_arrays(arrays, ['f0', 'label', 'f2'])
+    batches = [batch] * 3
+    table = pa.Table.from_batches(batches)
+    object_id = vineyard_client.put(table)
+    dtrain = vineyard_client.get(object_id, label='label')
+    assert dtrain.num_col() == 2
+    assert dtrain.num_row() == 6
+    arr = np.array([0, 1, 0, 1, 0, 1])
+    assert np.allclose(arr, dtrain.get_label())

--- a/python/vineyard/contrib/ml/xgboost.py
+++ b/python/vineyard/contrib/ml/xgboost.py
@@ -1,0 +1,108 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020-2021 Alibaba Group Holding Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from vineyard._C import ObjectMeta
+from vineyard.data.utils import from_json, to_json, build_numpy_buffer, normalize_dtype
+from vineyard.data import tensor, dataframe, arrow
+
+import pandas as pd
+import pyarrow as pa
+try:
+    from pandas.core.internals.blocks import BlockPlacement, NumpyBlock as Block
+except:
+    BlockPlacement = None
+    from pandas.core.internals.blocks import Block
+
+from pandas.core.internals.managers import BlockManager
+import numpy as np
+import xgboost as xgb
+
+
+def xgb_builder(client, value, builder, **kw):
+    # TODO: build DMatrix to vineyard objects
+    pass
+
+
+def xgb_tensor_resolver(obj):
+    array = tensor.numpy_ndarray_resolver(obj)
+    return xgb.DMatrix(array)
+
+
+def xgb_dataframe_resolver(obj, resolver, **kw):
+    meta = obj.meta
+    columns = from_json(meta['columns_'])
+    if not columns:
+        return pd.DataFrame()
+    # ensure zero-copy
+    blocks = []
+    index_size = 0
+    for idx, name in enumerate(columns):
+        np_value = tensor.numpy_ndarray_resolver(obj.member('__values_-value-%d' % idx))
+        index_size = len(np_value)
+        # ndim: 1 for SingleBlockManager/Series, 2 for BlockManager/DataFrame
+        if BlockPlacement:
+            placement = BlockPlacement(slice(idx, idx + 1, 1))
+        else:
+            placement = slice(idx, idx + 1, 1)
+        values = np.expand_dims(np_value, 0)
+        blocks.append(Block(values, placement, ndim=2))
+    index = np.arange(index_size)
+    df = pd.DataFrame(BlockManager(blocks, [pd.Index(columns), index]))
+    if 'label' in kw:
+        label = df.pop(kw['label'])
+        # data column can only be specified if label column is specified
+        if 'data' in kw:
+            df = np.stack(df[kw['data']].values)
+        return xgb.DMatrix(df, label)
+    return xgb.DMatrix(df)
+
+
+def xgb_recordBatch_resolver(obj, resolver, **kw):
+    rb = arrow.record_batch_resolver(obj, resolver)
+    # FIXME to_pandas is not zero_copy guaranteed
+    df = rb.to_pandas()
+    if 'label' in kw:
+        label = df.pop(kw['label'])
+        return xgb.DMatrix(df, label)
+    return xgb.DMatrix(df)
+
+
+def xgb_table_resolver(obj, resolver, **kw):
+    meta = obj.meta
+    batch_num = int(meta['batch_num_'])
+    batches = []
+    for idx in range(int(meta['__batches_-size'])):
+        batches.append(arrow.record_batch_resolver(obj.member('__batches_-%d' % idx), resolver))
+    tb = pa.Table.from_batches(batches)
+    # FIXME to_pandas is not zero_copy guaranteed
+    df = tb.to_pandas()
+    if 'label' in kw:
+        label = df.pop(kw['label'])
+        return xgb.DMatrix(df, label)
+    return xgb.DMatrix(df)
+
+
+def register_xgb_types(builder_ctx, resolver_ctx):
+    if builder_ctx is not None:
+        builder_ctx.register(xgb.DMatrix, xgb_builder)
+
+    if resolver_ctx is not None:
+        resolver_ctx.register('vineyard::Tensor', xgb_tensor_resolver)
+        resolver_ctx.register('vineyard::DataFrame', xgb_dataframe_resolver)
+        resolver_ctx.register('vineyard::RecordBatch', xgb_recordBatch_resolver)
+        resolver_ctx.register('vineyard::Table', xgb_table_resolver)


### PR DESCRIPTION
Signed-off-by: Diwen Zhu <diwen.zdw@alibaba-inc.com>

<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

As title, we omit the integration with global objects in this PR since xgboost does not support native distributed training.

Instead, we will try to handle global objects in distributed training frameworks that xgboost leverages (e.g., dask) in the future.

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Related to #280.