### PR TITLE
Add preliminary support for fuse on vineyard objects.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -52,8 +52,10 @@ jobs:
                               ccache \
                               cmake \
                               doxygen \
+                              fuse3 \
                               libboost-all-dev \
                               libcurl4-openssl-dev \
+                              libfuse3-dev \
                               libgflags-dev \
                               libgoogle-glog-dev \
                               libgmock-dev \
@@ -81,7 +83,7 @@ jobs:
           wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
           sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
           sudo apt update
-          sudo apt install -y libarrow-dev=3.0.0-1 libarrow-python-dev=3.0.0-1
+          sudo apt install -y libarrow-dev=3.0.0-1 libparquet-dev=3.0.0-1 libarrow-python-dev=3.0.0-1
 
           # install pyarrow from scratch
           sudo pip3 install --no-binary pyarrow pyarrow==3.0.0
@@ -180,6 +182,8 @@ jobs:
                    -DBUILD_VINEYARD_IO=ON \
                    -DBUILD_VINEYARD_IO_KAFKA=ON \
                    -DBUILD_VINEYARD_MIGRATION=ON \
+                   -DBUILD_VINEYARD_FUSE=ON \
+                   -DBUILD_VINEYARD_FUSE_PARQUET=ON \
                    -DBUILD_VINEYARD_TESTS=ON
 
       - name: Cpp format and lint

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ option(BUILD_VINEYARD_IO "Enable vineyard's IOAdaptor support" ON)
 option(BUILD_VINEYARD_GRAPH "Enable vineyard's graph data structures" ON)
 option(BUILD_VINEYARD_MALLOC "Build vineyard's implementation for client-side malloc" ON)
 option(BUILD_VINEYARD_MIGRATION "Enable vineyard's object migration support" ON)
+option(BUILD_VINEYARD_FUSE "Enable vineyard's fuse support" OFF)
+option(BUILD_VINEYARD_FUSE_PARQUET "Enable vineyard's fuse parquet support" OFF)
 
 option(BUILD_VINEYARD_TESTS "Generate make targets for vineyard tests" ON)
 option(BUILD_VINEYARD_TESTS_ALL "Include make targets for vineyard tests to ALL" OFF)
@@ -142,7 +144,7 @@ else()
 endif()
 
 macro(find_apache_arrow)
-    # workaround for: https://issues.apache.org/jira/projects/ARROW/issues/ARROW-11836
+    # workaround for: https://issues.apache.org/jira/browse/ARROW-11836
     if(NOT BUILD_VINEYARD_PYPI_PACKAGES)
       find_package(Arrow QUIET)
     endif()
@@ -192,6 +194,16 @@ macro(find_etcd_cpp_apiv3)
         include("cmake/BuildEtcdCpp.cmake")
     endif()
 endmacro(find_etcd_cpp_apiv3)
+
+macro(find_fuse)
+    include("cmake/FindFUSE3.cmake")
+    if(BUILD_VINEYARD_FUSE_PARQUET)
+        if(NOT ARROW_PARQUET)
+            message(FATAL_ERROR "Parquet is not enabled in the installed arrow.")
+        endif()
+        find_package(Parquet REQUIRED HINTS ${Arrow_DIR})
+    endif()
+endmacro()
 
 macro(find_intel_tbb)
     set(TBB_TEST OFF CACHE BOOL "Disable tbb testing")
@@ -379,6 +391,14 @@ set(VINEYARD_INSTALL_LIBS)
 # resolve targets dependencies
 if(BUILD_VINEYARD_PYPI_PACKAGES)
     set(BUILD_VINEYARD_PYTHON_BINDINGS ON)
+endif()
+
+if(BUILD_VINEYARD_FUSE_PARQUET)
+    set(BUILD_VINEYARD_FUSE ON)
+endif()
+
+if(BUILD_VINEYARD_FUSE)
+    set(BUILD_VINEYARD_BASIC ON)
 endif()
 
 if(BUILD_VINEYARD_GRAPH)
@@ -595,6 +615,12 @@ if(BUILD_VINEYARD_MIGRATION)
     # don't includes vineyard_migrate to "VINEYARD_LIBRARIES"
 endif()
 
+if(BUILD_VINEYARD_FUSE)
+    find_fuse()
+    add_subdirectory(modules/fuse)
+    list(APPEND VINEYARD_INSTALL_LIBS vineyard_fuse)
+endif()
+
 if(BUILD_VINEYARD_TESTS)
     enable_testing()
     file(GLOB TEST_FILES RELATIVE "${PROJECT_SOURCE_DIR}/test"
@@ -706,8 +732,11 @@ install(PROGRAMS "${VINEYARD_CODEGEN_SCRIPT}"
 install(FILES "${PROJECT_BINARY_DIR}/vineyard-config.cmake"
               "${PROJECT_BINARY_DIR}/vineyard-config-version.cmake"
               "${PROJECT_SOURCE_DIR}/cmake/FindArrow.cmake"
+              "${PROJECT_SOURCE_DIR}/cmake/FindFUSE3.cmake"
               "${PROJECT_SOURCE_DIR}/cmake/FindGFlags.cmake"
               "${PROJECT_SOURCE_DIR}/cmake/FindGlog.cmake"
+              "${PROJECT_SOURCE_DIR}/cmake/FindGperftools.cmake"
+              "${PROJECT_SOURCE_DIR}/cmake/FindLibUnwind.cmake"
               "${PROJECT_SOURCE_DIR}/cmake/FindRdkafka.cmake"
               "${PROJECT_SOURCE_DIR}/cmake/GenerateVineyard.cmake"
               "${PROJECT_SOURCE_DIR}/cmake/DetermineImplicitIncludes.cmake"

--- a/cmake/FindFUSE3.cmake
+++ b/cmake/FindFUSE3.cmake
@@ -1,0 +1,63 @@
+# This file is used to find fuse3 library in CMake script, based on code
+# from
+#
+#   https://github.com/fkie-cad/pcapFS/blob/master/cmake/Modules/FindFUSE3.cmake
+#
+# which is licensed under the MIT License.
+#
+# FindFUSE3.cmake
+#
+# Finds the FUSE3 library.
+#
+# This will define the following variables
+#
+#    FUSE3_FOUND
+#    FUSE3_INCLUDE_DIRS
+#    FUSE3_LIBRARIES
+#    FUSE3_VERSION
+#
+# and the following imported targets
+#
+#    FUSE3::FUSE3
+#
+
+if(FUSE3_INCLUDE_DIR AND FUSE3_LIBRARY)
+    set(FUSE_FIND_QUIETLY TRUE)
+endif()
+
+find_package(PkgConfig)
+pkg_check_modules(PC_FUSE3 REQUIRED QUIET fuse3)
+
+find_path(FUSE3_INCLUDE_DIR
+          NAMES fuse_lowlevel.h
+          PATHS "${PC_FUSE3_INCLUDE_DIRS}"
+          PATH_SUFFIXES fuse3
+)
+
+find_library(FUSE3_LIBRARY
+             NAMES fuse3
+             PATHS "${PC_FUSE3_LIBDIR}"
+)
+
+set(FUSE3_VERSION "${PC_FUSE3_VERSION}")
+
+mark_as_advanced(FUSE3_INCLUDE_DIR FUSE3_LIBRARY)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(FUSE3
+    REQUIRED_VARS FUSE3_INCLUDE_DIR FUSE3_LIBRARY
+    VERSION_VAR FUSE3_VERSION_STRING
+)
+
+if(FUSE_FOUND)
+    set(FUSE_INCLUDE_DIRS ${FUSE_INCLUDE_DIR})
+    set(FUSE_LIBRARIES ${FUSE_LIBRARY})
+endif()
+
+if(FUSE3_FOUND AND NOT TARGET FUSE::FUSE)
+    add_library(FUSE3::FUSE3 INTERFACE IMPORTED)
+    set_target_properties(FUSE3::FUSE3 PROPERTIES
+                          INTERFACE_INCLUDE_DIRECTORIES "${FUSE3_INCLUDE_DIR}"
+                          INTERFACE_LINK_LIBRARIES "${FUSE3_LIBRARY}"
+    )
+endif()

--- a/modules/fuse/CMakeLists.txt
+++ b/modules/fuse/CMakeLists.txt
@@ -1,0 +1,51 @@
+# build vineyard-fuse
+set(FUSE_SRC_FILES)
+list(APPEND FUSE_SRC_FILES "fused.cc")
+list(APPEND FUSE_SRC_FILES "adaptors/orc.cc")
+list(APPEND FUSE_SRC_FILES "adaptors/parquet.cc")
+
+add_library(vineyard_fuse ${FUSE_SRC_FILES})
+target_link_libraries(vineyard_fuse PUBLIC vineyard_client
+                                           vineyard_basic
+                                           ${ARROW_SHARED_LIB}
+)
+target_link_libraries(vineyard_fuse PUBLIC FUSE3::FUSE3)
+if(BUILD_VINEYARD_FUSE_PARQUET)
+    target_compile_options(vineyard_fuse PUBLIC -DWITH_PARQUET)
+    if(TARGET parquet_shared)
+        target_link_libraries(vineyard_fuse PUBLIC parquet_shared)
+    elseif(TARGET parquet_static)
+        target_link_libraries(vineyard_fuse PUBLIC parquet_static)
+    endif()
+endif()
+
+install_vineyard_target(vineyard_fuse)
+install_vineyard_headers("${CMAKE_CURRENT_SOURCE_DIR}")
+
+add_executable(vineyard-fusermount fusermount.cc)
+target_link_libraries(vineyard-fusermount PRIVATE vineyard_fuse)
+install_vineyard_target(vineyard-fusermount)
+
+if(BUILD_VINEYARD_TESTS)
+    enable_testing()
+    file(GLOB TEST_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}/test" "${CMAKE_CURRENT_SOURCE_DIR}/test/*.cc")
+    foreach(f ${TEST_FILES})
+        string(REGEX MATCH "^(.*)\\.[^.]*$" dummy ${f})
+        set(T_NAME ${CMAKE_MATCH_1})
+        message(STATUS "Found unit_test - " ${T_NAME})
+        if(BUILD_VINEYARD_TESTS_ALL)
+            add_executable(${T_NAME} test/${T_NAME}.cc)
+        else()
+            add_executable(${T_NAME} EXCLUDE_FROM_ALL test/${T_NAME}.cc)
+        endif()
+        target_link_libraries(${T_NAME} PRIVATE
+                              vineyard_fuse
+                              ${ARROW_SHARED_LIB}
+                              ${MPI_CXX_LIBRARIES})
+        if(${LIBUNWIND_FOUND})
+            target_link_libraries(${T_NAME} PRIVATE ${LIBUNWIND_LIBRARIES})
+        endif()
+        add_test(${T_NAME}, ${T_NAME})
+        add_dependencies(vineyard_tests ${T_NAME})
+    endforeach()
+endif()

--- a/modules/fuse/adaptors/formats.h
+++ b/modules/fuse/adaptors/formats.h
@@ -1,0 +1,22 @@
+/** Copyright 2020-2021 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef MODULES_FUSE_ADAPTORS_FORMATS_H_
+#define MODULES_FUSE_ADAPTORS_FORMATS_H_
+
+#include "fuse/adaptors/orc.h"
+#include "fuse/adaptors/parquet.h"
+
+#endif  // MODULES_FUSE_ADAPTORS_FORMATS_H_

--- a/modules/fuse/adaptors/orc.cc
+++ b/modules/fuse/adaptors/orc.cc
@@ -1,0 +1,30 @@
+/** Copyright 2020-2021 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "fuse/adaptors/orc.h"
+
+#if defined(WITH_ORC)
+
+#include "parquet/file_writer.h"
+
+namespace vineyard {
+namespace fuse {
+
+void orc_view(std::shared_ptr<vineyard::DataFrame>& df) {}
+
+}  // namespace fuse
+}  // namespace vineyard
+
+#endif

--- a/modules/fuse/adaptors/orc.h
+++ b/modules/fuse/adaptors/orc.h
@@ -1,0 +1,36 @@
+/** Copyright 2020-2021 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef MODULES_FUSE_ADAPTORS_ORC_H_
+#define MODULES_FUSE_ADAPTORS_ORC_H_
+
+#if defined(WITH_ORC)
+
+#include <memory>
+
+#include "basic/ds/dataframe.h"
+#include "client/client.h"
+
+namespace vineyard {
+namespace fuse {
+
+void orc_view(std::shared_ptr<vineyard::DataFrame>& df);
+
+}  // namespace fuse
+}  // namespace vineyard
+
+#endif
+
+#endif  // MODULES_FUSE_ADAPTORS_ORC_H_

--- a/modules/fuse/adaptors/parquet.cc
+++ b/modules/fuse/adaptors/parquet.cc
@@ -1,0 +1,62 @@
+/** Copyright 2020-2021 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "fuse/adaptors/parquet.h"
+
+#if defined(WITH_PARQUET)
+
+#include <limits>
+#include <memory>
+
+#include "arrow/io/memory.h"
+#include "arrow/util/logging.h"
+#include "parquet/api/reader.h"
+#include "parquet/api/schema.h"
+#include "parquet/api/writer.h"
+#include "parquet/arrow/reader.h"
+#include "parquet/arrow/schema.h"
+#include "parquet/arrow/writer.h"
+
+namespace vineyard {
+namespace fuse {
+
+std::shared_ptr<arrow::Buffer> parquet_view(
+    std::shared_ptr<vineyard::DataFrame>& df) {
+  // Add writer properties
+  ::parquet::WriterProperties::Builder builder;
+  builder.encoding(::parquet::Encoding::PLAIN);
+  builder.disable_dictionary();
+  builder.compression(::parquet::Compression::UNCOMPRESSED);
+  builder.disable_statistics();
+  builder.write_batch_size(std::numeric_limits<size_t>::max());
+  builder.max_row_group_length(std::numeric_limits<size_t>::max());
+  std::shared_ptr<::parquet::WriterProperties> props = builder.build();
+
+  auto batch = df->AsBatch(false);
+  std::shared_ptr<arrow::Table> table;
+  VINEYARD_CHECK_OK(RecordBatchesToTable({batch}, &table));
+  std::shared_ptr<arrow::io::BufferOutputStream> sink;
+  CHECK_ARROW_ERROR_AND_ASSIGN(sink, arrow::io::BufferOutputStream::Create());
+  ::parquet::arrow::WriteTable(*table, arrow::default_memory_pool(), sink,
+                               std::numeric_limits<size_t>::max(), props);
+  std::shared_ptr<arrow::Buffer> buffer;
+  CHECK_ARROW_ERROR_AND_ASSIGN(buffer, sink->Finish());
+  return buffer;
+}
+
+}  // namespace fuse
+}  // namespace vineyard
+
+#endif

--- a/modules/fuse/adaptors/parquet.h
+++ b/modules/fuse/adaptors/parquet.h
@@ -1,0 +1,37 @@
+/** Copyright 2020-2021 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef MODULES_FUSE_ADAPTORS_PARQUET_H_
+#define MODULES_FUSE_ADAPTORS_PARQUET_H_
+
+#if defined(WITH_PARQUET)
+
+#include <memory>
+
+#include "basic/ds/dataframe.h"
+#include "client/client.h"
+
+namespace vineyard {
+namespace fuse {
+
+std::shared_ptr<arrow::Buffer> parquet_view(
+    std::shared_ptr<vineyard::DataFrame>& df);
+
+}  // namespace fuse
+}  // namespace vineyard
+
+#endif
+
+#endif  // MODULES_FUSE_ADAPTORS_PARQUET_H_

--- a/modules/fuse/fused.cc
+++ b/modules/fuse/fused.cc
@@ -1,0 +1,175 @@
+/** Copyright 2020-2021 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "fuse/fused.h"
+
+#include <limits>
+#include <unordered_map>
+
+#include "basic/ds/array.h"
+#include "basic/ds/dataframe.h"
+#include "client/client.h"
+#include "client/ds/blob.h"
+#include "client/ds/i_object.h"
+#include "common/util/logging.h"
+#include "common/util/uuid.h"
+#include "fuse/adaptors/formats.h"
+
+namespace vineyard {
+
+namespace fuse {
+
+struct fs::fs_state_t fs::state {};
+
+int fs::fuse_getattr(const char* path, struct stat* stbuf,
+                     struct fuse_file_info*) {
+  VLOG(2) << "fuse: getattr on " << path;
+
+  memset(stbuf, 0, sizeof(struct stat));
+  if (strcmp(path, "/") == 0) {
+    stbuf->st_mode = S_IFDIR | 0755;
+    stbuf->st_nlink = 2;
+    return 0;
+  }
+  auto id = ObjectIDFromString(path + 1);
+  bool exists = false;
+  VINEYARD_CHECK_OK(state.client->Exists(id, exists));
+  if (!exists) {
+    return -ENOENT;
+  }
+
+  stbuf->st_mode = S_IFREG | 0444;
+  stbuf->st_nlink = 1;
+  stbuf->st_size = 0;  // not used, as we use `direct_io` in `open`.
+  return 0;
+}
+
+int fs::fuse_open(const char* path, struct fuse_file_info* fi) {
+  VLOG(2) << "fuse: open " << path << " with mode " << fi->flags;
+
+  if ((fi->flags & O_ACCMODE) != O_RDONLY) {
+    return -EACCES;
+  }
+  auto target = ObjectIDFromString(path + 1);
+  auto object = state.client->GetObject<vineyard::DataFrame>(target);
+  if (object == nullptr) {
+    return -ENOENT;
+  }
+  auto loc = state.views.find(target);
+  if (loc == state.views.end()) {
+    state.views[target] = fuse::parquet_view(object);
+  }
+  // bypass kernel's page cache to avoid knowing the size in `getattr`.
+  //
+  // see also:
+  // https://stackoverflow.com/questions/46267972/fuse-avoid-calculating-size-in-getattr
+  fi->direct_io = 1;
+  return 0;
+}
+
+int fs::fuse_read(const char* path, char* buf, size_t size, off_t offset,
+                  struct fuse_file_info* fi) {
+  VLOG(2) << "fuse: read " << path << " from " << offset << ", expect " << size
+          << " bytes";
+
+  auto target = ObjectIDFromString(path + 1);
+  auto loc = state.views.find(target);
+  if (loc == state.views.end()) {
+    return -ENOENT;
+  }
+  auto buffer = loc->second;
+  if (offset >= buffer->size()) {
+    return 0;
+  } else {
+    size_t slice = size;
+    if (slice > static_cast<size_t>(buffer->size() - offset)) {
+      slice = buffer->size() - offset;
+    }
+    memcpy(buf, buffer->data() + offset, slice);
+    return slice;
+  }
+}
+
+int fs::fuse_release(const char* path, struct fuse_file_info*) {
+  VLOG(2) << "fuse: release " << path;
+
+  auto target = ObjectIDFromString(path + 1);
+  auto loc = state.views.find(target);
+  if (loc == state.views.end()) {
+    return -ENOENT;
+  }
+  state.views.erase(loc);
+  return 0;
+}
+
+int fs::fuse_statfs(const char* path, struct statvfs*) {
+  VLOG(2) << "fuse: statfs " << path;
+  return 0;
+}
+
+int fs::fuse_opendir(const char* path, struct fuse_file_info* info) {
+  VLOG(2) << "fuse: opendir " << path;
+  return 0;
+}
+
+int fs::fuse_readdir(const char* path, void* buf, fuse_fill_dir_t filler,
+                     off_t offset, struct fuse_file_info* fi,
+                     enum fuse_readdir_flags flags) {
+  VLOG(2) << "fuse: readdir " << path;
+
+  if (strcmp(path, "/") != 0) {
+    return -ENOENT;
+  }
+
+  filler(buf, ".", NULL, 0, fuse_fill_dir_flags::FUSE_FILL_DIR_PLUS);
+  filler(buf, "..", NULL, 0, fuse_fill_dir_flags::FUSE_FILL_DIR_PLUS);
+
+  std::unordered_map<ObjectID, json> metas{};
+  VINEYARD_CHECK_OK(state.client->ListData(
+      "vineyard::DataFrame", false, std::numeric_limits<size_t>::max(), metas));
+  for (auto const& item : metas) {
+    std::string base = ObjectIDToString(item.first).c_str();
+    filler(buf, base.c_str(), NULL, 0, fuse_fill_dir_flags::FUSE_FILL_DIR_PLUS);
+  }
+  return 0;
+}
+
+void* fs::fuse_init(struct fuse_conn_info* conn, struct fuse_config* cfg) {
+  VLOG(2) << "fuse: initfs with vineyard socket " << state.vineyard_socket;
+
+  state.client.reset(new vineyard::Client());
+  state.client->Connect(state.vineyard_socket);
+
+  (void) conn;
+  cfg->kernel_cache = 0;
+  return NULL;
+}
+
+void fs::fuse_destroy(void* private_data) {
+  VLOG(2) << "fuse: destroy";
+
+  state.views.clear();
+  state.client->Disconnect();
+}
+
+int fs::fuse_access(const char* path, int mode) {
+  VLOG(2) << "fuse: access " << path << " with mode " << mode;
+
+  return mode;
+}
+
+}  // namespace fuse
+
+}  // namespace vineyard

--- a/modules/fuse/fused.h
+++ b/modules/fuse/fused.h
@@ -1,0 +1,77 @@
+/** Copyright 2020-2021 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef MODULES_FUSE_FUSED_H_
+#define MODULES_FUSE_FUSED_H_
+
+#include <memory>
+#include <ostream>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#define FUSE_USE_VERSION 32
+#include "fuse3/fuse.h"
+#include "fuse3/fuse_lowlevel.h"
+
+#include "client/client.h"
+
+namespace arrow {
+class Buffer;
+}
+
+namespace vineyard {
+
+namespace fuse {
+
+struct fs {
+  static struct fs_state_t {
+    std::string vineyard_socket;
+    std::shared_ptr<Client> client;
+    std::unordered_map<ObjectID, std::shared_ptr<arrow::Buffer>> views;
+  } state;
+
+  static int fuse_getattr(const char* path, struct stat* stbuf,
+                          struct fuse_file_info*);
+
+  static int fuse_open(const char* path, struct fuse_file_info* fi);
+
+  static int fuse_read(const char* path, char* buf, size_t size, off_t offset,
+                       struct fuse_file_info* fi);
+
+  static int fuse_release(const char* path, struct fuse_file_info*);
+
+  static int fuse_statfs(const char* path, struct statvfs*);
+
+  static int fuse_opendir(const char* path, struct fuse_file_info* info);
+
+  static int fuse_readdir(const char* path, void* buf, fuse_fill_dir_t filler,
+                          off_t offset, struct fuse_file_info* fi,
+                          enum fuse_readdir_flags flags);
+
+  static void* fuse_init(struct fuse_conn_info* conn, struct fuse_config* cfg);
+
+  static void fuse_destroy(void* private_data);
+
+  static int fuse_access(const char* path, int mode);
+};
+
+}  // namespace fuse
+
+}  // namespace vineyard
+
+#endif  // MODULES_FUSE_FUSED_H_

--- a/modules/fuse/fusermount.cc
+++ b/modules/fuse/fusermount.cc
@@ -1,0 +1,118 @@
+/** Copyright 2020-2021 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <stdio.h>
+
+#include <limits>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "common/util/env.h"
+#include "fuse/fused.h"
+
+/*
+ * Command line options
+ *
+ * Don't set default values for the char* fields here because fuse_opt_parse
+ * would attempt to free() them when the user specifies different values on the
+ * command line.
+ */
+static struct options {
+  const char* vineyard_socket;
+  int show_help;
+} options;
+
+#define OPTION(t, p) \
+  { t, offsetof(struct options, p), 1 }
+
+static const struct fuse_opt option_spec[] = {
+    OPTION("--vineyard-socket=%s", vineyard_socket),
+    OPTION("--help", show_help), OPTION("-h", show_help), FUSE_OPT_END};
+
+static void print_help(const char* progname) {
+  printf("usage: %s [options] <mountpoint>\n\n", progname);
+  printf(
+      "Vineyard specific options:\n"
+      "    --vineyard-socket=<s>  Path of UNIX-domain socket of vineyard "
+      "server\n"
+      "                           (default: \"$VINEYARD_IPC_SOCKET\")\n"
+      "\n");
+}
+
+static int process_args(struct fuse_args& args, int argc, char** argv) {
+  // Set defaults -- we have to use strdup so that fuse_opt_parse can free
+  // the defaults if other values are specified.
+  std::string env = vineyard::read_env("VINEYARD_IPC_SOCKET");
+  options.vineyard_socket = strdup(env.c_str());
+
+  /* Parse options */
+  if (fuse_opt_parse(&args, &options, option_spec, NULL) == -1) {
+    LOG(ERROR) << "Failed to parse command line options.";
+    print_help(argv[0]);
+    return 1;
+  }
+
+  /* When --help is specified, first print our own file-system
+     specific help text, then signal fuse_main to show
+     additional help (by adding `--help` to the options again)
+     without usage: line (by setting argv[0] to the empty
+     string) */
+  if (options.show_help) {
+    print_help(argv[0]);
+    assert(fuse_opt_add_arg(&args, "--help") == 0);
+    args.argv[0][0] = '\0';
+  }
+
+  // force running as foreground mode
+  assert(fuse_opt_add_arg(&args, "-f") == 0);
+
+  // populate state
+  vineyard::fuse::fs::state.vineyard_socket = options.vineyard_socket;
+  return 0;
+}
+
+static const struct fuse_operations vineyard_fuse_operations = {
+    .getattr = vineyard::fuse::fs::fuse_getattr,
+    .open = vineyard::fuse::fs::fuse_open,
+    .read = vineyard::fuse::fs::fuse_read,
+    .statfs = vineyard::fuse::fs::fuse_statfs,
+    .release = vineyard::fuse::fs::fuse_release,
+    .opendir = vineyard::fuse::fs::fuse_opendir,
+    .readdir = vineyard::fuse::fs::fuse_readdir,
+    .init = vineyard::fuse::fs::fuse_init,
+    .destroy = vineyard::fuse::fs::fuse_destroy,
+    .access = vineyard::fuse::fs::fuse_access,
+};
+
+int main(int argc, char* argv[]) {
+  // restore the default signal handling, when "vineyard-fusermount" is
+  // launched inside a bash script.
+  sigset(SIGINT, SIG_DFL);
+
+  FLAGS_stderrthreshold = 0;
+  vineyard::logging::InitGoogleLogging("vineyard");
+  vineyard::logging::InstallFailureSignalHandler();
+
+  struct fuse_args args = FUSE_ARGS_INIT(argc, argv);
+  int ret = process_args(args, argc, argv);
+  if (ret != 0) {
+    return ret;
+  }
+  LOG(INFO) << "Starting vineyard fuse driver ...";
+  ret = fuse_main(args.argc, args.argv, &vineyard_fuse_operations, NULL);
+  fuse_opt_free_args(&args);
+  return ret;
+}

--- a/modules/fuse/test/fuse_test.cc
+++ b/modules/fuse/test/fuse_test.cc
@@ -1,0 +1,38 @@
+/** Copyright 2020-2021 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <stdio.h>
+
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "arrow/status.h"
+#include "arrow/util/io_util.h"
+#include "arrow/util/logging.h"
+
+#include "basic/ds/array.h"
+#include "client/client.h"
+#include "client/ds/object_meta.h"
+#include "common/util/logging.h"
+#include "fuse/fused.h"
+
+using namespace vineyard;  // NOLINT(build/namespaces)
+
+int main() {
+  printf("%d%d\n", FUSE_MAJOR_VERSION, FUSE_MINOR_VERSION);
+  printf("%d\n", fuse_version());
+  return 0;
+}

--- a/test/runner.py
+++ b/test/runner.py
@@ -233,6 +233,7 @@ def run_single_vineyardd_tests():
         run_test('server_status_test')
         run_test('signature_test')
         run_test('shallow_copy_test')
+        run_test('shared_memory_test')
         run_test('deep_copy_test')
         run_test('stream_test')
         run_test('tensor_test')


### PR DESCRIPTION
What do these changes do?
-------------------------

The vineyard server can be mounted as

```
export VINEYARD_IPC_SOCKET=/tmp/vineyard.sock

./bin/vineyard-fusermount `pwd`/vineyard-fs
```

Here the ``pwd`/vineyard-fs` is the mount point.

Related issue number
--------------------

Fixes #430.

