### PR TITLE
Fixes the missing header.

### DIFF
--- a/test/hashmap_test.cc
+++ b/test/hashmap_test.cc
@@ -17,6 +17,7 @@ limitations under the License.
 #include <string>
 #include <thread>
 
+#include "arrow/status.h"
 #include "arrow/util/io_util.h"
 #include "arrow/util/logging.h"
 


### PR DESCRIPTION
What do these changes do?
-------------------------

The test case seems failed to compile on Ubuntu with some version of apache arrow. I believe the issue has been fixed in upstream, in later version of apache arrow.

Related issue number
--------------------

N/A

