### PR TITLE
Support injecting extra metadata in existing objects via a shallow copy.

### DIFF
--- a/python/client.cc
+++ b/python/client.cc
@@ -180,6 +180,20 @@ void bind_client(py::module& mod) {
           },
           "object_id"_a)
       .def(
+          "shallow_copy",
+          [](ClientBase* self, const ObjectIDWrapper object_id,
+             py::dict extra_metadata) -> ObjectIDWrapper {
+            ObjectID target_id;
+            json meta = detail::to_json(extra_metadata);
+            if (meta == json(nullptr)) {
+              throw_on_error(self->ShallowCopy(object_id, target_id));
+            } else {
+              throw_on_error(self->ShallowCopy(object_id, meta, target_id));
+            }
+            return target_id;
+          },
+          "object_id"_a, "extra_metadata"_a)
+      .def(
           "deep_copy",
           [](ClientBase* self,
              const ObjectIDWrapper object_id) -> ObjectIDWrapper {

--- a/python/vineyard/_vineyard_docs.py
+++ b/python/vineyard/_vineyard_docs.py
@@ -496,6 +496,22 @@ Parameters:
 
 Returns:
     ObjectID: The object id of newly shallow-copied vineyard object.
+
+.. method:: shallow_copy(object_id: ObjectID, extra_metadata: dict) -> ObjectID
+    :noindex:
+
+Create a shallow copy of the given vineyard object, with extra metadata.
+
+Parameters:
+    object_id: ObjectID
+        The vineyard object that is requested to be shallow-copied.
+    extra_metadata: dict
+        Extra metadata to apply to the newly created object. The fields of extra
+        metadata must be primitive types, e.g., string, number, and cannot be
+        array or dict.
+
+Returns:
+    ObjectID: The object id of newly shallow-copied vineyard object.
 ''')
 
 add_doc(

--- a/src/client/client_base.cc
+++ b/src/client/client_base.cc
@@ -188,6 +188,18 @@ Status ClientBase::ShallowCopy(const ObjectID id, ObjectID& target_id) {
   return Status::OK();
 }
 
+Status ClientBase::ShallowCopy(const ObjectID id, json const& extra_metadata,
+                               ObjectID& target_id) {
+  ENSURE_CONNECTED(this);
+  std::string message_out;
+  WriteShallowCopyRequest(id, extra_metadata, message_out);
+  RETURN_ON_ERROR(doWrite(message_out));
+  json message_in;
+  RETURN_ON_ERROR(doRead(message_in));
+  RETURN_ON_ERROR(ReadShallowCopyReply(message_in, target_id));
+  return Status::OK();
+}
+
 Status ClientBase::DeepCopy(const ObjectID object_id, ObjectID& target_id) {
   ENSURE_CONNECTED(this);
 

--- a/src/client/client_base.h
+++ b/src/client/client_base.h
@@ -222,6 +222,21 @@ class ClientBase {
   Status ShallowCopy(const ObjectID id, ObjectID& target_id);
 
   /**
+   * @brief Make a shallow copy on the given object. A "shallow copy" means the
+   * result object has the same type with the source object and they shares all
+   * member objects.
+   *
+   * @param id The object id to shallow copy.
+   * @param extra_metadata Feed extra metadata when shallow copying.
+   * @param target_id The result object id will be stored in `target_id` as
+   * return value.
+   *
+   * @return Status that indicates whether the shallow copy has succeeded.
+   */
+  Status ShallowCopy(const ObjectID id, json const& extra_metadata,
+                     ObjectID& target_id);
+
+  /**
    * @brief Make a deep copy on the given object.
    *
    * @param id The object id to deep copy.

--- a/src/common/util/protocols.cc
+++ b/src/common/util/protocols.cc
@@ -897,9 +897,21 @@ void WriteShallowCopyRequest(const ObjectID id, std::string& msg) {
   encode_msg(root, msg);
 }
 
-Status ReadShallowCopyRequest(const json& root, ObjectID& id) {
+void WriteShallowCopyRequest(const ObjectID id, json const& extra_metadata,
+                             std::string& msg) {
+  json root;
+  root["type"] = "shallow_copy_request";
+  root["id"] = id;
+  root["extra"] = extra_metadata;
+
+  encode_msg(root, msg);
+}
+
+Status ReadShallowCopyRequest(const json& root, ObjectID& id,
+                              json& extra_metadata) {
   RETURN_ON_ASSERT(root["type"] == "shallow_copy_request");
   id = root["id"].get<ObjectID>();
+  extra_metadata = root.value("extra", json::object());
   return Status::OK();
 }
 

--- a/src/common/util/protocols.h
+++ b/src/common/util/protocols.h
@@ -302,7 +302,11 @@ Status ReadStopStreamReply(const json& root);
 
 void WriteShallowCopyRequest(const ObjectID id, std::string& msg);
 
-Status ReadShallowCopyRequest(const json& root, ObjectID& id);
+void WriteShallowCopyRequest(const ObjectID id, json const& extra_metadata,
+                             std::string& msg);
+
+Status ReadShallowCopyRequest(const json& root, ObjectID& id,
+                              json& extra_metadata);
 
 void WriteShallowCopyReply(const ObjectID target_id, std::string& msg);
 

--- a/src/server/async/socket_server.cc
+++ b/src/server/async/socket_server.cc
@@ -581,9 +581,10 @@ bool SocketConnection::doExists(const json& root) {
 bool SocketConnection::doShallowCopy(const json& root) {
   auto self(shared_from_this());
   ObjectID id;
-  TRY_READ_REQUEST(ReadShallowCopyRequest, root, id);
+  json extra_metadata;
+  TRY_READ_REQUEST(ReadShallowCopyRequest, root, id, extra_metadata);
   RESPONSE_ON_ERROR(server_ptr_->ShallowCopy(
-      id, [self](const Status& status, const ObjectID target) {
+      id, extra_metadata, [self](const Status& status, const ObjectID target) {
         std::string message_out;
         if (status.ok()) {
           WriteShallowCopyReply(target, message_out);

--- a/src/server/server/vineyard_server.cc
+++ b/src/server/server/vineyard_server.cc
@@ -428,16 +428,18 @@ Status VineyardServer::Exists(const ObjectID id,
 }
 
 Status VineyardServer::ShallowCopy(const ObjectID id,
+                                   const json& extra_metadata,
                                    callback_t<const ObjectID> callback) {
   ENSURE_VINEYARDD_READY();
   RETURN_ON_ASSERT(!IsBlob(id), "The blobs cannot be shallow copied");
   ObjectID target_id = GenerateObjectID();
   meta_service_ptr_->RequestToShallowCopy(
-      [id, target_id](const Status& status, const json& meta,
-                      std::vector<IMetaService::op_t>& ops, bool& transient) {
+      [id, extra_metadata, target_id](const Status& status, const json& meta,
+                                      std::vector<IMetaService::op_t>& ops,
+                                      bool& transient) {
         if (status.ok()) {
-          return CATCH_JSON_ERROR(
-              meta_tree::ShallowCopyOps(meta, id, target_id, ops, transient));
+          return CATCH_JSON_ERROR(meta_tree::ShallowCopyOps(
+              meta, id, extra_metadata, target_id, ops, transient));
         } else {
           LOG(ERROR) << status.ToString();
           return status;

--- a/src/server/server/vineyard_server.h
+++ b/src/server/server/vineyard_server.h
@@ -114,7 +114,8 @@ class VineyardServer : public std::enable_shared_from_this<VineyardServer> {
 
   Status Exists(const ObjectID id, callback_t<const bool> callback);
 
-  Status ShallowCopy(const ObjectID id, callback_t<const ObjectID> callback);
+  Status ShallowCopy(const ObjectID id, json const& extra_metadata,
+                     callback_t<const ObjectID> callback);
 
   Status DeepCopy(const ObjectID id, const std::string& peer,
                   const std::string& peer_rpc_endpoint,

--- a/src/server/util/meta_tree.h
+++ b/src/server/util/meta_tree.h
@@ -66,7 +66,7 @@ Status DelDataOps(const json& tree, const std::string& name,
                   std::vector<IMetaService::op_t>& ops, bool& sync_remote);
 
 Status ShallowCopyOps(const json& tree, const ObjectID id,
-                      const ObjectID target,
+                      const json& extra_metadata, const ObjectID target,
                       std::vector<IMetaService::op_t>& ops, bool& transient);
 
 Status FilterAtInstance(const json& tree, const InstanceID& instance_id,


### PR DESCRIPTION
What do these changes do?
-------------------------

Extends shallow-copy to support more kinds of operations.


Related issue number
--------------------

N/A

