### PR TITLE
Use a lock to protect the mutable write buffer queue.

### DIFF
--- a/src/server/async/socket_server.h
+++ b/src/server/async/socket_server.h
@@ -166,6 +166,7 @@ class SocketConnection : public std::enable_shared_from_this<SocketConnection> {
 
   asio::streambuf buf_;
   socket_message_queue_t write_msgs_;
+  std::recursive_mutex write_msgs_mutex_;  // protect the write_msgs
 
   std::unordered_set<int> used_fds_;
   // the associated reader of the stream


### PR DESCRIPTION

What do these changes do?
-------------------------

After introduce multi-thread socket server there seems a contention, that should be invalid for good clients, but the vineyardd shouldn't crash.

Related issue number
--------------------

Resolves #463 

