### PR TITLE
Airflow: unitest, and support easier launching of vineyard server.

### DIFF
--- a/python/vineyard/contrib/airflow/README.rst
+++ b/python/vineyard/contrib/airflow/README.rst
@@ -103,6 +103,27 @@ table in backend databases of Airflow.
 The example is adapted from the documentation of Airflow, see also
 `Tutorial on the Taskflow API`_.
 
+Run the tests
+-------------
+
+1. Start your vineyardd with the following command,
+
+    .. code:: bash
+
+        python3 -m vineyard.deploy
+
+2. Set airflow to use the vineyard XCom backend, and run tests with pytest,
+
+    .. code:: bash
+
+        export AIRFLOW__CORE__XCOM_BACKEND=vineyard.contrib.airflow.xcom.VineyardXCom
+
+        pytest -s -vvv python/vineyard/contrib/airflow/tests/test_python_dag.py
+        pytest -s -vvv python/vineyard/contrib/airflow/tests/test_pandas_dag.py
+
+
+The pandas test suite is not possible to run with the default XCom backend, vineyard
+enables airflow to exchange **complex** and **big** data without modify the DAG and tasks!
 
 .. _launching vineyard: https://v6d.io/notes/getting-started.html#starting-vineyard-server
 .. _Tutorial on the Taskflow API: https://airflow.apache.org/docs/apache-airflow/stable/tutorial_taskflow_api.html

--- a/python/vineyard/contrib/airflow/tests/__init__.py
+++ b/python/vineyard/contrib/airflow/tests/__init__.py
@@ -1,0 +1,17 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020-2021 Alibaba Group Holding Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/python/vineyard/contrib/airflow/tests/test_base.py
+++ b/python/vineyard/contrib/airflow/tests/test_base.py
@@ -1,0 +1,72 @@
+# Refer from airflow:
+#
+#   airflow/tests/decorators/test_python.py
+#
+# with the following license:
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from datetime import timedelta
+import unittest
+
+from airflow.models import DAG, DagRun, TaskInstance as TI
+from airflow.utils import timezone
+from airflow.utils.session import create_session
+
+DEFAULT_DATE = timezone.datetime(2016, 1, 1)
+END_DATE = timezone.datetime(2016, 1, 2)
+INTERVAL = timedelta(hours=12)
+FROZEN_NOW = timezone.datetime(2016, 1, 2, 12, 1, 1)
+
+TI_CONTEXT_ENV_VARS = [
+    'AIRFLOW_CTX_DAG_ID',
+    'AIRFLOW_CTX_TASK_ID',
+    'AIRFLOW_CTX_EXECUTION_DATE',
+    'AIRFLOW_CTX_DAG_RUN_ID',
+]
+
+
+class TestPythonBase(unittest.TestCase):
+    """Base test class for TestPythonOperator classes"""
+
+    name = 'python_dag_on_vineyard'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        with create_session() as session:
+            session.query(DagRun).delete()
+            session.query(TI).delete()
+
+    def setUp(self):
+        super().setUp()
+        self.dag = DAG(self.name, default_args={'owner': 'airflow', 'start_date': DEFAULT_DATE})
+        self.addCleanup(self.dag.clear)
+        self.clear_run()
+        self.addCleanup(self.clear_run)
+
+    def tearDown(self):
+        super().tearDown()
+
+        with create_session() as session:
+            session.query(DagRun).delete()
+            session.query(TI).delete()
+
+    def clear_run(self):
+        self.run = False

--- a/python/vineyard/contrib/airflow/tests/test_pandas_dag.py
+++ b/python/vineyard/contrib/airflow/tests/test_pandas_dag.py
@@ -1,0 +1,67 @@
+# Referred from airflow testsuite:
+#
+#   airflow/tests/decorators/test_python.py
+#
+# which has the following license header:
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import numpy as np
+import pandas as pd
+
+from airflow.decorators import task as task_decorator
+from airflow.utils import timezone
+from airflow.utils.state import State
+from airflow.utils.types import DagRunType
+
+from .test_base import TestPythonBase, DEFAULT_DATE
+
+
+class TestAirflowPandasDag(TestPythonBase):
+    def test_multiple_outputs(self):
+        """Tests pushing multiple outputs as a dictionary"""
+
+        x = pd.DataFrame({'x': np.arange(10), 'y': np.arange(10, 20)})
+        y = np.random.rand(10, 20)
+
+        @task_decorator(multiple_outputs=True)
+        def return_dict(number: int):
+            return {'number': x, '43': y}
+
+        test_number = 10
+        with self.dag:
+            dag_node = return_dict(test_number)
+
+        dr = self.dag.create_dagrun(
+            run_id=DagRunType.MANUAL,
+            start_date=timezone.utcnow(),
+            execution_date=DEFAULT_DATE,
+            state=State.RUNNING,
+        )
+
+        dag_node.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+
+        ti = dr.get_task_instances()[0]
+
+        r1 = ti.xcom_pull(key='number')
+        pd.testing.assert_frame_equal(x, r1)
+        r2 = ti.xcom_pull(key='43')
+        np.testing.assert_array_almost_equal(y, r2)
+
+        rs = ti.xcom_pull()
+        assert rs.keys() == {'number', '43'}

--- a/python/vineyard/contrib/airflow/tests/test_python_dag.py
+++ b/python/vineyard/contrib/airflow/tests/test_python_dag.py
@@ -1,0 +1,55 @@
+# Referred from airflow testsuite:
+#
+#   airflow/tests/decorators/test_python.py
+#
+# which has the following license header:
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow.decorators import task as task_decorator
+from airflow.utils import timezone
+from airflow.utils.state import State
+from airflow.utils.types import DagRunType
+
+from .test_base import TestPythonBase, DEFAULT_DATE
+
+
+class TestAirflowPandasDag(TestPythonBase):
+    def test_multiple_outputs(self):
+        """Tests pushing multiple outputs as a dictionary"""
+        @task_decorator(multiple_outputs=True)
+        def return_dict(number: int):
+            return {'number': number + 1, '43': 43}
+
+        test_number = 10
+        with self.dag:
+            dag_node = return_dict(test_number)
+
+        dr = self.dag.create_dagrun(
+            run_id=DagRunType.MANUAL,
+            start_date=timezone.utcnow(),
+            execution_date=DEFAULT_DATE,
+            state=State.RUNNING,
+        )
+
+        dag_node.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+
+        ti = dr.get_task_instances()[0]
+        assert ti.xcom_pull(key='number') == test_number + 1
+        assert ti.xcom_pull(key='43') == 43
+        assert ti.xcom_pull() == {'number': test_number + 1, '43': 43}

--- a/python/vineyard/deploy/__main__.py
+++ b/python/vineyard/deploy/__main__.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020-2021 Alibaba Group Holding Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import logging
+import signal
+
+from .local import start_vineyardd
+
+logger = logging.getLogger('vineyard')
+
+
+def deploy_vineyardd(etcd_endpoints=None, size='256Mi', socket=None, rpc=True, rpc_socket_port=9600):
+    with start_vineyardd(etcd_endpoints=etcd_endpoints,
+                         size=size,
+                         socket=socket,
+                         rpc=rpc,
+                         rpc_socket_port=rpc_socket_port) as (_, socket):
+        logger.info("Vineyard server is listening %s ...", socket)
+
+        try:
+            signal.pause()
+        except KeyboardInterrupt:
+            logger.info("Vineyard exitting ...")
+
+
+if __name__ == '__main__':
+    deploy_vineyardd()

--- a/python/vineyard/deploy/local.py
+++ b/python/vineyard/deploy/local.py
@@ -19,7 +19,6 @@
 import contextlib
 import logging
 import os
-import pkg_resources
 import shutil
 import subprocess
 import sys


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

+ Add test suite to run dag with python value
+ Add test suite to run dag with pandas dataframe (which is not possible with the default XCom backend).
+ Add a helper function to deploy vineyardd eaiser.

Related issue number
--------------------

Part of #374 

