### PR TITLE
Update __init__.py to import VineyardXCom

### DIFF
--- a/python/vineyard/contrib/airflow/xcom/__init__.py
+++ b/python/vineyard/contrib/airflow/xcom/__init__.py
@@ -15,3 +15,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from .backend import VineyardXCom


### PR DESCRIPTION
When trying to use the XCom provider Airflow cannot find the VineyardXCom class because it is not defined in the \_\_init\_\_.py file so it needs to be defined.

What do these changes do?
-------------------------

Fix error when trying to use the XCom backend.


Related issue number
--------------------
None