### PR TITLE
Vineyard IO: raise exceptions when encounter errors in writers (in its `join()`)

### DIFF
--- a/modules/io/adaptors/parse_dataframe_to_bytes.py
+++ b/modules/io/adaptors/parse_dataframe_to_bytes.py
@@ -16,10 +16,8 @@
 # limitations under the License.
 #
 
-import io
 import json
 import sys
-from urllib.parse import urlparse
 
 import pyarrow as pa
 import vineyard

--- a/modules/io/adaptors/read_bytes.py
+++ b/modules/io/adaptors/read_bytes.py
@@ -29,9 +29,13 @@ from fsspec.utils import read_block
 from fsspec.core import split_protocol
 from vineyard.io.byte import ByteStreamBuilder
 
-from vineyard.drivers.io import ossfs
+try:
+    from vineyard.drivers.io import ossfs
+except ImportError:
+    ossfs = None
 
-fsspec.register_implementation("oss", ossfs.OSSFileSystem)
+if ossfs:
+    fsspec.register_implementation("oss", ossfs.OSSFileSystem)
 
 
 def report_status(status, content):

--- a/modules/io/adaptors/read_orc.py
+++ b/modules/io/adaptors/read_orc.py
@@ -29,10 +29,14 @@ import pyorc
 import vineyard
 from vineyard.io.dataframe import DataframeStreamBuilder
 
-from vineyard.drivers.io import ossfs
+try:
+    from vineyard.drivers.io import ossfs
+except ImportError:
+    ossfs = None
 
+if ossfs:
+    fsspec.register_implementation("oss", ossfs.OSSFileSystem)
 fsspec.register_implementation("hive", fsspec.implementations.hdfs.PyArrowHDFS)
-fsspec.register_implementation("oss", ossfs.OSSFileSystem)
 
 
 def arrow_type(field):

--- a/modules/io/adaptors/write_bytes.py
+++ b/modules/io/adaptors/write_bytes.py
@@ -22,13 +22,15 @@ import sys
 import traceback
 
 import fsspec
-import pyarrow as pa
 import vineyard
-from vineyard.io.byte import ByteStreamBuilder
 
-from vineyard.drivers.io import ossfs
+try:
+    from vineyard.drivers.io import ossfs
+except ImportError:
+    ossfs = None
 
-fsspec.register_implementation("oss", ossfs.OSSFileSystem)
+if ossfs:
+    fsspec.register_implementation("oss", ossfs.OSSFileSystem)
 
 
 def report_status(status, content):

--- a/modules/io/adaptors/write_orc.py
+++ b/modules/io/adaptors/write_orc.py
@@ -19,14 +19,11 @@
 import base64
 import json
 import sys
-from typing import Dict
-from urllib.parse import urlparse
 
 import fsspec
 import pyarrow as pa
 import pyorc
 import vineyard
-from vineyard.io.dataframe import DataframeStreamBuilder
 
 
 def orc_type(field):

--- a/modules/io/adaptors/write_vineyard_dataframe.py
+++ b/modules/io/adaptors/write_vineyard_dataframe.py
@@ -16,10 +16,8 @@
 # limitations under the License.
 #
 
-import io
 import json
 import sys
-from urllib.parse import urlparse
 
 import pyarrow as pa
 import vineyard

--- a/modules/io/python/drivers/io/tests/test_migrate_stream.py
+++ b/modules/io/python/drivers/io/tests/test_migrate_stream.py
@@ -19,10 +19,6 @@
 import filecmp
 import itertools
 import pytest
-import configparser
-import glob
-import os
-from urllib.parse import urlparse
 
 import vineyard
 import vineyard.io

--- a/modules/io/python/drivers/io/tests/test_open.py
+++ b/modules/io/python/drivers/io/tests/test_open.py
@@ -43,7 +43,6 @@
 
 import filecmp
 import pytest
-import configparser
 import glob
 import os
 from urllib.parse import urlparse

--- a/modules/io/python/drivers/io/tests/test_serialize.py
+++ b/modules/io/python/drivers/io/tests/test_serialize.py
@@ -18,7 +18,6 @@
 
 import os
 import pytest
-import itertools
 import numpy as np
 
 import vineyard


### PR DESCRIPTION
What do these changes do?
-------------------------

If the writer fails with the `FAILED` status the raise an exception with proper error message to the client.


Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #484 

