### PR TITLE
Depends on etcd-distro, and make python3 -m vineyard work.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -77,12 +77,6 @@ jobs:
                               uuid-dev \
                               wget
 
-          # install etcd
-          wget https://github.com/etcd-io/etcd/releases/download/v3.4.13/etcd-v3.4.13-linux-amd64.tar.gz
-          tar zxvf etcd-v3.4.13-linux-amd64.tar.gz
-          sudo mv etcd-v3.4.13-linux-amd64/etcd /usr/local/bin/
-          sudo mv etcd-v3.4.13-linux-amd64/etcdctl /usr/local/bin/
-
           # install apache-arrow
           wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
           sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ Vineyard is designed to solve these issues by providing:
 1. **In-memory** distributed data sharing in a **zero-copy** fashion to avoid
    introducing extra I/O costs by exploiting a shared memory manager derived from plasma.
 
-2. Built-in **out-of-box high-level** abstraction to share the distributed
+2. Built-in **out-of-the-box high-level** abstraction to share the distributed
    data with complex structures (e.g., distributed graphs)
    with nearly zero extra development cost, while the transformation costs are eliminated.
 
@@ -129,7 +129,7 @@ for example tensor could be `torch.tensor`, `tf.Tensor`, `mxnet.ndarray` etc., n
 mention that every `graph processing engine <https://github.com/alibaba/GraphScope>`_
 has its own graph structure representations.
 
-The variety of data abstractions makes the sharing hard. Vineyard provides out-of-box
+The variety of data abstractions makes the sharing hard. Vineyard provides out-of-the-box
 high-level data abstractions over in-memory blobs, by describing objects using hierarchical
 metadatas. Various computation systems can utilize the built-in high level data abstractions
 to exchange data with other systems in computation pipeline in a concise manner.
@@ -154,7 +154,7 @@ between systems such routines cannot be easily reused.
 
 Vineyard provides such common manipulate routines on immutable data as drivers.
 Besides sharing the high level data abstractions, vineyard extends the capability
-of data structures by drivers, enabling out-of-box reusable routines for the
+of data structures by drivers, enabling out-of-the-box reusable routines for the
 boilerplate part in computation jobs.
 
 Integrate with Kubernetes

--- a/charts/vineyard/README.md
+++ b/charts/vineyard/README.md
@@ -3,7 +3,7 @@ vineyard charts
 
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/vineyard)](https://artifacthub.io/packages/helm/vineyard/vineyard)
 
-[Vineyard][3] is an in-memory immutable data manager that provides **out-of-box high-level**
+[Vineyard][3] is an in-memory immutable data manager that provides **out-of-the-box high-level**
 abstraction and **zero-copy in-memory** sharing for distributed data in big data tasks,
 such as numerical computing, machine learning, and graph analytics.
 

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -61,14 +61,6 @@ RUN cd /tmp && \
     pip3 install auditwheel && \
     sed -i 's/p.error/logger.warning/g' /usr/local/lib/python3.8/dist-packages/auditwheel/main_repair.py
 
-# install etcd
-RUN cd /tmp && \
-    wget https://github.com/etcd-io/etcd/releases/download/v3.4.13/etcd-v3.4.13-linux-amd64.tar.gz && \
-    tar zxvf etcd-v3.4.13-linux-amd64.tar.gz && \
-    mv etcd-v3.4.13-linux-amd64/etcd /usr/bin/ && \
-    mv etcd-v3.4.13-linux-amd64/etcdctl /usr/bin/ && \
-    rm -rf /tmp/etcd-v3.4.13-linux-amd64.tar.gz /tmp/etcd-v3.4.13-linux-amd64
-
 # install kubectl
 RUN cd /tmp && \
     wget https://dl.k8s.io/release/v1.19.0/bin/linux/amd64/kubectl && \

--- a/docs/notes/airflow.rst
+++ b/docs/notes/airflow.rst
@@ -142,7 +142,7 @@ Users can try Airflow provider for Vineyard by the following steps:
 
     .. code:: bash
 
-        vineyardd --socket=/tmp/vineyard.sock
+        python -m vineyard --socket=/tmp/vineyard.sock
 
     See also our documentation about `launching vineyard`_.
 

--- a/docs/notes/divein.rst
+++ b/docs/notes/divein.rst
@@ -55,7 +55,7 @@ To address this issue, vineyard provides:
     and start to use the data for computation.
     
 
-2.  Built-in **out-of-box high-level** abstraction to share the distributed 
+2.  Built-in **out-of-the-box high-level** abstraction to share the distributed
     data with complex structures (e.g., distributed graphs) 
     with nearly zero extra development cost, while the transformation costs are eliminated.
 
@@ -250,8 +250,8 @@ these vineyard instances are launched distributively on each machine of the clus
 
 .. code:: console
 
-    $ vineyardd --socket /var/run/vineyard.sock1
-    $ vineyardd --socket /var/run/vineyard.sock2
+    $ python3 -m vineyard --socket /var/run/vineyard.sock1
+    $ python3 -m vineyard --socket /var/run/vineyard.sock2
 
 Then we can create a distributed pair of arrays in vineyard with the
 first array stored in the first vineyard instance which listens to ipc_socket

--- a/docs/notes/getting-started.rst
+++ b/docs/notes/getting-started.rst
@@ -6,7 +6,7 @@ Starting vineyard server
 
 .. code:: console
      
-     $ vineyardd
+     $ python3 -m vineyard
 
 A vineyard daemon server will be launched on the underlying machine with default
 settings. The default ``socket`` is ``/var/run/vineyard.sock``, and it is
@@ -19,7 +19,7 @@ the same ``etcd_endpoint``. The default value of ``etcd_endpoint`` is
 ``http://127.0.0.1:2379``, and ``vineyard`` will launch the ``etcd_endpoint`` 
 in case the etcd servers are not started on the cluster.
 
-Use ``vineyardd --help`` for other parameter settings.
+Use ``python3 -m vineyard --help`` for other parameter settings.
 
 Connecting to vineyard
 ----------------------

--- a/docs/notes/install.rst
+++ b/docs/notes/install.rst
@@ -11,27 +11,6 @@ and can be easily installed with :code:`pip`:
 
     pip3 install vineyard
 
-Install etcd
-------------
-
-Start vineyard requires etcd (>= 3.3.0), a latest version of etcd can be downloaded via
-
-for Ubuntu or (Debian):
-
-.. code:: shell
-
-    wget https://github.com/etcd-io/etcd/releases/download/v3.4.13/etcd-v3.4.13-linux-amd64.tar.gz
-    tar zxvf etcd-v3.4.13-linux-amd64.tar.gz
-    export PATH=etcd-v3.4.13-linux-amd64:$PATH
-
-Or for MacOS:
-
-.. code:: shell
-
-    wget https://github.com/etcd-io/etcd/releases/download/v3.4.13/etcd-v3.4.13-darwin-amd64.zip
-    unzip etcd-v3.4.13-darwin-amd64.zip
-    export PATH=etcd-v3.4.13-darwin-amd64:$PATH
-
 Prepare dependencies
 --------------------
 

--- a/docs/notes/troubleshooting.rst
+++ b/docs/notes/troubleshooting.rst
@@ -83,4 +83,4 @@ could helps you when error occurs.
 
     .. code:: bash
 
-       vineyardd --socket=/tmp/vineyard.sock
+       python3 -m vineyard --socket=/tmp/vineyard.sock

--- a/python/vineyard/__main__.py
+++ b/python/vineyard/__main__.py
@@ -16,25 +16,7 @@
 # limitations under the License.
 #
 
-import subprocess
-import sys
-
-from .utils import find_vineyardd_path
-
-
-def deploy_vineyardd(args):
-    try:
-        vineyardd = find_vineyardd_path()
-        if vineyardd is None:
-            raise RuntimeError("Unable to vineyardd")
-        return subprocess.call([vineyardd] + args)
-    except KeyboardInterrupt:
-        return 0
-
-
-def main():
-    raise SystemExit(deploy_vineyardd(sys.argv[1:]))
-
+from .deploy.__main__ import main
 
 if __name__ == '__main__':
     main()

--- a/python/vineyard/contrib/airflow/README.rst
+++ b/python/vineyard/contrib/airflow/README.rst
@@ -110,7 +110,7 @@ Run the tests
 
     .. code:: bash
 
-        python3 -m vineyard.deploy
+        python3 -m vineyard
 
 2. Set airflow to use the vineyard XCom backend, and run tests with pytest,
 

--- a/python/vineyard/deploy/distributed.py
+++ b/python/vineyard/deploy/distributed.py
@@ -97,8 +97,8 @@ def start_vineyardd(hosts=None,
     ]
     # yapf: enable
 
+    procs = []
     try:
-        procs = []
         for host in hosts:
             proc = subprocess.Popen(ssh_base_cmd(host) + command,
                                     env=env,

--- a/python/vineyard/deploy/etcd.py
+++ b/python/vineyard/deploy/etcd.py
@@ -72,8 +72,8 @@ def start_etcd(host=None, etcd_executable=None, data_dir=None):
     ]
     # yapf: enable
 
+    proc = None
     try:
-        proc = None
         if host is None:
             commands = []
         else:

--- a/python/vineyard/deploy/local.py
+++ b/python/vineyard/deploy/local.py
@@ -122,6 +122,7 @@ def start_vineyardd(etcd_endpoints=None,
     if etcd_prefix is not None:
         command.extend(('--etcd_prefix', etcd_prefix))
 
+    proc = None
     try:
         proc = subprocess.Popen(command,
                                 env=env,

--- a/python/vineyard/io/serialization.py
+++ b/python/vineyard/io/serialization.py
@@ -17,7 +17,6 @@
 #
 
 import logging
-import traceback
 from urllib.parse import urlparse
 
 import vineyard

--- a/setup.py
+++ b/setup.py
@@ -159,6 +159,8 @@ setup(
         'wheel',
     ],
     install_requires=[
+        'argcomplete',
+        "etcd-distro",
         'numpy',
         'pandas<1.0.0; python_version<"3.6"',
         'pandas<1.2.0; python_version<"3.7"',
@@ -169,11 +171,11 @@ setup(
         'shared-memory38; python_version<="3.7"',
         'sortedcontainers',
         'treelib',
-        'argcomplete',
     ],
     extras_require={
         'dev': [
             'breathe',
+            'docutils==0.16',
             'libclang',
             'nbsphinx',
             'parsec',
@@ -183,7 +185,6 @@ setup(
             'pytest-datafiles',
             'sphinx>=3.0.2',
             'sphinx_rtd_theme',
-            'docutils==0.16',
         ],
         "kubernetes": [
             "kubernetes",


### PR DESCRIPTION
What do these changes do?
-------------------------

Vineyard now depends a python package called `etcd-distro` to install etcd without explicit `wget`. Now vineyard can be easy launched by

```python
python3 -m vineyard
```

Related issue number
--------------------

Fixes #520

