### PR TITLE
Add more helpers in arrow utils.

### DIFF
--- a/modules/basic/ds/arrow_utils.cc
+++ b/modules/basic/ds/arrow_utils.cc
@@ -259,6 +259,11 @@ Status EmptyTableBuilder::Build(const std::shared_ptr<arrow::Schema>& schema,
   return Status::OK();
 }
 
+std::shared_ptr<arrow::Schema> EmptyTableBuilder::EmptySchema() {
+  return std::shared_ptr<arrow::Schema>(
+      new arrow::Schema({}, arrow::Endianness::Native));
+}
+
 std::shared_ptr<arrow::DataType> type_name_to_arrow_type(
     const std::string& name) {
   if (name == "bool") {

--- a/modules/basic/ds/arrow_utils.h
+++ b/modules/basic/ds/arrow_utils.h
@@ -31,6 +31,7 @@ limitations under the License.
 #include "arrow/ipc/writer.h"
 #include "arrow/table.h"
 #include "arrow/table_builder.h"
+#include "arrow/type.h"
 #include "arrow/util/config.h"
 #include "glog/logging.h"
 
@@ -208,6 +209,8 @@ Status DeserializeTable(std::shared_ptr<arrow::Buffer> buffer,
 struct EmptyTableBuilder {
   static Status Build(const std::shared_ptr<arrow::Schema>& schema,
                       std::shared_ptr<arrow::Table>& table);
+
+  static std::shared_ptr<arrow::Schema> EmptySchema();
 };
 
 /**


### PR DESCRIPTION


What do these changes do?
-------------------------

`EmptyTableBuilder::EmptySchema`: generate empty schema.

Related issue number
--------------------

None.
