### PR TITLE
Fixes resolving pd.DataFrame that has nested columns value.

### DIFF
--- a/python/vineyard/data/dataframe.py
+++ b/python/vineyard/data/dataframe.py
@@ -20,9 +20,17 @@ import numpy as np
 import pandas as pd
 try:
     from pandas.core.internals.blocks import BlockPlacement, NumpyBlock as Block
-except:
+except ImportError:
     BlockPlacement = None
     from pandas.core.internals.blocks import Block
+try:
+    from pandas.core.indexes.base import ensure_index
+except ImportError:
+    try:
+        from pandas.core.indexes.base import _ensure_index as ensure_index
+    except ImportError:
+        from pandas.indexes.base import _ensure_index as ensure_index
+
 from pandas.core.internals.managers import BlockManager
 
 from vineyard._C import Object, ObjectID, ObjectMeta
@@ -87,7 +95,7 @@ def pandas_dataframe_resolver(obj, resolver):
         index = resolver.run(obj.member('index_'))
     else:
         index = pd.RangeIndex(index_size)
-    return pd.DataFrame(BlockManager(blocks, [pd.Index(columns), index]))
+    return pd.DataFrame(BlockManager(blocks, [ensure_index(columns), index]))
 
 
 def pandas_sparse_array_builder(client, value, builder, **kw):

--- a/python/vineyard/data/tests/test_dataframe.py
+++ b/python/vineyard/data/tests/test_dataframe.py
@@ -33,6 +33,13 @@ def test_pandas_dataframe(vineyard_client):
     pd.testing.assert_frame_equal(df, vineyard_client.get(object_id))
 
 
+def test_pandas_dataframe_complex_columns(vineyard_client):
+    # see gh#533
+    df = pd.DataFrame([1, 2, 3, 4], columns=[['x']])
+    object_id = vineyard_client.put(df)
+    pd.testing.assert_frame_equal(df, vineyard_client.get(object_id))
+
+
 def test_pandas_dataframe_int_columns(vineyard_client):
     df = pd.DataFrame({1: [1, 2, 3, 4], 2: [5, 6, 7, 8]})
     object_id = vineyard_client.put(df)


### PR DESCRIPTION

What do these changes do?
-------------------------

When the `columns` is a nested list, use `MultiIndex` instead to keep consistent with `pandas.DataFrame.__init__()`.

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Resolves #533.

