### PR TITLE
Use unique_ptr to allow better flexibility for FFI interfaces.

### DIFF
--- a/modules/basic/ds/dataframe.h
+++ b/modules/basic/ds/dataframe.h
@@ -126,9 +126,9 @@ class GlobalDataFrameBaseBuilder;
  */
 class GlobalDataFrame : public Registered<GlobalDataFrame>, GlobalObject {
  public:
-  static std::shared_ptr<Object> Create() __attribute__((used)) {
+  static std::unique_ptr<Object> Create() __attribute__((used)) {
     return std::static_pointer_cast<Object>(
-        std::make_shared<GlobalDataFrame>());
+        std::unique_ptr<GlobalDataFrame>{new GlobalDataFrame()});
   }
 
   void Construct(const ObjectMeta& meta) override;

--- a/modules/basic/ds/tensor.h
+++ b/modules/basic/ds/tensor.h
@@ -162,8 +162,9 @@ class GlobalTensorBaseBuilder;
  */
 class GlobalTensor : public Registered<GlobalTensor>, GlobalObject {
  public:
-  static std::shared_ptr<Object> Create() __attribute__((used)) {
-    return std::static_pointer_cast<Object>(std::make_shared<GlobalTensor>());
+  static std::unique_ptr<Object> Create() __attribute__((used)) {
+    return std::static_pointer_cast<Object>(
+        std::unique_ptr<GlobalTensor>{new GlobalTensor()});
   }
 
   void Construct(const ObjectMeta& meta) override;

--- a/modules/basic/stream/parallel_stream.h
+++ b/modules/basic/stream/parallel_stream.h
@@ -28,8 +28,9 @@ class ParallelStreamBuilder;
 
 class ParallelStream : public Registered<ParallelStream>, GlobalObject {
  public:
-  static std::shared_ptr<Object> Create() __attribute__((used)) {
-    return std::static_pointer_cast<Object>(std::make_shared<ParallelStream>());
+  static std::unique_ptr<Object> Create() __attribute__((used)) {
+    return std::static_pointer_cast<Object>(
+        std::unique_ptr<ParallelStream>{new ParallelStream()});
   }
 
   void Construct(const ObjectMeta& meta) override {

--- a/python/vineyard/core/codegen.py
+++ b/python/vineyard/core/codegen.py
@@ -323,15 +323,19 @@ def generate_template_type(name, ts):
 
 create_tpl = '''
 {class_header}
-std::shared_ptr<Object> {class_name_elaborated}::Create() {{
-    return std::static_pointer_cast<Object>(std::make_shared<{class_name_elaborated}>());
+std::unique_ptr<Object> {class_name_elaborated}::Create() {{
+    return std::static_pointer_cast<Object>(
+        std::unique_ptr<{class_name_elaborated}>{{
+            new {class_name_elaborated}()}});
 }}
 '''
 
 create_meth_tpl = '''
   public:
-    static std::shared_ptr<Object> Create() __attribute__((used)) {{
-        return std::static_pointer_cast<Object>(std::make_shared<{class_name_elaborated}>());
+    static std::unique_ptr<Object> Create() __attribute__((used)) {{
+        return std::static_pointer_cast<Object>(
+            std::unique_ptr<{class_name_elaborated}>{{
+                new {class_name_elaborated}()}});
     }}
 '''
 

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -227,7 +227,7 @@ std::shared_ptr<Object> Client::GetObject(const ObjectID id) {
   VINEYARD_ASSERT(!meta.MetaData().empty());
   auto object = ObjectFactory::Create(meta.GetTypeName());
   if (object == nullptr) {
-    object = std::shared_ptr<Object>(new Object());
+    object = std::unique_ptr<Object>(new Object());
   }
   object->Construct(meta);
   return object;
@@ -239,7 +239,7 @@ Status Client::GetObject(const ObjectID id, std::shared_ptr<Object>& object) {
   RETURN_ON_ASSERT(!meta.MetaData().empty());
   object = ObjectFactory::Create(meta.GetTypeName());
   if (object == nullptr) {
-    object = std::shared_ptr<Object>(new Object());
+    object = std::unique_ptr<Object>(new Object());
   }
   object->Construct(meta);
   return Status::OK();
@@ -259,10 +259,10 @@ std::vector<std::shared_ptr<Object>> Client::GetObjects(
   for (auto const& meta : metas) {
     auto object = ObjectFactory::Create(meta.GetTypeName());
     if (object == nullptr) {
-      object = std::shared_ptr<Object>(new Object());
+      object = std::unique_ptr<Object>(new Object());
     }
     object->Construct(meta);
-    objects.emplace_back(object);
+    objects.emplace_back(std::shared_ptr<Object>(object.release()));
   }
   return objects;
 }
@@ -301,10 +301,10 @@ std::vector<std::shared_ptr<Object>> Client::ListObjects(
 
     auto object = ObjectFactory::Create(meta.GetTypeName());
     if (object == nullptr) {
-      object = std::shared_ptr<Object>(new Object());
+      object = std::unique_ptr<Object>(new Object());
     }
     object->Construct(meta);
-    objects.emplace_back(object);
+    objects.emplace_back(std::shared_ptr<Object>(object.release()));
   }
   return objects;
 }

--- a/src/client/ds/blob.h
+++ b/src/client/ds/blob.h
@@ -80,8 +80,8 @@ class Blob : public Registered<Blob> {
    */
   const std::shared_ptr<arrow::Buffer>& Buffer() const;
 
-  static std::shared_ptr<Object> Create() __attribute__((used)) {
-    return std::static_pointer_cast<Object>(std::shared_ptr<Blob>{new Blob()});
+  static std::unique_ptr<Object> Create() __attribute__((used)) {
+    return std::static_pointer_cast<Object>(std::unique_ptr<Blob>{new Blob()});
   }
 
   /**

--- a/src/client/ds/object_factory.cc
+++ b/src/client/ds/object_factory.cc
@@ -16,10 +16,11 @@ limitations under the License.
 #include "client/ds/object_factory.h"
 
 #include "client/ds/i_object.h"
+#include "client/ds/object_meta.h"
 
 namespace vineyard {
 
-std::shared_ptr<Object> ObjectFactory::Create(std::string const& type_name) {
+std::unique_ptr<Object> ObjectFactory::Create(std::string const& type_name) {
   auto& known_types = getKnownTypes();
   auto creator = known_types.find(type_name);
   if (creator == known_types.end()) {
@@ -28,6 +29,21 @@ std::shared_ptr<Object> ObjectFactory::Create(std::string const& type_name) {
     return nullptr;
   } else {
     return (creator->second)();
+  }
+}
+
+std::unique_ptr<Object> ObjectFactory::Create(std::string const& type_name,
+                                              ObjectMeta const& metadata) {
+  auto& known_types = getKnownTypes();
+  auto creator = known_types.find(type_name);
+  if (creator == known_types.end()) {
+    VLOG(11) << "Failed to create an instance due to the unknown typename: "
+             << type_name;
+    return nullptr;
+  } else {
+    auto target = (creator->second)();
+    target->Construct(metadata);
+    return target;
   }
 }
 

--- a/src/client/ds/object_factory.h
+++ b/src/client/ds/object_factory.h
@@ -27,6 +27,7 @@ namespace vineyard {
 
 class Client;
 class Object;
+class ObjectMeta;
 
 /**
  * @brief FORCE_INSTANTIATE is a tool to guarantee the argument not be optimized
@@ -42,7 +43,7 @@ inline void FORCE_INSTANTIATE(T) {}
  */
 class __attribute__((visibility("default"))) ObjectFactory {
  public:
-  using object_initializer_t = std::shared_ptr<Object> (*)();
+  using object_initializer_t = std::unique_ptr<Object> (*)();
 
   /**
    * @brief Register tht type `T` to the factory. A registrable type must have
@@ -66,8 +67,18 @@ class __attribute__((visibility("default"))) ObjectFactory {
    *
    * @param type_name The type to be instantiated.
    */
-  static std::shared_ptr<Object> __attribute__((visibility("default")))
+  static std::unique_ptr<Object> __attribute__((visibility("default")))
   Create(std::string const& type_name);
+
+  /**
+   * @brief Initialize an instance by looking up the `type_name` in the factory,
+   * and construct the object using the metadata.
+   *
+   * @param type_name The type to be instantiated.
+   * @param metadata The metadata used to construct the object.
+   */
+  static std::unique_ptr<Object> __attribute__((visibility("default")))
+  Create(std::string const& type_name, ObjectMeta const& metadata);
 
   /**
    * @brief Expose the internal registered types.
@@ -85,5 +96,29 @@ class __attribute__((visibility("default"))) ObjectFactory {
 };
 
 }  // namespace vineyard
+
+namespace std {
+
+// std::unique_ptr casts:
+template <class T, class U>
+inline unique_ptr<T> static_pointer_cast(unique_ptr<U>&& r) noexcept {
+  return std::unique_ptr<T>(static_cast<T*>(r.release()));
+}
+
+template <class T, class U>
+inline unique_ptr<T> dynamic_pointer_cast(unique_ptr<U>&& r) noexcept {
+  return std::unique_ptr<T>(dynamic_cast<T*>(r.release()));
+}
+
+template <class T, class U>
+inline unique_ptr<T> const_pointer_cast(unique_ptr<U>&& r) noexcept {
+  return std::unique_ptr<T>(const_cast<T*>(r.release()));
+}
+
+template <class T, class U>
+inline unique_ptr<T> reinterpert_pointer_cast(unique_ptr<U>&& r) noexcept {
+  return std::unique_ptr<T>(reinterpret_cast<T*>(r.release()));
+}
+}  // namespace std
 
 #endif  // SRC_CLIENT_DS_OBJECT_FACTORY_H_

--- a/src/client/ds/object_meta.cc
+++ b/src/client/ds/object_meta.cc
@@ -141,7 +141,7 @@ std::shared_ptr<Object> ObjectMeta::GetMember(const std::string& name) const {
   ObjectMeta meta = this->GetMemberMeta(name);
   auto object = ObjectFactory::Create(meta.GetTypeName());
   if (object == nullptr) {
-    object = std::shared_ptr<Object>(new Object());
+    object = std::unique_ptr<Object>(new Object());
   }
   object->Construct(meta);
   return object;

--- a/src/client/rpc_client.cc
+++ b/src/client/rpc_client.cc
@@ -121,7 +121,7 @@ std::shared_ptr<Object> RPCClient::GetObject(const ObjectID id) {
   VINEYARD_ASSERT(!meta.MetaData().empty());
   auto object = ObjectFactory::Create(meta.GetTypeName());
   if (object == nullptr) {
-    object = std::shared_ptr<Object>(new Object());
+    object = std::unique_ptr<Object>(new Object());
   }
   object->Construct(meta);
   return object;
@@ -134,7 +134,7 @@ Status RPCClient::GetObject(const ObjectID id,
   RETURN_ON_ASSERT(!meta.MetaData().empty());
   object = ObjectFactory::Create(meta.GetTypeName());
   if (object == nullptr) {
-    object = std::shared_ptr<Object>(new Object());
+    object = std::unique_ptr<Object>(new Object());
   }
   object->Construct(meta);
   return Status::OK();
@@ -151,10 +151,10 @@ std::vector<std::shared_ptr<Object>> RPCClient::GetObjects(
   for (auto const& meta : metas) {
     auto object = ObjectFactory::Create(meta.GetTypeName());
     if (object == nullptr) {
-      object = std::shared_ptr<Object>(new Object());
+      object = std::unique_ptr<Object>(new Object());
     }
     object->Construct(meta);
-    objects.emplace_back(object);
+    objects.emplace_back(std::shared_ptr<Object>(object.release()));
   }
   return objects;
 }
@@ -172,10 +172,10 @@ std::vector<std::shared_ptr<Object>> RPCClient::ListObjects(
     meta.SetMetaData(this, kv.second);
     auto object = ObjectFactory::Create(meta.GetTypeName());
     if (object == nullptr) {
-      object = std::shared_ptr<Object>(new Object());
+      object = std::unique_ptr<Object>(new Object());
     }
     object->Construct(meta);
-    objects.emplace_back(object);
+    objects.emplace_back(std::shared_ptr<Object>(object.release()));
   }
   return objects;
 }


### PR DESCRIPTION


What do these changes do?
-------------------------

The `std::shared_ptr` doesn't have a `release()` method to drop the lifetime
management, and is not friendly for Java FFI, etc.

The change is on internal interfaces and shouldn't break any public APIs.

Related issue number
--------------------

Related to #171.

