### PR TITLE
Run xgboost tests use a scoped fixture, rather than populating the global ctx

### DIFF
--- a/python/vineyard/contrib/ml/tests/test_xgboost.py
+++ b/python/vineyard/contrib/ml/tests/test_xgboost.py
@@ -24,9 +24,17 @@ import pytest
 
 import vineyard
 from vineyard.core import default_builder_context, default_resolver_context
+from vineyard.core.builder import builder_context
+from vineyard.core.resolver import resolver_context
 from vineyard.contrib.ml.xgboost import register_xgb_types
 
-register_xgb_types(default_builder_context, default_resolver_context)
+
+@pytest.fixture(scope="module", autouse=True)
+def vineyard_for_xgboost():
+    with builder_context() as builder:
+        with resolver_context() as resolver:
+            register_xgb_types(builder, resolver)
+            yield builder, resolver
 
 
 def test_numpy_ndarray(vineyard_client):

--- a/python/vineyard/contrib/ml/tests/test_xgboost.py
+++ b/python/vineyard/contrib/ml/tests/test_xgboost.py
@@ -22,8 +22,6 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 
-import vineyard
-from vineyard.core import default_builder_context, default_resolver_context
 from vineyard.core.builder import builder_context
 from vineyard.core.resolver import resolver_context
 from vineyard.contrib.ml.xgboost import register_xgb_types

--- a/python/vineyard/core/builder.py
+++ b/python/vineyard/core/builder.py
@@ -28,6 +28,9 @@ class BuilderContext():
     def __init__(self):
         self.__factory = dict()
 
+    def __str__(self) -> str:
+        return str(self.__factory)
+
     def register(self, type_id, builder):
         ''' Register a Python type to the builder context.
 

--- a/python/vineyard/core/driver.py
+++ b/python/vineyard/core/driver.py
@@ -30,6 +30,9 @@ class DriverContext():
     def __init__(self):
         self.__factory = defaultdict(SortedDict)
 
+    def __str__(self) -> str:
+        return str(self.__factory)
+
     def register(self, typename_prefix, meth, func):
         self.__factory[meth][typename_prefix] = func
 

--- a/python/vineyard/core/resolver.py
+++ b/python/vineyard/core/resolver.py
@@ -31,6 +31,9 @@ class ResolverContext():
     def __init__(self):
         self.__factory = SortedDict()
 
+    def __str__(self) -> str:
+        return str(self.__factory)
+
     def register(self, typename_prefix, resolver):
         self.__factory[typename_prefix] = resolver
 


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

Use a scoped autouse fixture to run xgboost tests.

Related issue number
--------------------

Follow-up work for #394 and #399.

