### PR TITLE
Allow the IPC socket connectable by other users.

### DIFF
--- a/src/server/async/ipc_server.cc
+++ b/src/server/async/ipc_server.cc
@@ -41,6 +41,11 @@ IPCServer::~IPCServer() {
 }
 
 void IPCServer::Start() {
+  std::string const& ipc_socket =
+      ipc_spec_["socket"].get_ref<std::string const&>();
+  chmod(ipc_socket.c_str(),
+        S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
+
   vs_ptr_->IPCReady();
   SocketServer::Start();
   LOG(INFO) << "Vineyard will listen on " << ipc_spec_["socket"] << " for IPC";


### PR DESCRIPTION
What do these changes do?
-------------------------

On Kubernetes, we still launch the vineyard using `root` user, but allow other users to operate on the socket and estalish the connection.

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #404.
