### PR TITLE
Ensure `mmap` in the same order with send_fd in server.

### DIFF
--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -432,7 +432,7 @@ Status Client::GetBufferSizes(const std::set<ObjectID>& ids,
   std::vector<Payload> payloads;
   RETURN_ON_ERROR(ReadGetBuffersReply(message_in, payloads));
   for (auto const& item : payloads) {
-    uint8_t *shared = nullptr;
+    uint8_t* shared = nullptr;
     if (item.data_size > 0) {
       VINEYARD_CHECK_OK(
           mmapToClient(item.store_fd, item.map_size, true, true, &shared));

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -432,6 +432,11 @@ Status Client::GetBufferSizes(const std::set<ObjectID>& ids,
   std::vector<Payload> payloads;
   RETURN_ON_ERROR(ReadGetBuffersReply(message_in, payloads));
   for (auto const& item : payloads) {
+    uint8_t *shared = nullptr;
+    if (item.data_size > 0) {
+      VINEYARD_CHECK_OK(
+          mmapToClient(item.store_fd, item.map_size, true, true, &shared));
+    }
     sizes.emplace(item.object_id, item.data_size);
   }
   return Status::OK();

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -180,13 +180,13 @@ Status Client::GetNextStreamChunk(ObjectID const id, size_t const size,
   RETURN_ON_ERROR(ReadGetNextStreamChunkReply(message_in, object));
   RETURN_ON_ASSERT(size == static_cast<size_t>(object.data_size),
                    "The size of returned chunk doesn't match");
-  uint8_t* mmapped_ptr = nullptr;
+  uint8_t *mmapped_ptr = nullptr, *dist = nullptr;
   if (object.data_size > 0) {
     RETURN_ON_ERROR(mmapToClient(object.store_fd, object.map_size, false, true,
                                  &mmapped_ptr));
+    dist = mmapped_ptr + object.data_offset;
   }
-  blob.reset(new arrow::MutableBuffer(mmapped_ptr + object.data_offset,
-                                      object.data_size));
+  blob.reset(new arrow::MutableBuffer(dist, object.data_size));
   return Status::OK();
 }
 
@@ -200,13 +200,13 @@ Status Client::PullNextStreamChunk(ObjectID const id,
   RETURN_ON_ERROR(doRead(message_in));
   Payload object;
   RETURN_ON_ERROR(ReadPullNextStreamChunkReply(message_in, object));
-  uint8_t* mmapped_ptr = nullptr;
+  uint8_t *mmapped_ptr = nullptr, *dist = nullptr;
   if (object.data_size > 0) {
     RETURN_ON_ERROR(mmapToClient(object.store_fd, object.map_size, true, true,
                                  &mmapped_ptr));
+    dist = mmapped_ptr + object.data_offset;
   }
-  blob.reset(
-      new arrow::Buffer(mmapped_ptr + object.data_offset, object.data_size));
+  blob.reset(new arrow::Buffer(dist, object.data_size));
   return Status::OK();
 }
 
@@ -368,13 +368,13 @@ Status Client::CreateBuffer(const size_t size, ObjectID& id, Payload& payload,
   RETURN_ON_ERROR(ReadCreateBufferReply(message_in, id, payload));
   RETURN_ON_ASSERT(static_cast<size_t>(payload.data_size) == size);
 
-  uint8_t* shared = nullptr;
+  uint8_t *shared = nullptr, *dist = nullptr;
   if (payload.data_size > 0) {
     RETURN_ON_ERROR(
         mmapToClient(payload.store_fd, payload.map_size, false, true, &shared));
+    dist = shared + payload.data_offset;
   }
-  buffer = std::make_shared<arrow::MutableBuffer>(shared + payload.data_offset,
-                                                  payload.data_size);
+  buffer = std::make_shared<arrow::MutableBuffer>(dist, payload.data_size);
   return Status::OK();
 }
 
@@ -402,18 +402,18 @@ Status Client::GetBuffers(
   RETURN_ON_ERROR(doWrite(message_out));
   json message_in;
   RETURN_ON_ERROR(doRead(message_in));
-  std::map<ObjectID, Payload> payloads;
+  std::vector<Payload> payloads;
   RETURN_ON_ERROR(ReadGetBuffersReply(message_in, payloads));
   for (auto const& item : payloads) {
     std::shared_ptr<arrow::Buffer> buffer = nullptr;
-    uint8_t* shared = nullptr;
-    if (item.second.data_size > 0) {
-      VINEYARD_CHECK_OK(mmapToClient(item.second.store_fd, item.second.map_size,
-                                     true, true, &shared));
+    uint8_t *shared = nullptr, *dist = nullptr;
+    if (item.data_size > 0) {
+      VINEYARD_CHECK_OK(
+          mmapToClient(item.store_fd, item.map_size, true, true, &shared));
+      dist = shared + item.data_offset;
     }
-    buffer = std::make_shared<arrow::Buffer>(shared + item.second.data_offset,
-                                             item.second.data_size);
-    buffers.emplace(item.first, buffer);
+    buffer = std::make_shared<arrow::Buffer>(dist, item.data_size);
+    buffers.emplace(item.object_id, buffer);
   }
   return Status::OK();
 }
@@ -429,10 +429,10 @@ Status Client::GetBufferSizes(const std::set<ObjectID>& ids,
   RETURN_ON_ERROR(doWrite(message_out));
   json message_in;
   RETURN_ON_ERROR(doRead(message_in));
-  std::map<ObjectID, Payload> payloads;
+  std::vector<Payload> payloads;
   RETURN_ON_ERROR(ReadGetBuffersReply(message_in, payloads));
   for (auto const& item : payloads) {
-    sizes.emplace(item.first, item.second.data_size);
+    sizes.emplace(item.object_id, item.data_size);
   }
   return Status::OK();
 }

--- a/src/client/ds/blob.cc
+++ b/src/client/ds/blob.cc
@@ -199,13 +199,13 @@ void BlobWriter::Dump() const {
 std::shared_ptr<Object> BlobWriter::_Seal(Client& client) {
   VINEYARD_ASSERT(!this->sealed(), "The blob writer has been already sealed.");
   // get blob and re-map
-  uint8_t* mmapped_ptr = nullptr;
+  uint8_t *mmapped_ptr = nullptr, *dist = nullptr;
   if (payload_.data_size > 0) {
     VINEYARD_CHECK_OK(client.mmapToClient(payload_.store_fd, payload_.map_size,
                                           false, true, &mmapped_ptr));
+    dist = mmapped_ptr + payload_.data_offset;
   }
-  auto buffer = arrow::Buffer::Wrap(mmapped_ptr + payload_.data_offset,
-                                    payload_.data_size);
+  auto buffer = arrow::Buffer::Wrap(dist, payload_.data_size);
 
   std::shared_ptr<Blob> blob(new Blob());
 
@@ -257,7 +257,6 @@ Status BufferSet::EmplaceBuffer(ObjectID const id,
       return Status::Invalid(
           "Invalid internal state: duplicated buffer, id = " +
           ObjectIDToString(id));
-
     } else {
       p->second = buffer;
       return Status::OK();

--- a/src/common/util/protocols.cc
+++ b/src/common/util/protocols.cc
@@ -330,14 +330,13 @@ void WriteGetBuffersReply(const std::vector<std::shared_ptr<Payload>>& objects,
   encode_msg(root, msg);
 }
 
-Status ReadGetBuffersReply(const json& root,
-                           std::map<ObjectID, Payload>& objects) {
+Status ReadGetBuffersReply(const json& root, std::vector<Payload>& objects) {
   CHECK_IPC_ERROR(root, "get_buffers_reply");
   for (size_t i = 0; i < root["num"]; ++i) {
     json tree = root[std::to_string(i)];
     Payload object;
     object.FromJSON(tree);
-    objects.emplace(object.object_id, object);
+    objects.emplace_back(object);
   }
   return Status::OK();
 }

--- a/src/common/util/protocols.h
+++ b/src/common/util/protocols.h
@@ -194,8 +194,7 @@ Status ReadGetBuffersRequest(const json& root, std::vector<ObjectID>& ids);
 void WriteGetBuffersReply(const std::vector<std::shared_ptr<Payload>>& objects,
                           std::string& msg);
 
-Status ReadGetBuffersReply(const json& root,
-                           std::map<ObjectID, Payload>& objects);
+Status ReadGetBuffersReply(const json& root, std::vector<Payload>& objects);
 
 void WriteGetRemoteBuffersRequest(const std::unordered_set<ObjectID>& ids,
                                   std::string& msg);


### PR DESCRIPTION


What do these changes do?
-------------------------

This pull request enhances the implementation detail of `mmap` -> `pointer` -> `buffer`.


Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

N/A

