### PR TITLE
Catch JSON error as well when reading the RPC request from client.

### DIFF
--- a/src/server/async/socket_server.cc
+++ b/src/server/async/socket_server.cc
@@ -105,16 +105,46 @@ void SocketConnection::doReadBody() {
                    });
 }
 
+#ifndef __REPORT_JSON_ERROR
+#ifndef NDEBUG
+#define __REPORT_JSON_ERROR(err, data) \
+  LOG(ERROR) << "json: " << err.what() << " when parsing" << data
+#else
+#define __REPORT_JSON_ERROR(err, data) LOG(ERROR) << "json: " << err.what()
+#endif  // NDEBUG
+#endif  // __REPORT_JSON_ERROR
+
+#ifndef TRY_READ_FROM_JSON
+#define TRY_READ_FROM_JSON(read_action, data)                  \
+  try {                                                        \
+    read_action;                                               \
+  } catch (std::out_of_range const& err) {                     \
+    __REPORT_JSON_ERROR(err, data);                            \
+    std::string message_out;                                   \
+    WriteErrorReply(Status::Invalid(err.what()), message_out); \
+    this->doWrite(message_out);                                \
+    return false;                                              \
+  } catch (json::exception const& err) {                       \
+    __REPORT_JSON_ERROR(err, data);                            \
+    std::string message_out;                                   \
+    WriteErrorReply(Status::Invalid(err.what()), message_out); \
+    this->doWrite(message_out);                                \
+    return false;                                              \
+  }
+
+#endif  // TRY_READ_FROM_JSON
+
 #ifndef TRY_READ_REQUEST
-#define TRY_READ_REQUEST(operation)                    \
-  do {                                                 \
-    auto read_status = (operation);                    \
-    if (!read_status.ok()) {                           \
-      std::string error_message_out;                   \
-      WriteErrorReply(read_status, error_message_out); \
-      self->doWrite(error_message_out);                \
-      return false;                                    \
-    }                                                  \
+#define TRY_READ_REQUEST(operation, data, ...)                             \
+  do {                                                                     \
+    Status read_status;                                                    \
+    TRY_READ_FROM_JSON(read_status = operation(data, ##__VA_ARGS__), data) \
+    if (!read_status.ok()) {                                               \
+      std::string error_message_out;                                       \
+      WriteErrorReply(read_status, error_message_out);                     \
+      self->doWrite(error_message_out);                                    \
+      return false;                                                        \
+    }                                                                      \
   } while (0)
 #endif  // TRY_READ_REQUEST
 
@@ -138,29 +168,7 @@ bool SocketConnection::processMessage(const std::string& message_in) {
   std::istringstream is(message_in);
 
   // DON'T let vineyardd crash when the client is malicious.
-  try {
-    root = json::parse(message_in);
-  } catch (std::out_of_range const& err) {
-#ifndef NDEBUG
-    LOG(ERROR) << "json: " << err.what() << " when parsing" << message_in;
-#else
-    LOG(ERROR) << "json: " << err.what();
-#endif
-    std::string message_out;
-    WriteErrorReply(Status::Invalid(err.what()), message_out);
-    this->doWrite(message_out);
-    return false;
-  } catch (json::exception const& err) {
-#ifndef NDEBUG
-    LOG(ERROR) << "json: " << err.what() << " when parsing" << message_in;
-#else
-    LOG(ERROR) << "json: " << err.what();
-#endif
-    std::string message_out;
-    WriteErrorReply(Status::Invalid(err.what()), message_out);
-    this->doWrite(message_out);
-    return false;
-  }
+  TRY_READ_FROM_JSON(root = json::parse(message_in), message_in);
 
   std::string const& type = root["type"].get_ref<std::string const&>();
   CommandType cmd = ParseCommandType(type);
@@ -262,7 +270,7 @@ bool SocketConnection::processMessage(const std::string& message_in) {
 bool SocketConnection::doRegister(const json& root) {
   auto self(shared_from_this());
   std::string client_version, message_out;
-  TRY_READ_REQUEST(ReadRegisterRequest(root, client_version));
+  TRY_READ_REQUEST(ReadRegisterRequest, root, client_version);
   WriteRegisterReply(server_ptr_->IPCSocket(), server_ptr_->RPCEndpoint(),
                      server_ptr_->instance_id(), message_out);
   doWrite(message_out);
@@ -275,7 +283,7 @@ bool SocketConnection::doGetBuffers(const json& root) {
   std::vector<std::shared_ptr<Payload>> objects;
   std::string message_out;
 
-  TRY_READ_REQUEST(ReadGetBuffersRequest(root, ids));
+  TRY_READ_REQUEST(ReadGetBuffersRequest, root, ids);
   RESPONSE_ON_ERROR(server_ptr_->GetBulkStore()->Get(ids, objects));
   WriteGetBuffersReply(objects, message_out);
 
@@ -333,7 +341,7 @@ bool SocketConnection::doGetRemoteBuffers(const json& root) {
   std::vector<std::shared_ptr<Payload>> objects;
   std::string message_out;
 
-  TRY_READ_REQUEST(ReadGetBuffersRequest(root, ids));
+  TRY_READ_REQUEST(ReadGetBuffersRequest, root, ids);
   RESPONSE_ON_ERROR(server_ptr_->GetBulkStore()->Get(ids, objects));
   WriteGetBuffersReply(objects, message_out);
 
@@ -357,7 +365,7 @@ bool SocketConnection::doCreateBuffer(const json& root) {
   std::shared_ptr<Payload> object;
   std::string message_out;
 
-  TRY_READ_REQUEST(ReadCreateBufferRequest(root, size));
+  TRY_READ_REQUEST(ReadCreateBufferRequest, root, size);
   ObjectID object_id;
   RESPONSE_ON_ERROR(
       server_ptr_->GetBulkStore()->Create(size, object_id, object));
@@ -381,7 +389,7 @@ bool SocketConnection::doCreateRemoteBuffer(const json& root) {
   size_t size;
   std::shared_ptr<Payload> object;
 
-  TRY_READ_REQUEST(ReadCreateBufferRequest(root, size));
+  TRY_READ_REQUEST(ReadCreateBufferRequest, root, size);
   ObjectID object_id;
   RESPONSE_ON_ERROR(
       server_ptr_->GetBulkStore()->Create(size, object_id, object));
@@ -412,7 +420,7 @@ bool SocketConnection::doCreateRemoteBuffer(const json& root) {
 bool SocketConnection::doDropBuffer(const json& root) {
   auto self(shared_from_this());
   ObjectID object_id = InvalidObjectID();
-  TRY_READ_REQUEST(ReadDropBufferRequest(root, object_id));
+  TRY_READ_REQUEST(ReadDropBufferRequest, root, object_id);
   auto status = server_ptr_->GetBulkStore()->Delete(object_id);
   std::string message_out;
   if (status.ok()) {
@@ -428,7 +436,7 @@ bool SocketConnection::doGetData(const json& root) {
   auto self(shared_from_this());
   std::vector<ObjectID> ids;
   bool sync_remote = false, wait = false;
-  TRY_READ_REQUEST(ReadGetDataRequest(root, ids, sync_remote, wait));
+  TRY_READ_REQUEST(ReadGetDataRequest, root, ids, sync_remote, wait);
   json tree;
   RESPONSE_ON_ERROR(server_ptr_->GetData(
       ids, sync_remote, wait, [self]() { return self->running_.load(); },
@@ -451,7 +459,7 @@ bool SocketConnection::doListData(const json& root) {
   std::string pattern;
   bool regex;
   size_t limit;
-  TRY_READ_REQUEST(ReadListDataRequest(root, pattern, regex, limit));
+  TRY_READ_REQUEST(ReadListDataRequest, root, pattern, regex, limit);
   RESPONSE_ON_ERROR(server_ptr_->ListData(
       pattern, regex, limit, [self](const Status& status, const json& tree) {
         std::string message_out;
@@ -470,7 +478,7 @@ bool SocketConnection::doListData(const json& root) {
 bool SocketConnection::doCreateData(const json& root) {
   auto self(shared_from_this());
   json tree;
-  TRY_READ_REQUEST(ReadCreateDataRequest(root, tree));
+  TRY_READ_REQUEST(ReadCreateDataRequest, root, tree);
   RESPONSE_ON_ERROR(server_ptr_->CreateData(
       tree, [self](const Status& status, const ObjectID id,
                    const Signature signature, const InstanceID instance_id) {
@@ -490,7 +498,7 @@ bool SocketConnection::doCreateData(const json& root) {
 bool SocketConnection::doPersist(const json& root) {
   auto self(shared_from_this());
   ObjectID id;
-  TRY_READ_REQUEST(ReadPersistRequest(root, id));
+  TRY_READ_REQUEST(ReadPersistRequest, root, id);
   RESPONSE_ON_ERROR(server_ptr_->Persist(id, [self](const Status& status) {
     std::string message_out;
     if (status.ok()) {
@@ -508,7 +516,7 @@ bool SocketConnection::doPersist(const json& root) {
 bool SocketConnection::doIfPersist(const json& root) {
   auto self(shared_from_this());
   ObjectID id;
-  TRY_READ_REQUEST(ReadIfPersistRequest(root, id));
+  TRY_READ_REQUEST(ReadIfPersistRequest, root, id);
   RESPONSE_ON_ERROR(server_ptr_->IfPersist(
       id, [self](const Status& status, bool const persist) {
         std::string message_out;
@@ -527,7 +535,7 @@ bool SocketConnection::doIfPersist(const json& root) {
 bool SocketConnection::doExists(const json& root) {
   auto self(shared_from_this());
   ObjectID id;
-  TRY_READ_REQUEST(ReadExistsRequest(root, id));
+  TRY_READ_REQUEST(ReadExistsRequest, root, id);
   RESPONSE_ON_ERROR(
       server_ptr_->Exists(id, [self](const Status& status, bool const exists) {
         std::string message_out;
@@ -546,7 +554,7 @@ bool SocketConnection::doExists(const json& root) {
 bool SocketConnection::doShallowCopy(const json& root) {
   auto self(shared_from_this());
   ObjectID id;
-  TRY_READ_REQUEST(ReadShallowCopyRequest(root, id));
+  TRY_READ_REQUEST(ReadShallowCopyRequest, root, id);
   RESPONSE_ON_ERROR(server_ptr_->ShallowCopy(
       id, [self](const Status& status, const ObjectID target) {
         std::string message_out;
@@ -566,7 +574,7 @@ bool SocketConnection::doDelData(const json& root) {
   auto self(shared_from_this());
   std::vector<ObjectID> ids;
   bool force, deep, fastpath;
-  TRY_READ_REQUEST(ReadDelDataRequest(root, ids, force, deep, fastpath));
+  TRY_READ_REQUEST(ReadDelDataRequest, root, ids, force, deep, fastpath);
   RESPONSE_ON_ERROR(server_ptr_->DelData(
       ids, force, deep, fastpath, [self](const Status& status) {
         std::string message_out;
@@ -585,7 +593,7 @@ bool SocketConnection::doDelData(const json& root) {
 bool SocketConnection::doCreateStream(const json& root) {
   auto self(shared_from_this());
   ObjectID stream_id;
-  TRY_READ_REQUEST(ReadCreateStreamRequest(root, stream_id));
+  TRY_READ_REQUEST(ReadCreateStreamRequest, root, stream_id);
   auto status = server_ptr_->GetStreamStore()->Create(stream_id);
   std::string message_out;
   if (status.ok()) {
@@ -602,7 +610,7 @@ bool SocketConnection::doOpenStream(const json& root) {
   auto self(shared_from_this());
   ObjectID stream_id;
   int64_t mode;
-  TRY_READ_REQUEST(ReadOpenStreamRequest(root, stream_id, mode));
+  TRY_READ_REQUEST(ReadOpenStreamRequest, root, stream_id, mode);
   auto status = server_ptr_->GetStreamStore()->Open(stream_id, mode);
   std::string message_out;
   if (status.ok()) {
@@ -619,7 +627,7 @@ bool SocketConnection::doGetNextStreamChunk(const json& root) {
   auto self(shared_from_this());
   ObjectID stream_id;
   size_t size;
-  TRY_READ_REQUEST(ReadGetNextStreamChunkRequest(root, stream_id, size));
+  TRY_READ_REQUEST(ReadGetNextStreamChunkRequest, root, stream_id, size);
   RESPONSE_ON_ERROR(server_ptr_->GetStreamStore()->Get(
       stream_id, size, [self](const Status& status, const ObjectID chunk) {
         std::string message_out;
@@ -652,7 +660,7 @@ bool SocketConnection::doGetNextStreamChunk(const json& root) {
 bool SocketConnection::doPullNextStreamChunk(const json& root) {
   auto self(shared_from_this());
   ObjectID stream_id;
-  TRY_READ_REQUEST(ReadPullNextStreamChunkRequest(root, stream_id));
+  TRY_READ_REQUEST(ReadPullNextStreamChunkRequest, root, stream_id);
   this->associated_streams_.emplace(stream_id);
   RESPONSE_ON_ERROR(server_ptr_->GetStreamStore()->Pull(
       stream_id, [self](const Status& status, const ObjectID chunk) {
@@ -687,7 +695,7 @@ bool SocketConnection::doStopStream(const json& root) {
   auto self(shared_from_this());
   ObjectID stream_id;
   bool failed;
-  TRY_READ_REQUEST(ReadStopStreamRequest(root, stream_id, failed));
+  TRY_READ_REQUEST(ReadStopStreamRequest, root, stream_id, failed);
   // NB: don't erase the metadata from meta_service, since there's may
   // reader listen on this stream.
   RESPONSE_ON_ERROR(server_ptr_->GetStreamStore()->Stop(stream_id, failed));
@@ -701,7 +709,7 @@ bool SocketConnection::doPutName(const json& root) {
   auto self(shared_from_this());
   ObjectID object_id;
   std::string name;
-  TRY_READ_REQUEST(ReadPutNameRequest(root, object_id, name));
+  TRY_READ_REQUEST(ReadPutNameRequest, root, object_id, name);
   RESPONSE_ON_ERROR(
       server_ptr_->PutName(object_id, name, [self](const Status& status) {
         std::string message_out;
@@ -721,7 +729,7 @@ bool SocketConnection::doGetName(const json& root) {
   auto self(shared_from_this());
   std::string name;
   bool wait;
-  TRY_READ_REQUEST(ReadGetNameRequest(root, name, wait));
+  TRY_READ_REQUEST(ReadGetNameRequest, root, name, wait);
   RESPONSE_ON_ERROR(server_ptr_->GetName(
       name, wait, [self]() { return self->running_.load(); },
       [self](const Status& status, const ObjectID& object_id) {
@@ -741,7 +749,7 @@ bool SocketConnection::doGetName(const json& root) {
 bool SocketConnection::doDropName(const json& root) {
   auto self(shared_from_this());
   std::string name;
-  TRY_READ_REQUEST(ReadDropNameRequest(root, name));
+  TRY_READ_REQUEST(ReadDropNameRequest, root, name);
   RESPONSE_ON_ERROR(server_ptr_->DropName(name, [self](const Status& status) {
     std::string message_out;
     LOG(INFO) << "drop name callback: " << status;
@@ -763,8 +771,8 @@ bool SocketConnection::doMigrateObject(const json& root) {
   bool local;
   bool is_stream;
   std::string peer, peer_rpc_endpoint;
-  TRY_READ_REQUEST(ReadMigrateObjectRequest(root, object_id, local, is_stream,
-                                            peer, peer_rpc_endpoint));
+  TRY_READ_REQUEST(ReadMigrateObjectRequest, root, object_id, local, is_stream,
+                   peer, peer_rpc_endpoint);
   if (is_stream) {
     RESPONSE_ON_ERROR(server_ptr_->MigrateStream(
         object_id, local, peer, peer_rpc_endpoint,
@@ -800,7 +808,7 @@ bool SocketConnection::doMigrateObject(const json& root) {
 
 bool SocketConnection::doClusterMeta(const json& root) {
   auto self(shared_from_this());
-  TRY_READ_REQUEST(ReadClusterMetaRequest(root));
+  TRY_READ_REQUEST(ReadClusterMetaRequest, root);
   RESPONSE_ON_ERROR(
       server_ptr_->ClusterInfo([self](const Status& status, const json& tree) {
         std::string message_out;
@@ -818,7 +826,7 @@ bool SocketConnection::doClusterMeta(const json& root) {
 
 bool SocketConnection::doInstanceStatus(const json& root) {
   auto self(shared_from_this());
-  TRY_READ_REQUEST(ReadInstanceStatusRequest(root));
+  TRY_READ_REQUEST(ReadInstanceStatusRequest, root);
   RESPONSE_ON_ERROR(server_ptr_->InstanceStatus(
       [self](const Status& status, const json& tree) {
         std::string message_out;
@@ -839,7 +847,7 @@ bool SocketConnection::doMakeArena(const json& root) {
   size_t size;
   std::string message_out;
 
-  TRY_READ_REQUEST(ReadMakeArenaRequest(root, size));
+  TRY_READ_REQUEST(ReadMakeArenaRequest, root, size);
   if (size == std::numeric_limits<size_t>::max()) {
     size = server_ptr_->GetBulkStore()->FootprintLimit();
   }
@@ -865,7 +873,7 @@ bool SocketConnection::doFinalizeArena(const json& root) {
   std::vector<size_t> offsets, sizes;
   std::string message_out;
 
-  TRY_READ_REQUEST(ReadFinalizeArenaRequest(root, fd, offsets, sizes));
+  TRY_READ_REQUEST(ReadFinalizeArenaRequest, root, fd, offsets, sizes);
   RESPONSE_ON_ERROR(
       server_ptr_->GetBulkStore()->FinalizeArena(fd, offsets, sizes));
   WriteFinalizeArenaReply(message_out);


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

The client my given invalid json, which, yeilds the "invalid" error status.
The input from clients could be invalid "json" object as well, which leads
to JSON exception finally and crash the server.

This pull request enhances such check to make sure vineyard not crash.


Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

N/A
