### PR TITLE
Fix template type in VertexDataColum

### DIFF
--- a/modules/graph/fragment/arrow_fragment.h
+++ b/modules/graph/fragment/arrow_fragment.h
@@ -370,13 +370,13 @@ class ArrowFragment
   }
 
   template <typename DATA_T>
-  property_graph_utils::VertexDataColumn<DATA_T, vertex_t> vertex_data_column(
+  property_graph_utils::VertexDataColumn<DATA_T, vid_t> vertex_data_column(
       label_id_t label, prop_id_t prop) const {
     if (vertex_tables_[label]->num_rows() == 0) {
-      return property_graph_utils::VertexDataColumn<DATA_T, vertex_t>(
+      return property_graph_utils::VertexDataColumn<DATA_T, vid_t>(
           InnerVertices(label));
     } else {
-      return property_graph_utils::VertexDataColumn<DATA_T, vertex_t>(
+      return property_graph_utils::VertexDataColumn<DATA_T, vid_t>(
           InnerVertices(label), vertex_tables_[label]->column(prop)->chunk(0));
     }
   }


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------
Fix the type parameters inconsistency in arrow_fragment::vertex_data_column

<!-- Please give a short brief about these changes. -->


Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #426

