### PR TITLE
Reduce code duplication about how to view dataframe as a recordbatch.

### DIFF
--- a/modules/basic/ds/dataframe.cc
+++ b/modules/basic/ds/dataframe.cc
@@ -42,7 +42,7 @@ const std::pair<size_t, size_t> DataFrame::shape() const {
   }
 }
 
-const std::shared_ptr<arrow::RecordBatch> DataFrame::RecordBatchView() const {
+const std::shared_ptr<arrow::RecordBatch> DataFrame::AsBatch(bool copy) const {
   size_t num_columns = this->Columns().size();
   int64_t num_rows = 0;
   std::vector<std::shared_ptr<arrow::Array>> columns(num_columns);
@@ -57,6 +57,7 @@ const std::shared_ptr<arrow::RecordBatch> DataFrame::RecordBatchView() const {
       field_name = json_to_string(cname);
     }
     auto df_col = this->Column(cname);
+    num_rows = df_col->shape()[0];
 
     if (auto tensor = std::dynamic_pointer_cast<Tensor<int32_t>>(df_col)) {
       num_rows = tensor->shape()[0];
@@ -77,14 +78,19 @@ const std::shared_ptr<arrow::RecordBatch> DataFrame::RecordBatchView() const {
     }
 
     std::shared_ptr<arrow::Buffer> copied_buffer;
+    if (copy) {
 #if defined(ARROW_VERSION) && ARROW_VERSION < 17000
-    CHECK_ARROW_ERROR(
-        df_col->buffer()->Copy(0, df_col->buffer()->size(), &copied_buffer));
+      CHECK_ARROW_ERROR(
+          df_col->buffer()->Copy(0, df_col->buffer()->size(), &copied_buffer));
 #else
-    CHECK_ARROW_ERROR_AND_ASSIGN(
-        copied_buffer,
-        df_col->buffer()->CopySlice(0, df_col->buffer()->size()));
+      CHECK_ARROW_ERROR_AND_ASSIGN(
+          copied_buffer,
+          df_col->buffer()->CopySlice(0, df_col->buffer()->size()));
 #endif
+    } else {
+      copied_buffer = df_col->buffer();
+    }
+
     columns[i] = arrow::MakeArray(arrow::ArrayData::Make(
         FromAnyType(df_col->value_type()), num_rows, {nullptr, copied_buffer}));
     fields[i] = std::make_shared<arrow::Field>(

--- a/modules/basic/ds/dataframe.vineyard-mod
+++ b/modules/basic/ds/dataframe.vineyard-mod
@@ -88,7 +88,7 @@ class DataFrame : public Registered<DataFrame> {
   /**
    * @brief Get a RecordBatch view for the dataframe.
    */
-  const std::shared_ptr<arrow::RecordBatch> RecordBatchView() const;
+  const std::shared_ptr<arrow::RecordBatch> AsBatch(bool copy = false) const;
 
  private:
   __attribute__((annotate("codegen"))) size_t partition_index_row_;

--- a/modules/basic/stream/dataframe_stream.vineyard-mod
+++ b/modules/basic/stream/dataframe_stream.vineyard-mod
@@ -65,16 +65,16 @@ class __attribute__((annotate("no-vineyard"))) DataframeStreamWriter {
     return client_.StopStream(id_, false);
   }
 
-  Status WriteTable(std::shared_ptr<arrow::Table>& table) {
+  Status WriteTable(std::shared_ptr<arrow::Table> table) {
     std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
     RETURN_ON_ERROR(TableToRecordBatches(table, &batches));
-    for (auto batch : batches) {
+    for (auto const& batch : batches) {
       RETURN_ON_ERROR(WriteBatch(batch));
     }
     return Status::OK();
   }
 
-  Status WriteBatch(std::shared_ptr<arrow::RecordBatch>& batch) {
+  Status WriteBatch(std::shared_ptr<arrow::RecordBatch> batch) {
     size_t size = 0;
     RETURN_ON_ERROR(GetRecordBatchStreamSize(*batch, &size));
     std::unique_ptr<arrow::MutableBuffer> buffer;
@@ -97,40 +97,8 @@ class __attribute__((annotate("no-vineyard"))) DataframeStreamWriter {
     return Status::OK();
   }
 
-  Status WriteDataframe(std::shared_ptr<DataFrame>& df) {
-    size_t num_columns = df->Columns().size();
-    int64_t num_rows = 0;
-    std::vector<std::shared_ptr<arrow::Array>> columns(num_columns);
-    std::vector<std::shared_ptr<arrow::Field>> fields(num_columns);
-    for (size_t i = 0; i < num_columns; ++i) {
-      // cast to arrow::Array
-      auto cname = df->Columns()[i];
-      std::string field_name;
-      if (cname.is_string()) {
-        field_name = cname.get_ref<std::string const&>();
-      } else {
-        field_name = json_to_string(cname);
-      }
-      auto df_col = df->Column(cname);
-      num_rows = df_col->shape()[0];
-      std::shared_ptr<arrow::Buffer> copied_buffer;
-#if defined(ARROW_VERSION) && ARROW_VERSION < 17000
-      RETURN_ON_ARROW_ERROR(
-          df_col->buffer()->Copy(0, df_col->buffer()->size(), &copied_buffer));
-#else
-      RETURN_ON_ARROW_ERROR_AND_ASSIGN(
-          copied_buffer,
-          df_col->buffer()->CopySlice(0, df_col->buffer()->size()));
-#endif
-      columns[i] = arrow::MakeArray(
-          arrow::ArrayData::Make(FromAnyType(df_col->value_type()), num_rows,
-                                 {nullptr, copied_buffer}));
-      fields[i] = std::make_shared<arrow::Field>(
-          field_name, FromAnyType(df_col->value_type()));
-    }
-    auto batch =
-        arrow::RecordBatch::Make(arrow::schema(fields), num_rows, columns);
-    return WriteBatch(batch);
+  Status WriteDataframe(std::shared_ptr<DataFrame> df) {
+    return WriteBatch(df->AsBatch());
   }
 
   DataframeStreamWriter(Client& client, ObjectID const& id,

--- a/modules/graph/loader/arrow_fragment_loader.h
+++ b/modules/graph/loader/arrow_fragment_loader.h
@@ -108,7 +108,7 @@ inline Status ReadRecordBatchesFromVineyardDataFrame(
   int start_to_read = part_id * split_size;
   int end_to_read = std::min(local_chunks.size(), (part_id + 1) * split_size);
   for (int idx = start_to_read; idx != end_to_read; ++idx) {
-    batches.emplace_back(local_chunks[idx]->RecordBatchView());
+    batches.emplace_back(local_chunks[idx]->AsBatch(true));
   }
   return Status::OK();
 }
@@ -197,7 +197,7 @@ inline Status ReadTableFromVineyardDataFrame(
   std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
   batches.reserve(end_to_read - start_to_read);
   for (int idx = start_to_read; idx != end_to_read; ++idx) {
-    batches.emplace_back(local_chunks[idx]->RecordBatchView());
+    batches.emplace_back(local_chunks[idx]->AsBatch(true));
   }
   if (batches.empty()) {
     table = nullptr;


### PR DESCRIPTION

What do these changes do?
-------------------------

Rename the `RecordBatchView` as `AsBatch`, and remove the duplication code in the stream module.

Related issue number
--------------------

Caught during working on #430 

