### PR TITLE
Disable the not-enough-shared-memory warnings on Mac.

### DIFF
--- a/src/server/memory/allocator.cc
+++ b/src/server/memory/allocator.cc
@@ -53,11 +53,18 @@ BulkAllocator::Allocator BulkAllocator::allocator_{};
 #endif
 
 void* BulkAllocator::Init(const size_t size) {
+#if __linux__
+  // Seems that mac os doesn't respect the sysctl configuration.
+  //
+  // Vineyard actually can use shared memory larger than the the sysctl result,
+  // we disable the warning on mac for less inaccurate warnings.
   int64_t shmmax = get_maximum_shared_memory();
   if (shmmax < static_cast<float>(size)) {
     LOG(WARNING) << "'size' is greater than the maximum shared memory size ("
                  << shmmax << ")";
   }
+#endif
+
 #if defined(WITH_DLMALLOC)
   return Allocator::Init(size);
 #endif


### PR DESCRIPTION
What do these changes do?
-------------------------

It seems incorrect and the default `sysctl` value is too small, but we actually can use more shared memory segments.

Related issue number
--------------------

None.

