### PR TITLE
Adds tree option to query command in vineyard-ctl

### DIFF
--- a/docs/notes/ctl.rst
+++ b/docs/notes/ctl.rst
@@ -73,6 +73,7 @@ Options:
 + :code:`exists`: Check if the object exists or not.
 + :code:`stdout`: Get object to stdout.
 + :code:`output_file`: Get object to file.
++ :code:`tree`: Get object lineage in tree-like style.
 
 Example:
 

--- a/setup.py
+++ b/setup.py
@@ -168,6 +168,7 @@ setup(
         'setuptools',
         'shared-memory38; python_version<="3.7"',
         'sortedcontainers',
+        'treelib',
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
Signed-off-by: rohangupta <rohaninjmu@gmail.com>

What do these changes do?
-------------------------

Added `tree` option to `query` **command** in `vineyard-ctl`. `tree` lets you print vineyard object lineage in a tree-like style.

Part of #291.

