### PR TITLE
[MRG]🎉 init prometheus setting

### DIFF
--- a/prometheus/grok_exporter.yml
+++ b/prometheus/grok_exporter.yml
@@ -1,0 +1,36 @@
+global:
+  config_version: 3
+input:
+  type: file
+  path: /tmp/vineyard.*.log.INFO.*
+  readall: false
+  fail_on_missing_logfile: true
+imports:
+grok_patterns:
+  - 'BASE10NUM (?<![0-9.+-])(?>[+-]?(?:(?:[0-9]+(?:\.[0-9]+)?)|(?:\.[0-9]+)))'
+  - 'NUMBER (?:%{BASE10NUM})'
+  - 'USERNAME [a-zA-Z0-9._-]+'
+  - 'LABEL [a-zA-Z]+'
+metrics:
+  - type: counter
+    name: data_requests_total
+    help: number of GetData or CreateData requests
+    match: '%{USERNAME:user} %{LABEL:op} data_requests_total %{NUMBER:val}'
+    value: '{{.val}}'
+    labels:
+      user: '{{.user}}'
+      operation: '{{.op}}'
+  - type: summary
+    name: data_request_latency
+    help: Data request duration seconds.
+    match: '%{USERNAME:user} %{LABEL:op} data_request_latency %{NUMBER:val}ms'
+    value: '{{.val}}'
+    quantiles: {0.5: 0.05, 0.9: 0.01, 0.99: 0.001}
+    labels:
+      user: '{{.user}}'
+      operation: '{{.op}}'
+server:
+  protocol: http
+  host: localhost
+  port: 9144
+  path: /metrics

--- a/prometheus/prometheus.rules.yml
+++ b/prometheus/prometheus.rules.yml
@@ -1,0 +1,5 @@
+groups:
+  - name: avg
+    rules:
+      - record: operation:data_request_latency:avg
+        expr: avg by (operation) (data_request_latency_sum)/(data_request_latency_count)

--- a/prometheus/prometheus.rules.yml
+++ b/prometheus/prometheus.rules.yml
@@ -1,5 +1,5 @@
 groups:
-  - name: avg
+  - name: request
     rules:
       - record: operation:data_request_latency:avg
         expr: avg by (operation) (data_request_latency_sum)/(data_request_latency_count)

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,13 @@
+global:
+  scrape_interval: 5s
+  evaluation_interval: 5s
+  external_labels:
+    monitor: 'vineyardd-monitor'
+
+rule_files:
+  - './prometheus.rules.yml'
+
+scrape_configs:
+  - job_name: "vineyardd"
+    static_configs:
+      - targets: ["localhost:9144"]

--- a/src/common/util/logging.h
+++ b/src/common/util/logging.h
@@ -21,13 +21,15 @@ limitations under the License.
 namespace vineyard {
 namespace logging = google;
 #ifndef LOG_COUNTER
-#define LOG_COUNTER(metric_name, label) \
-LOG_EVERY_N(INFO, 1) << getenv("USER") << " " << (label) << " " << (metric_name)<< " "<< logging::COUNTER;
+#define LOG_COUNTER(metric_name, label)                           \
+  LOG_EVERY_N(INFO, 1) << getenv("USER") << " " << (label) << " " \
+                       << (metric_name) << " " << logging::COUNTER;
 #endif
 
 #ifndef LOG_SUMMARY
-#define LOG_SUMMARY(metric_name, label, metric_val) \
-LOG(INFO) << getenv("USER") <<" " << (label) << " "<< (metric_name)<< " " << (metric_val) * 1000 << "ms";
+#define LOG_SUMMARY(metric_name, label, metric_val)                            \
+  LOG(INFO) << getenv("USER") << " " << (label) << " " << (metric_name) << " " \
+            << (metric_val) *1000 << "ms";
 #endif
 
 }  // namespace vineyard

--- a/src/common/util/logging.h
+++ b/src/common/util/logging.h
@@ -20,6 +20,16 @@ limitations under the License.
 
 namespace vineyard {
 namespace logging = google;
+#ifndef LOG_COUNTER
+#define LOG_COUNTER(metric_name, label) \
+LOG_EVERY_N(INFO, 1) << getenv("USER") << " " << (label) << " " << (metric_name)<< " "<< logging::COUNTER;
+#endif
+
+#ifndef LOG_SUMMARY
+#define LOG_SUMMARY(metric_name, label, metric_val) \
+LOG(INFO) << getenv("USER") <<" " << (label) << " "<< (metric_name)<< " " << (metric_val) * 1000 << "ms";
+#endif
+
 }  // namespace vineyard
 
 #endif  // SRC_COMMON_UTIL_LOGGING_H_

--- a/src/server/server/vineyard_server.cc
+++ b/src/server/server/vineyard_server.cc
@@ -343,7 +343,7 @@ Status VineyardServer::CreateData(
       },
       boost::bind(callback, _1, id, signature, _2));
   double endTime = GetCurrentTime();
-  LOG_SUMMARY("data_request_latency", "create",  endTime - startTime);
+  LOG_SUMMARY("data_request_latency", "create", endTime - startTime);
   LOG_COUNTER("data_requests_total", "create");
   return Status::OK();
 }

--- a/src/server/server/vineyard_server.cc
+++ b/src/server/server/vineyard_server.cc
@@ -191,6 +191,7 @@ Status VineyardServer::GetData(const std::vector<ObjectID>& ids,
                                std::function<bool()> alive,
                                callback_t<const json&> callback) {
   ENSURE_VINEYARDD_READY();
+  double startTime = GetCurrentTime();
   meta_service_ptr_->RequestToGetData(
       sync_remote, [this, ids, wait, alive, callback](const Status& status,
                                                       const json& meta) {
@@ -261,6 +262,9 @@ Status VineyardServer::GetData(const std::vector<ObjectID>& ids,
           return status;
         }
       });
+  double endTime = GetCurrentTime();
+  LOG_SUMMARY("data_request_latency", "get", endTime - startTime);
+  LOG_COUNTER("data_requests_total", "get");
   return Status::OK();
 }
 
@@ -290,6 +294,7 @@ Status VineyardServer::CreateData(
     const json& tree,
     callback_t<const ObjectID, const Signature, const InstanceID> callback) {
   ENSURE_VINEYARDD_READY();
+  double startTime = GetCurrentTime();
 #if !defined(NDEBUG)
   if (VLOG_IS_ON(10)) {
     VLOG(10) << "Got request from client to create data:";
@@ -337,6 +342,9 @@ Status VineyardServer::CreateData(
         }
       },
       boost::bind(callback, _1, id, signature, _2));
+  double endTime = GetCurrentTime();
+  LOG_SUMMARY("data_request_latency", "create",  endTime - startTime);
+  LOG_COUNTER("data_requests_total", "create");
   return Status::OK();
 }
 


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

- add basic metrics to log: data_request_latency and data_requests_total

![image](https://user-images.githubusercontent.com/35693452/128595164-33e10c14-32c6-4598-9a27-0b20749652f4.png)

-  add [grok_exporter](https://github.com/fstab/grok_exporter) setting file to export those metrics from log files, metrics will be displayed on : <http://localhost:9144/metrics>

```bash
./grok_exporter -config v6d/prometheus/grok_exporter.yml -disable-exporter-metrics
```
![image](https://user-images.githubusercontent.com/35693452/128595113-d6fb74f9-339e-437b-9b75-7c050f3a6b21.png)


-  add [prometheus](https://prometheus.io/) setting file to read those metrics

```bash
./prometheus --config.file=v6d/prometheus/prometheus.yml
```
-  add a prometheus recording rule file to calculate average request latency/

![image](https://user-images.githubusercontent.com/35693452/128595136-280749bd-f046-4cc8-9a7c-586c84697344.png)





Related issue number #275 
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #issue number

