### PR TITLE
Implements a static constructor to get metadata from unsafe sources.

### DIFF
--- a/src/client/ds/object_factory.cc
+++ b/src/client/ds/object_factory.cc
@@ -32,6 +32,10 @@ std::unique_ptr<Object> ObjectFactory::Create(std::string const& type_name) {
   }
 }
 
+std::unique_ptr<Object> ObjectFactory::Create(ObjectMeta const& metadata) {
+  return ObjectFactory::Create(metadata.GetTypeName(), metadata);
+}
+
 std::unique_ptr<Object> ObjectFactory::Create(std::string const& type_name,
                                               ObjectMeta const& metadata) {
   auto& known_types = getKnownTypes();

--- a/src/client/ds/object_factory.h
+++ b/src/client/ds/object_factory.h
@@ -74,6 +74,18 @@ class __attribute__((visibility("default"))) ObjectFactory {
    * @brief Initialize an instance by looking up the `type_name` in the factory,
    * and construct the object using the metadata.
    *
+   * @param metadata The metadata used to construct the object.
+   */
+  static std::unique_ptr<Object> __attribute__((visibility("default")))
+  Create(ObjectMeta const& metadata);
+
+  /**
+   * @brief Initialize an instance by looking up the `type_name` in the factory,
+   * and construct the object using the metadata.
+   *
+   * We keep this variant with explicit `typename` for fine-grained controll of
+   * the resolver.
+   *
    * @param type_name The type to be instantiated.
    * @param metadata The metadata used to construct the object.
    */

--- a/src/client/ds/object_meta.h
+++ b/src/client/ds/object_meta.h
@@ -491,6 +491,20 @@ class ObjectMeta {
 
   void SetMetaData(ClientBase* client, const json& meta);
 
+  /**
+   * Construct object metadata from unsafe sources.
+   */
+  static std::unique_ptr<ObjectMeta> Unsafe(std::string meta, size_t nobjects,
+                                            ObjectID* objects,
+                                            uintptr_t* pointers, size_t* sizes);
+
+  /**
+   * Construct object metadata from unsafe sources.
+   */
+  static std::unique_ptr<ObjectMeta> Unsafe(json meta, size_t nobjects,
+                                            ObjectID* objects,
+                                            uintptr_t* pointers, size_t* sizes);
+
   using const_iterator =
       nlohmann::detail::iteration_proxy_value<json::const_iterator>;
   const_iterator begin() const { return json::iterator_wrapper(meta_).begin(); }


### PR DESCRIPTION

What do these changes do?
-------------------------

Makes the `ObjectMeta` decouple from `vineyard::Client`, and make it could be constructed easily from foreign languages.

Related issue number
--------------------

Part of #227.

