### PR TITLE
Add a command line flag to control whether printing the metrics.

### DIFF
--- a/src/common/util/logging.h
+++ b/src/common/util/logging.h
@@ -20,18 +20,6 @@ limitations under the License.
 
 namespace vineyard {
 namespace logging = google;
-#ifndef LOG_COUNTER
-#define LOG_COUNTER(metric_name, label)                           \
-  LOG_EVERY_N(INFO, 1) << getenv("USER") << " " << (label) << " " \
-                       << (metric_name) << " " << logging::COUNTER;
-#endif
-
-#ifndef LOG_SUMMARY
-#define LOG_SUMMARY(metric_name, label, metric_val)                            \
-  LOG(INFO) << getenv("USER") << " " << (label) << " " << (metric_name) << " " \
-            << (metric_val) *1000 << "ms";
-#endif
-
 }  // namespace vineyard
 
 #endif  // SRC_COMMON_UTIL_LOGGING_H_

--- a/src/server/async/socket_server.cc
+++ b/src/server/async/socket_server.cc
@@ -141,13 +141,21 @@ bool SocketConnection::processMessage(const std::string& message_in) {
   try {
     root = json::parse(message_in);
   } catch (std::out_of_range const& err) {
+#ifndef NDEBUG
+    LOG(ERROR) << "json: " << err.what() << " when parsing" << message_in;
+#else
     LOG(ERROR) << "json: " << err.what();
+#endif
     std::string message_out;
     WriteErrorReply(Status::Invalid(err.what()), message_out);
     this->doWrite(message_out);
     return false;
   } catch (json::exception const& err) {
+#ifndef NDEBUG
+    LOG(ERROR) << "json: " << err.what() << " when parsing" << message_in;
+#else
     LOG(ERROR) << "json: " << err.what();
+#endif
     std::string message_out;
     WriteErrorReply(Status::Invalid(err.what()), message_out);
     this->doWrite(message_out);

--- a/src/server/server/vineyard_server.cc
+++ b/src/server/server/vineyard_server.cc
@@ -31,6 +31,7 @@ limitations under the License.
 #include "server/services/meta_service.h"
 #include "server/util/kubectl.h"
 #include "server/util/meta_tree.h"
+#include "server/util/metrics.h"
 #include "server/util/proc.h"
 
 namespace vineyard {

--- a/src/server/util/metrics.h
+++ b/src/server/util/metrics.h
@@ -1,0 +1,40 @@
+/** Copyright 2020-2021 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef SRC_SERVER_UTIL_METRICS_H_
+#define SRC_SERVER_UTIL_METRICS_H_
+
+#include "common/util/logging.h"
+#include "server/util/spec_resolvers.h"
+
+namespace vineyard {
+
+#ifndef LOG_COUNTER
+#define LOG_COUNTER(metric_name, label)                                  \
+  LOG_IF_EVERY_N(INFO, FLAGS_prometheus, 1)                              \
+      << getenv("USER") << " " << (label) << " " << (metric_name) << " " \
+      << logging::COUNTER;
+#endif
+
+#ifndef LOG_SUMMARY
+#define LOG_SUMMARY(metric_name, label, metric_val)                      \
+  LOG_IF(INFO, FLAGS_prometheus)                                         \
+      << getenv("USER") << " " << (label) << " " << (metric_name) << " " \
+      << (metric_val) *1000 << "ms";
+#endif
+
+}  // namespace vineyard
+
+#endif  // SRC_SERVER_UTIL_METRICS_H_

--- a/src/server/util/spec_resolvers.cc
+++ b/src/server/util/spec_resolvers.cc
@@ -22,6 +22,8 @@ limitations under the License.
 #include "common/util/logging.h"
 #include "server/util/spec_resolvers.h"
 
+namespace vineyard {
+
 // meta data
 DEFINE_string(deployment, "local", "deployment mode: local, distributed");
 DEFINE_string(etcd_endpoint, "http://127.0.0.1:2379", "endpoint of etcd");
@@ -41,7 +43,11 @@ DEFINE_int32(rpc_socket_port, 9600, "port to listen in rpc server");
 // Kubernetes
 DEFINE_bool(sync_crds, false, "Synchronize CRDs when persisting objects");
 
-namespace vineyard {
+// Whether to print metrics for prometheus or not.
+DEFINE_bool(prometheus, false,
+            "Whether to print metrics for prometheus or not");
+DEFINE_bool(metrics, false,
+            "Alias for --prometheus, and takes precedence over --prometheus");
 
 const Resolver& Resolver::get(std::string name) {
   static auto server_resolver = ServerSpecResolver();

--- a/src/server/util/spec_resolvers.h
+++ b/src/server/util/spec_resolvers.h
@@ -18,9 +18,15 @@ limitations under the License.
 
 #include <string>
 
+#include "gflags/gflags.h"
+
 #include "common/util/json.h"
 
 namespace vineyard {
+
+// Whether to print metrics for prometheus or not, default value is false.
+DECLARE_bool(prometheus);
+DECLARE_bool(metrics);
 
 /**
  * @brief Resolver is the base class of different kinds of

--- a/src/server/vineyardd.cc
+++ b/src/server/vineyardd.cc
@@ -83,6 +83,11 @@ int main(int argc, char* argv[]) {
   }
   vineyard::flags::HandleCommandLineHelpFlags();
 
+  // tweak other flags, specially alias
+  if (vineyard::FLAGS_metrics) {
+    vineyard::FLAGS_prometheus = true;
+  }
+
   LOG(INFO) << "Hello vineyard!";
 
   // Ignore SIGPIPE signals to avoid killing the server when writting to a lost


### PR DESCRIPTION

What do these changes do?
-------------------------

Add a command line flags `--prometheus` and `--metrics` to conditionally print the metric logs.

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Follow-up work for #418.

