### PR TITLE
Airflow: support running among distributed celery workers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -608,6 +608,7 @@ add_custom_target(vineyard_cpplint
 
 add_custom_target(python_install
         COMMAND python3 setup.py install
+        COMMAND python3 setup_airflow.py install
         COMMAND python3 setup_ml.py install
         COMMAND python3 setup_dask.py install
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ class FormatAndLint(Command):
         self.inplace = False
 
     def finalize_options(self):
-        if self.inplace or self.inplace == "True" or self.inplace == "true":
+        if self.inplace in ['true', 'True', '1', 't'] or self.inplace:
             self.inplace = True
         else:
             self.inplace = False

--- a/setup_airflow.py
+++ b/setup_airflow.py
@@ -47,7 +47,6 @@ def find_airflow_packages(root):
     for pkg in find_packages(root):
         if 'contrib.airflow' in pkg:
             pkgs.append(pkg)
-    print(pkgs)
     return pkgs
 
 

--- a/setup_dask.py
+++ b/setup_dask.py
@@ -47,7 +47,6 @@ def find_dask_packages(root):
     for pkg in find_packages(root):
         if 'contrib.dask' in pkg:
             pkgs.append(pkg)
-    print(pkgs)
     return pkgs
 
 
@@ -82,7 +81,10 @@ setup(
         "install": install_plat
     },
     zip_safe=False,
-    install_requires=['vineyard', 'dask[complete]'],
+    install_requires=[
+        'vineyard',
+        'dask[complete]'
+    ],
     platform=['POSIX', 'MacOS'],
     license="Apache License 2.0",
     classifiers=[

--- a/setup_ml.py
+++ b/setup_ml.py
@@ -81,11 +81,7 @@ setup(
         "install": install_plat
     },
     zip_safe=False,
-    install_requires=[
-        'vineyard',
-        'tensorflow',
-        'xgboost'
-    ],
+    install_requires=['vineyard', 'tensorflow', 'xgboost'],
     platform=['POSIX', 'MacOS'],
     license="Apache License 2.0",
     classifiers=[

--- a/setup_ml.py
+++ b/setup_ml.py
@@ -47,7 +47,6 @@ def find_ml_packages(root):
     for pkg in find_packages(root):
         if 'contrib.ml' in pkg:
             pkgs.append(pkg)
-    print(pkgs)
     return pkgs
 
 
@@ -82,7 +81,11 @@ setup(
         "install": install_plat
     },
     zip_safe=False,
-    install_requires=['vineyard', 'tensorflow', 'xgboost'],
+    install_requires=[
+        'vineyard',
+        'tensorflow',
+        'xgboost'
+    ],
     platform=['POSIX', 'MacOS'],
     license="Apache License 2.0",
     classifiers=[


### PR DESCRIPTION

What do these changes do?
-------------------------

Making airflow's distributed celery worker can run on vineyard xcom backend, includes,

+ enable auto-migration when accessing remote objects

This pull request tidy these setup.py files as well.

Related issue number
--------------------

Part of #374.

