### PR TITLE
Enhance the assertion on typename for better error message.

### DIFF
--- a/python/vineyard/core/codegen.py
+++ b/python/vineyard/core/codegen.py
@@ -368,7 +368,9 @@ construct_tpl = '''
 {class_header}
 void {class_name_elaborated}::Construct(const ObjectMeta &meta) {{
     std::string __type_name = type_name<{class_name_elaborated}>();
-    CHECK(meta.GetTypeName() == __type_name);
+    VINEYARD_ASSERT(
+        meta.GetTypeName() == __type_name,
+        "Expect typename '" + __type_name + "', but got '" + meta.GetTypeName() + "'");
     this->meta_ = meta;
     this->id_ = meta.GetId();
 


### PR DESCRIPTION

What do these changes do?
-------------------------

The "Check failed: meta.TypeName() == __type_name" message doesn't make any sense.

Related issue number
--------------------

None

