### PR TITLE
Add the pair of init() and shutdown() methods to help new users to deploy vineyardd easily

### DIFF
--- a/docs/examples/distributed-learning.ipynb
+++ b/docs/examples/distributed-learning.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Distributed Learning with Vineyard\n",
     "==================================\n",
@@ -60,13 +59,12 @@
     "-------\n",
     "\n",
     "The distributed deployment of vineyard and dask is as follows: on each machine, we launch a vineyard daemon process to handle the local data storage on that machine; and we also launch a dask worker on that machine for the computation accordingly. In this notebook, we limit the machine number as 1 (i.e., the local machine) just for demonstration."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "import vineyard\n",
     "import subprocess as sp\n",
@@ -77,11 +75,12 @@
     "# launch dask scheduler and worker\n",
     "dask_scheduler = sp.Popen(['dask-scheduler', '--host', 'localhost'])\n",
     "dask_worker = sp.Popen(['dask-worker', 'tcp://localhost:8786'])"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Preprocessing the data\n",
     "----------------------\n",
@@ -89,31 +88,30 @@
     "To read the data, we replace\n",
     "**pd.read_csv** by **dd.read_csv**, which will automatically\n",
     "read the data in parallel."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "import dask.dataframe as dd\n",
     "raw_data = dd.read_csv('covtype.data', header=None)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Then we preprocess the data using the same code from the example,\n",
     "except the replacement of **pd.concat** to **dd.concat** only."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "\"\"\"\n",
     "The two categorical features in the dataset are binary-encoded.\n",
@@ -158,20 +156,20 @@
     "\n",
     "# Convert the target label indices into a range from 0 to 6 (there are 7 labels in total).\n",
     "data[\"Cover_Type\"] = data[\"Cover_Type\"] - 1"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Finally, instead of saving the preprocessed data into files, we store them in Vineyard.\n"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "import vineyard\n",
     "from vineyard.core.builder import builder_context\n",
@@ -181,19 +179,20 @@
     "    register_dask_types(builder, None) # register dask builders\n",
     "    gdf_id = client.put(data, dask_scheduler='tcp://localhost:8786')\n",
     "    print(gdf_id)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "We saved the preprocessed data as a global dataframe\n",
     "in Vineyard with the ObjectID above."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Training the model\n",
     "------------------\n",
@@ -240,13 +239,12 @@
     "```\n",
     "In our solution, we provide a function to load dataset from the global dataframe\n",
     "generated in the last step."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "from vineyard.core.resolver import resolver_context\n",
     "from vineyard.contrib.ml.tensorflow import register_tf_types\n",
@@ -264,20 +262,20 @@
     "    train_dataset = ds.skip(len_test).batch(batch_size)\n",
     "\n",
     "    return train_dataset, test_dataset"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "And modify the training procedure with a few lines of horovod code."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "import horovod.keras as hvd\n",
     "\n",
@@ -307,20 +305,20 @@
     "    _, accuracy = model.evaluate(test_dataset, verbose=0)\n",
     "\n",
     "    print(f\"Test accuracy: {round(accuracy * 100, 2)}%\")"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "All the other parts of training procedure are the same as the single machine solution."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "TARGET_FEATURE_NAME = \"Cover_Type\"\n",
     "\n",
@@ -455,53 +453,54 @@
     "\n",
     "\n",
     "baseline_model = create_baseline_model()"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Let's run it:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "run_experiment(baseline_model)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "We clear the environments in the end."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "dask_worker.terminate()\n",
     "dask_scheduler.terminate()\n",
     "\n",
-    "vineyardd.shutdown()"
-   ]
+    "vineyard.shutdown()"
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Finally, we can use **horovodrun** to run the above code distributedly in a cluster for distributed learning on big datasets."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Conclusion\n",
     "----------\n",
@@ -509,7 +508,8 @@
     "From this example, we can see that with the help of Vineyard, users can easily extend\n",
     "their single machine solutions to distributed learning using dedicated systems without\n",
     "worrying about the cross-system data sharing issues."
-   ]
+   ],
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/docs/examples/distributed-learning.ipynb
+++ b/docs/examples/distributed-learning.ipynb
@@ -68,22 +68,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
     "import vineyard\n",
     "import subprocess as sp\n",
     "\n",
-    "from pathlib import Path\n",
-    "\n",
     "# launch local vineyardd\n",
-    "ctx = vineyard.deploy.local.start_vineyardd(size='1G')\n",
-    "vineyardd, socket = ctx.__enter__()\n",
-    "print(\"Vineyard daemon launched at IPC:\", socket)\n",
+    "client = vineyard.init()\n",
     "\n",
     "# launch dask scheduler and worker\n",
     "dask_scheduler = sp.Popen(['dask-scheduler', '--host', 'localhost'])\n",
-    "new_env = os.environ.copy()\n",
-    "new_env['VINEYARD_IPC_SOCKET'] = socket\n",
-    "dask_worker = sp.Popen(['dask-worker', 'tcp://localhost:8786'], env=new_env)"
+    "dask_worker = sp.Popen(['dask-worker', 'tcp://localhost:8786'])"
    ]
   },
   {
@@ -184,8 +177,6 @@
     "from vineyard.core.builder import builder_context\n",
     "from vineyard.contrib.dask.dask import register_dask_types\n",
     "\n",
-    "client = vineyard.connect(socket)\n",
-    "\n",
     "with builder_context() as builder:\n",
     "    register_dask_types(builder, None) # register dask builders\n",
     "    gdf_id = client.put(data, dask_scheduler='tcp://localhost:8786')\n",
@@ -263,7 +254,7 @@
     "def get_dataset_from_vineyard(object_id, batch_size, shuffle=False):\n",
     "    with resolver_context() as resolver:\n",
     "        register_tf_types(None, resolver) # register tf resolvers\n",
-    "        ds = vineyard.connect(socket).get(object_id, label=TARGET_FEATURE_NAME) # specify the label column\n",
+    "        ds = vineyard.connect().get(object_id, label=TARGET_FEATURE_NAME) # specify the label column\n",
     "\n",
     "    if shuffle:\n",
     "        ds = ds.shuffle(len(ds))\n",
@@ -497,7 +488,8 @@
    "source": [
     "dask_worker.terminate()\n",
     "dask_scheduler.terminate()\n",
-    "vineyardd.terminate()"
+    "\n",
+    "vineyardd.shutdown()"
    ]
   },
   {

--- a/python/vineyard/__init__.py
+++ b/python/vineyard/__init__.py
@@ -104,7 +104,6 @@ from .data import register_builtin_types
 from .data.graph import Graph
 from .deploy.local import init, shutdown
 
-
 logger = logging.getLogger('vineyard')
 
 

--- a/python/vineyard/__init__.py
+++ b/python/vineyard/__init__.py
@@ -102,7 +102,7 @@ from .core import default_builder_context, default_resolver_context, default_dri
     builder_context, resolver_context, driver_context
 from .data import register_builtin_types
 from .data.graph import Graph
-from .deploy.local import init, shutdown
+from .deploy.local import init, shutdown, get_default_client, get_default_socket
 
 logger = logging.getLogger('vineyard')
 

--- a/python/vineyard/__init__.py
+++ b/python/vineyard/__init__.py
@@ -102,6 +102,8 @@ from .core import default_builder_context, default_resolver_context, default_dri
     builder_context, resolver_context, driver_context
 from .data import register_builtin_types
 from .data.graph import Graph
+from .deploy.local import init, shutdown
+
 
 logger = logging.getLogger('vineyard')
 

--- a/python/vineyard/deploy/distributed.py
+++ b/python/vineyard/deploy/distributed.py
@@ -113,7 +113,7 @@ def start_vineyardd(hosts=None,
             if rc is not None:
                 err = textwrap.indent(proc.stdout.read(), ' ' * 4)
                 raise RuntimeError('vineyardd exited unexpectedly with code %d: error is:\n%s' % (rc, err))
-        yield procs, socket
+        yield procs, socket, etcd_endpoints
     finally:
         logger.info('Distributed vineyardd being killed')
         for proc in procs:

--- a/python/vineyard/deploy/local.py
+++ b/python/vineyard/deploy/local.py
@@ -168,8 +168,8 @@ def init(proc_num=1, socket=None, **kw):
     
     it will launch a local vineyardd and return a connected client to the vineyardd.
 
-    If a vineyardd has been launched at **SOCKET**, pass the socket either by setting the
-    environment variable **VINEYARD_IPC_SOCKET** as the socket before head, or simply use:
+    If a specific **SOCKET** path is needed, pass the socket either by setting the
+    environment variable **VINEYARD_IPC_SOCKET** as the SOCKET before head, or simply use:
     
     .. code::
     
@@ -202,7 +202,10 @@ def init(proc_num=1, socket=None, **kw):
     etcd_endpoints = None
     etcd_prefix = f'vineyard_init_at_{time.time()}'
     for idx in range(proc_num):
-        ipc_socket = f'{socket}.{idx}' if socket else None
+        if proc_num > 1:
+            ipc_socket = f'{socket}.{idx}' if socket else None
+        else:
+            ipc_socket = socket
         try:
             client = connect(ipc_socket)
         except:

--- a/python/vineyard/deploy/local.py
+++ b/python/vineyard/deploy/local.py
@@ -206,14 +206,14 @@ def init(num_instances=1, **kw):
 
 def get_default_client():
     if not __default_instance_contexts:
-        raise ValueError("Vineyard has not been initialized, use vineyard.init()")
+        raise ValueError("Vineyard has not been initialized, use vineyard.init() to launch vineyard instances")
     clients = [__default_instance_contexts[k][1] for k in __default_instance_contexts]
     return clients if len(clients) > 1 else clients[0]
 
 
 def get_default_socket():
     if not __default_instance_contexts:
-        raise ValueError("Vineyard has not been initialized, use vineyard.init() to launch vineyard daemons")
+        raise ValueError("Vineyard has not been initialized, use vineyard.init() to launch vineyard instances")
     sockets = __default_instance_contexts.keys()
     return sockets if len(sockets) > 1 else sockets[0]
 

--- a/python/vineyard/deploy/tests/test_local.py
+++ b/python/vineyard/deploy/tests/test_local.py
@@ -20,9 +20,7 @@ import vineyard
 
 
 def test_local_cluster():
-    client1 = vineyard.init(etcd_prefix='test')
-    client2 = vineyard.init(etcd_prefix='test')
-    client3 = vineyard.init(etcd_prefix='test')
+    client1, client2, client3 = vineyard.init(proc_num=3)
     assert client1 != client2
     assert client1 != client3
     assert client2 != client3
@@ -31,7 +29,6 @@ def test_local_cluster():
     meta2 = client2.get_meta(obj_id)
     meta3 = client3.get_meta(obj_id)
     assert str(meta2) == str(meta3)
-    vineyard.shutdown()
 
 
 def test_local_single():

--- a/python/vineyard/deploy/tests/test_local.py
+++ b/python/vineyard/deploy/tests/test_local.py
@@ -1,0 +1,41 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020-2021 Alibaba Group Holding Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import vineyard
+
+
+def test_local_cluster():
+    client1 = vineyard.init(etcd_prefix='test')
+    client2 = vineyard.init(etcd_prefix='test')
+    client3 = vineyard.init(etcd_prefix='test')
+    assert client1 != client2
+    assert client1 != client3
+    assert client2 != client3
+    obj_id = client1.put([1024, 1024])
+    client1.persist(obj_id)
+    meta2 = client2.get_meta(obj_id)
+    meta3 = client3.get_meta(obj_id)
+    assert str(meta2) == str(meta3)
+    vineyard.shutdown()
+
+
+def test_local_single():
+    client = vineyard.init()
+    obj_id = client.put(1024)
+    assert client.get(obj_id) == 1024
+    vineyard.shutdown()

--- a/python/vineyard/deploy/tests/test_local.py
+++ b/python/vineyard/deploy/tests/test_local.py
@@ -20,7 +20,7 @@ import vineyard
 
 
 def test_local_cluster():
-    client1, client2, client3 = vineyard.init(proc_num=3)
+    client1, client2, client3 = vineyard.init(num_instances=3)
     assert client1 != client2
     assert client1 != client3
     assert client2 != client3
@@ -29,10 +29,14 @@ def test_local_cluster():
     meta2 = client2.get_meta(obj_id)
     meta3 = client3.get_meta(obj_id)
     assert str(meta2) == str(meta3)
+    vineyard.shutdown()
 
 
 def test_local_single():
     client = vineyard.init()
     obj_id = client.put(1024)
-    assert client.get(obj_id) == 1024
+    client1 = vineyard.connect()
+    assert client1.get(obj_id) == 1024
+    client2 = vineyard.get_default_client()
+    assert client == client2
     vineyard.shutdown()


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

In general, the init method handles three scenarios: no vineyardd exists; vineyardd already launched at an IPC socket;
mimic the local cluster mode. While the shutdown method can both close single or all the vineyardds.

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #391 

