### PR TITLE
Revisit the implementation of typename: more customizable and stable.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,4 +26,8 @@
 	path = thirdparty/jemalloc
 	url = https://github.com/jemalloc/jemalloc.git
 	shallow = true
+[submodule "thirdparty/ctti"]
+	path = thirdparty/ctti
+	url = https://github.com/Manu343726/ctti.git
+	shallow = true
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,10 @@ macro(find_boost)
     add_compile_options(-DBOOST_BIND_GLOBAL_PLACEHOLDERS)
 endmacro(find_boost)
 
+macro(find_ctti)
+    add_subdirectory(thirdparty/ctti)
+endmacro(find_ctti)
+
 macro(find_etcd_cpp_apiv3)
     if(USE_EXTERNAL_ETCD_LIBS)
         find_package(etcd-cpp-api QUIET)
@@ -271,6 +275,7 @@ endmacro(find_pthread)
 macro(find_common_libraries)
     find_apache_arrow()
     find_boost()
+    find_ctti()
     find_glog()
     find_gflags()
     find_jemalloc()
@@ -456,6 +461,16 @@ if(BUILD_VINEYARD_CLIENT)
     target_link_libraries(vineyard_client PRIVATE jemalloc ${CMAKE_DL_LIBS})
     target_compile_options(vineyard_client PUBLIC -DWITH_JEMALLOC)
 
+    target_include_directories(vineyard_client PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/ctti/include>
+        $<INSTALL_INTERFACE:include>
+    )
+    install(DIRECTORY thirdparty/ctti/include/ctti
+            DESTINATION include                 # target directory
+            FILES_MATCHING                      # install only matched files
+            PATTERN "*.hpp"                     # select C++ template header files
+    )
+
     if(BUILD_SHARED_LIBS AND BUILD_VINEYARD_PYPI_PACKAGES)
         target_compile_options(vineyard_client PRIVATE -Os)
         add_target_link_options(vineyard_client PRIVATE OPTIONS -Os)
@@ -566,6 +581,7 @@ if(BUILD_VINEYARD_TESTS)
         add_test(${T_NAME}, ${T_NAME})
         add_dependencies(vineyard_tests ${T_NAME})
 
+        target_compile_options(${T_NAME} PRIVATE "-std=c++17")
         if(${T_NAME} STREQUAL "delete_test" OR ${T_NAME} STREQUAL "rpc_delete_test")
             target_compile_options(${T_NAME} PRIVATE "-fno-access-control")
         endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -565,9 +565,7 @@ if(BUILD_VINEYARD_TESTS)
             add_executable(${T_NAME} EXCLUDE_FROM_ALL test/${T_NAME}.cc)
         endif()
 
-        target_link_libraries(${T_NAME} PRIVATE
-                              vineyard_client vineyard_basic vineyard_io vineyard_graph
-        )
+        target_link_libraries(${T_NAME} PRIVATE ${VINEYARD_INSTALL_LIBS})
         if(ARROW_SHARED_LIB)
             target_link_libraries(${T_NAME} PRIVATE ${ARROW_SHARED_LIB})
         else()

--- a/README.rst
+++ b/README.rst
@@ -244,6 +244,7 @@ We thank the following excellent opensource projects:
 
 - `apache-arrow <https://github.com/apache/arrow>`_, a cross-language development platform for in-memory analytics;
 - `boost-leaf <https://github.com/boostorg/leaf>`_, a C++ lightweight error augmentation framework;
+- `ctti <https://github.com/Manu343726/ctti>`_, a C++ compile-time type information library;
 - `dlmalloc <http://gee.cs.oswego.edu/dl/html/malloc.htmlp>`_, Doug Lea's memory allocator;
 - `etcd-cpp-apiv3 <https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3>`_, a C++ API for etcd's v3 client API;
 - `flat_hash_map <https://github.com/skarupke/flat_hash_map>`_, an efficient hashmap implementation;

--- a/python/vineyard/data/base.py
+++ b/python/vineyard/data/base.py
@@ -44,7 +44,7 @@ def double_builder(client, value, **kwargs):
 
 def string_builder(client, value, **kwargs):
     meta = ObjectMeta(**kwargs)
-    meta['typename'] = 'vineyard::Scalar<std::basic_string<char,std::char_traits<char>,std::allocator<char>>>'
+    meta['typename'] = 'vineyard::Scalar<std::string>'
     meta['value_'] = value
     meta['type_'] = getattr(type(value), '__name__')
     meta['nbytes'] = 0
@@ -93,7 +93,7 @@ def tuple_builder(client, value, builder, **kwargs):
 def scalar_resolver(obj):
     meta = obj.meta
     typename = obj.typename
-    if typename == 'vineyard::Scalar<std::basic_string<char,std::char_traits<char>,std::allocator<char>>>':
+    if typename == 'vineyard::Scalar<std::string>':
         return meta['value_']
     if typename == 'vineyard::Scalar<int>':
         return int(meta['value_'])

--- a/test/runner.py
+++ b/test/runner.py
@@ -237,6 +237,7 @@ def run_single_vineyardd_tests():
         run_test('stream_test')
         run_test('tensor_test')
         run_test('tuple_test')
+        run_test('typename_test')
         run_test('version_test')
 
         run_invalid_client_test('127.0.0.1', rpc_socket_port)

--- a/test/typename_test.cc
+++ b/test/typename_test.cc
@@ -38,8 +38,6 @@ template <typename K, typename V>
 using TX = TXXXX<K, V>;
 
 int main(int, const char**) {
-  using namespace std;
-
   {
     const auto type = type_name<int32_t>();
     CHECK_EQ(type, "int");

--- a/test/typename_test.cc
+++ b/test/typename_test.cc
@@ -1,0 +1,92 @@
+/** Copyright 2020-2021 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "common/util/logging.h"
+#include "common/util/typename.h"
+
+#include "basic/ds/hashmap.h"
+
+using namespace vineyard;  // NOLINT(build/namespaces)
+
+template <typename K, typename V>
+using my_hashmap = Hashmap<K, V>;
+
+template <typename K, typename V>
+struct T {};
+
+template <typename K, typename V>
+struct TXXXX {};
+
+template <typename K, typename V>
+using TX = TXXXX<K, V>;
+
+int main(int, const char**) {
+  using namespace std;
+
+  {
+    const auto type = type_name<int32_t>();
+    CHECK_EQ(type, "int");
+  }
+  {
+    const auto type = type_name<uint32_t>();
+    CHECK_EQ(type, "uint");
+  }
+  {
+    const auto type = type_name<int64_t>();
+    CHECK_EQ(type, "int64");
+  }
+  {
+    const auto type = type_name<uint64_t>();
+    CHECK_EQ(type, "uint64");
+  }
+  {
+    const auto type = type_name<std::string>();
+    CHECK_EQ(type, "std::string");
+  }
+  {
+    const auto type = type_name<Hashmap<int64_t, double>>();
+    CHECK_EQ(type,
+             "vineyard::Hashmap<int64,double,std::hash<int64>,std::equal_to<"
+             "int64>>");
+  }
+  {
+    const auto type = type_name<my_hashmap<int64_t, double>>();
+    CHECK_EQ(type,
+             "vineyard::Hashmap<int64,double,std::hash<int64>,std::equal_to<"
+             "int64>>");
+  }
+  {
+    const auto type = type_name<T<int64_t, std::string>>();
+    CHECK_EQ(type, "T<int64,std::string>");
+  }
+  {
+    const auto type = type_name<TXXXX<int64_t, std::string>>();
+    CHECK_EQ(type, "TXXXX<int64,std::string>");
+  }
+  {
+    const auto type =
+        type_name<TX<int64_t, TXXXX<int64_t, T<int64_t, std::string>>>>();
+    CHECK_EQ(type, "TXXXX<int64,TXXXX<int64,T<int64,std::string>>>");
+  }
+
+  LOG(INFO) << "Passed typename tests...";
+
+  return 0;
+}


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

Revisit the `vineyard::type_name` implementation to make it more composable and stable when acrossing platforms. e.g., `std::string` will be always `std::string` no matter on which platform, and `int64_t` will be always "int64", rather than "long", or "long long" on different platforms.

Users can supply their own typename for customized type, e.g.,

```cpp
struct XX {
};

namespace vineyard {

template <>
inline const std::string type_name() {
    return "XX-name";
}
}
```

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #457 

