### PR TITLE
Refine the resolver context implementation, and refactor duplicated code

### DIFF
--- a/python/vineyard/contrib/ml/tensorflow.py
+++ b/python/vineyard/contrib/ml/tensorflow.py
@@ -16,20 +16,12 @@
 # limitations under the License.
 #
 
-from vineyard._C import ObjectMeta
-from vineyard.data.utils import from_json, to_json, build_numpy_buffer, normalize_dtype
-
-import pandas as pd
-import pyarrow as pa
-try:
-    from pandas.core.internals.blocks import BlockPlacement, NumpyBlock as Block
-except:
-    BlockPlacement = None
-    from pandas.core.internals.blocks import Block
-
-from pandas.core.internals.managers import BlockManager
 import numpy as np
 import tensorflow as tf
+
+from vineyard._C import ObjectMeta
+from vineyard.core.resolver import resolver_context, default_resolver_context
+from vineyard.data.utils import from_json, to_json, build_numpy_buffer, normalize_dtype
 
 
 def tf_tensor_builder(client, value, **kw):
@@ -54,7 +46,6 @@ def tf_tensor_builder(client, value, **kw):
 def tf_dataframe_builder(client, value, builder, **kw):
     meta = ObjectMeta()
     meta['typename'] = 'vineyard::DataFrame'
-    print(len(value))
     for feat, labels in value.take(1):
         cols = list(feat.keys())
     cols.append('target')
@@ -72,7 +63,6 @@ def tf_dataframe_builder(client, value, builder, **kw):
     meta['partition_index_row_'] = kw.get('partition_index', [0, 0])[0]
     meta['partition_index_column_'] = kw.get('partition_index', [0, 0])[1]
     meta['row_batch_index_'] = kw.get('row_batch_index', 0)
-    print(meta)
     return client.create_metadata(meta)
 
 
@@ -109,51 +99,31 @@ def tf_tensor_resolver(obj):
     return data
 
 
-def tf_dataframe_resolver(obj, resolver):
-    meta = obj.meta
-    columns = from_json(meta['columns_'])
-    if not columns:
-        return pd.DataFrame()
-    blocks = []
-    index_size = 0
-    for idx, name in enumerate(columns):
-        np_value = resolver.run(obj.member('__values_-value-%d' % idx))
-        index_size = len(np_value)
-        if BlockPlacement:
-            placement = BlockPlacement(slice(idx, idx + 1, 1))
-        else:
-            placement = slice(idx, idx + 1, 1)
-        values = np.expand_dims(np_value, 0)
-        blocks.append(Block(values, placement, ndim=2))
-    if 'index_' in meta:
-        index = resolver.run(obj.member('index_'))
-    else:
-        index = pd.RangeIndex(index_size)
-    df = pd.DataFrame(BlockManager(blocks, [pd.Index(columns), index]))
+def tf_dataframe_resolver(obj, **kw):
+    with resolver_context(base=default_resolver_context) as resolver:
+        df = resolver(obj, **kw)
     labels = df.pop('target')
     return tf.data.Dataset.from_tensor_slices((dict(df), labels))
 
 
-def tf_recordBatch_resolver(obj, resolver):
-    meta = obj.meta
-    schema = resolver.run(obj.member('schema_'))
-    columns = []
-    for idx in range(int(meta['__columns_-size'])):
-        columns.append(resolver.run(obj.member('__columns_-%d' % idx)))
-    arrow = pa.RecordBatch.from_arrays(columns, schema=schema).to_pandas()
-    labels = arrow.pop('target')
-    return tf.data.Dataset.from_tensor_slices((dict(arrow), labels))
+def tf_record_batch_resolver(obj, **kw):
+    with resolver_context(base=default_resolver_context) as resolver:
+        records = resolver(obj, **kw)
+    records = records.to_pandas()
+    labels = records.pop('target')
+    return tf.data.Dataset.from_tensor_slices((dict(records), labels))
 
 
 def tf_table_resolver(obj, resolver):
     meta = obj.meta
     batches = []
-    for idx in range(int(meta['__batches_-size'])):
-        batches.append(resolver.run(obj.member('__batches_-%d' % idx)))
-    tfData = batches[0]
+    with resolver_context(base=default_resolver_context) as resolver:
+        for idx in range(int(meta['__batches_-size'])):
+            batches.append(resolver(obj.member('__batches_-%d' % idx)))
+    tf_data = batches[0]
     for i in range(1, len(batches)):
-        tfData = tfData.concatenate(batches[i])
-    return tfData
+        tf_data = tf_data.concatenate(batches[i])
+    return tf_data
 
 
 def tf_global_tensor_resolver(obj, resolver, **kw):
@@ -164,10 +134,10 @@ def tf_global_tensor_resolver(obj, resolver, **kw):
     for i in range(partition_index):
         if meta[f'partition_{i}'].islocal:
             data.append(resolver.run(obj.member(f'partition_{i}')))
-    tfData = data[0]
+    tf_data = data[0]
     for i in range(1, len(data)):
-        tfData = tfData.concatenate(data[i])
-    return tfData
+        tf_data = tf_data.concatenate(data[i])
+    return tf_data
 
 
 def tf_global_dataframe_resolver(obj, resolver, **kw):
@@ -178,10 +148,10 @@ def tf_global_dataframe_resolver(obj, resolver, **kw):
     for i in range(partition_index):
         if meta[f'partition_{i}'].islocal:
             data.append(resolver.run(obj.member(f'partition_{i}')))
-    tfData = data[0]
+    tf_data = data[0]
     for i in range(1, len(data)):
-        tfData = tfData.concatenate(data[i])
-    return tfData
+        tf_data = tf_data.concatenate(data[i])
+    return tf_data
 
 
 def register_tf_types(builder_ctx, resolver_ctx):
@@ -191,7 +161,7 @@ def register_tf_types(builder_ctx, resolver_ctx):
     if resolver_ctx is not None:
         resolver_ctx.register('vineyard::Tensor', tf_tensor_resolver)
         resolver_ctx.register('vineyard::DataFrame', tf_dataframe_resolver)
-        resolver_ctx.register('vineyard::RecordBatch', tf_recordBatch_resolver)
+        resolver_ctx.register('vineyard::RecordBatch', tf_record_batch_resolver)
         resolver_ctx.register('vineyard::Table', tf_table_resolver)
         resolver_ctx.register('vineyard::GlobalTensor', tf_global_tensor_resolver)
         resolver_ctx.register('vineyard::GlobalDataFrame', tf_global_dataframe_resolver)

--- a/python/vineyard/contrib/ml/tensorflow.py
+++ b/python/vineyard/contrib/ml/tensorflow.py
@@ -117,9 +117,8 @@ def tf_record_batch_resolver(obj, **kw):
 def tf_table_resolver(obj, resolver):
     meta = obj.meta
     batches = []
-    with resolver_context(base=default_resolver_context) as resolver:
-        for idx in range(int(meta['__batches_-size'])):
-            batches.append(resolver(obj.member('__batches_-%d' % idx)))
+    for idx in range(int(meta['__batches_-size'])):
+        batches.append(resolver(obj.member('__batches_-%d' % idx)))
     tf_data = batches[0]
     for i in range(1, len(batches)):
         tf_data = tf_data.concatenate(batches[i])

--- a/python/vineyard/contrib/ml/xgboost.py
+++ b/python/vineyard/contrib/ml/xgboost.py
@@ -19,8 +19,7 @@
 import numpy as np
 import xgboost as xgb
 
-from vineyard.core.resolver import resolver_context
-from vineyard.data import tensor, dataframe, arrow
+from vineyard.core.resolver import resolver_context, default_resolver_context
 
 
 def xgb_builder(client, value, builder, **kw):
@@ -28,25 +27,27 @@ def xgb_builder(client, value, builder, **kw):
     pass
 
 
-def xgb_tensor_resolver(obj):
-    array = tensor.numpy_ndarray_resolver(obj)
+def xgb_tensor_resolver(obj, **kw):
+    with resolver_context(base=default_resolver_context) as resolver:
+        array = resolver(obj, **kw)
     return xgb.DMatrix(array)
 
 
-def xgb_dataframe_resolver(obj, resolver, **kw):
-    with resolver_context({'vineyard::Tensor': tensor.numpy_ndarray_resolver}) as ctx:
-        df = dataframe.pandas_dataframe_resolver(obj, ctx)
-        if 'label' in kw:
-            label = df.pop(kw['label'])
-            # data column can only be specified if label column is specified
-            if 'data' in kw:
-                df = np.stack(df[kw['data']].values)
-            return xgb.DMatrix(df, label)
-        return xgb.DMatrix(df)
+def xgb_dataframe_resolver(obj, **kw):
+    with resolver_context(base=default_resolver_context) as resolver:
+        df = resolver(obj, **kw)
+    if 'label' in kw:
+        label = df.pop(kw['label'])
+        # data column can only be specified if label column is specified
+        if 'data' in kw:
+            df = np.stack(df[kw['data']].values)
+        return xgb.DMatrix(df, label)
+    return xgb.DMatrix(df)
 
 
-def xgb_recordBatch_resolver(obj, resolver, **kw):
-    rb = arrow.record_batch_resolver(obj, resolver)
+def xgb_recordBatch_resolver(obj, **kw):
+    with resolver_context(base=default_resolver_context) as resolver:
+        rb = resolver(obj, **kw)
     # FIXME to_pandas is not zero_copy guaranteed
     df = rb.to_pandas()
     if 'label' in kw:
@@ -55,15 +56,16 @@ def xgb_recordBatch_resolver(obj, resolver, **kw):
     return xgb.DMatrix(df)
 
 
-def xgb_table_resolver(obj, resolver, **kw):
-    with resolver_context({'vineyard::RecordBatch': arrow.record_batch_resolver}) as ctx:
-        tb = arrow.table_resolver(obj, ctx)
-        # FIXME to_pandas is not zero_copy guaranteed
-        df = tb.to_pandas()
-        if 'label' in kw:
-            label = df.pop(kw['label'])
-            return xgb.DMatrix(df, label)
-        return xgb.DMatrix(df)
+def xgb_table_resolver(obj, **kw):
+    with resolver_context(base=default_resolver_context) as resolver:
+        tb = resolver(obj, **kw)
+
+    # FIXME to_pandas is not zero_copy guaranteed
+    df = tb.to_pandas()
+    if 'label' in kw:
+        label = df.pop(kw['label'])
+        return xgb.DMatrix(df, label)
+    return xgb.DMatrix(df)
 
 
 def register_xgb_types(builder_ctx, resolver_ctx):

--- a/python/vineyard/core/builder.py
+++ b/python/vineyard/core/builder.py
@@ -74,6 +74,9 @@ class BuilderContext():
                 return self.__factory[ty](client, value, **kw)
         raise RuntimeError('Unknown type to build as vineyard object')
 
+    def __call__(self, client, value, **kw):
+        return self.run(client, value, **kw)
+
     def extend(self, builders=None):
         builder = BuilderContext()
         builder.__factory = copy.copy(self.__factory)

--- a/python/vineyard/core/driver.py
+++ b/python/vineyard/core/driver.py
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-from collections import defaultdict
 import contextlib
+import copy
 import functools
 import threading
 
@@ -28,28 +28,35 @@ from .utils import find_most_precise_match
 
 class DriverContext():
     def __init__(self):
-        self.__factory = defaultdict(SortedDict)
+        self.__factory = SortedDict(dict)
 
     def __str__(self) -> str:
         return str(self.__factory)
 
     def register(self, typename_prefix, meth, func):
-        self.__factory[meth][typename_prefix] = func
+        if typename_prefix not in self.__factory:
+            self.__factory[typename_prefix] = dict()
+        self.__factory[typename_prefix][meth] = func
 
     def resolve(self, obj, typename):
-        for meth_name, methods in self.__factory.items():
-            prefix, method = find_most_precise_match(typename, methods)
-            if prefix is not None:
-                meth = functools.partial(method, obj)
+        prefix, methods = find_most_precise_match(typename, self.__factory)
+        if prefix:
+            for meth, func in methods.items():
                 # if shouldn't failed, since it has already been wrapped in during resolving
-                setattr(obj, meth_name, meth)
+                setattr(obj, meth, functools.partial(func, obj))
         return obj
+
+    def __call__(self, obj, typename):
+        return self.resolve(obj, typename)
 
     def extend(self, drivers=None):
         driver = DriverContext()
-        driver.__factory.update(((k, v.copy()) for k, v in self.__factory.items()))
+        driver.__factory.update(((k, copy.copy(v)) for k, v in self.__factory.items()))
         if drivers:
-            driver.__factory.update(drivers)
+            for ty, methods in drivers.items():
+                if ty not in self.__factory:
+                    driver.__factory[ty] = dict()
+                driver.__factory[ty].update(methods)
         return driver
 
 
@@ -88,13 +95,11 @@ def driver_context(drivers=None, base=None):
         _driver_context_local.default_driver = current_driver
 
 
-def repartition(g):
-    raise NotImplementedError('No repartition method implementation yet')
-
-
 def register_builtin_drivers(ctx):
     assert isinstance(ctx, DriverContext)
-    ctx.register('vineyard::Graph', 'repartition', repartition)
+
+    # TODO
+    # there's no builtin drivers yet.
 
 
 def registerize(func):

--- a/python/vineyard/core/resolver.py
+++ b/python/vineyard/core/resolver.py
@@ -43,9 +43,14 @@ class ResolverContext():
         vineyard_client = kw.pop('__vineyard_client', None)
         if prefix:
             resolver_func_sig = inspect.getfullargspec(resolver)
-            if 'resolver' in resolver_func_sig.args or resolver_func_sig.varkw is not None:
-                kw['resolver'] = self
-            value = resolver(obj, **kw)
+            if resolver_func_sig.varkw is not None:
+                value = resolver(obj, resolver=self, **kw)
+            else:
+                # don't pass the `**kw`.
+                if 'resolver' in resolver_func_sig.args:
+                    value = resolver(obj, resolver=self)
+                else:
+                    value = resolver(obj)
             if value is None:
                 # if the obj has been resolved by pybind types, and there's no proper resolver, it
                 # shouldn't be an error

--- a/python/vineyard/core/utils.py
+++ b/python/vineyard/core/utils.py
@@ -29,9 +29,10 @@ def find_most_precise_match(typename, candidates):
             List of candidates to match with, the first element is prefix, and the second
             entry is the candidate item, e.g., resolver or driver method.
     '''
-    for prefix, candidate in candidates.items():
-        if typename.startswith(prefix):
-            return prefix, candidate
+    if candidates:
+        for prefix, candidate in candidates.items():
+            if typename.startswith(prefix):
+                return prefix, candidate
     return None, None
 
 


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

This pull request fixes #423, by patching `__vineyard_ref` in the resolver, and add a `__call__` method for builder/resolver/driver context.

This pull request also reduces the code duplication in the ML integration to make the code more concise.

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #423.

