### PR TITLE
Adds memory_status option to query command in vineyard-ctl

### DIFF
--- a/docs/notes/ctl.rst
+++ b/docs/notes/ctl.rst
@@ -74,6 +74,8 @@ Options:
 + :code:`stdout`: Get object to stdout.
 + :code:`output_file`: Get object to file.
 + :code:`tree`: Get object lineage in tree-like style.
++ :code:`memory_status`: Get the memory used by the vineyard object.
++ :code:`detail`: Get detailed memory used by the vineyard object.
 
 Example:
 


### PR DESCRIPTION
Signed-off-by: rohangupta <rohaninjmu@gmail.com>

What do these changes do?
-------------------------

Added `memory_status` option to `query` **command** in `vineyard-ctl`. `memory_status` lets you print the **memory** used by a **vineyard object**.

Part of #291.
