### PR TITLE
Try implements vineyard data types as a subclass of existing C++ classes

### DIFF
--- a/modules/basic/ds/arrow-v2.h
+++ b/modules/basic/ds/arrow-v2.h
@@ -1,0 +1,370 @@
+/** Copyright 2020-2021 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef MODULES_BASIC_DS_ARROW_V2_H_
+#define MODULES_BASIC_DS_ARROW_V2_H_
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "basic/ds/arrow-v2.vineyard.h"
+#include "basic/ds/arrow_utils.h"
+#include "client/client.h"
+#include "client/ds/blob.h"
+
+namespace vineyard {
+
+namespace v2 {
+
+#ifndef BUILD_NULL_BITMAP
+#define BUILD_NULL_BITMAP(builder, array)                                \
+  {                                                                      \
+    if (array->null_bitmap() && array->null_count() > 0) {               \
+      std::unique_ptr<BlobWriter> bitmap_buffer_writer;                  \
+      RETURN_ON_ERROR(client.CreateBlob(array->null_bitmap()->size(),    \
+                                        bitmap_buffer_writer));          \
+      memcpy(bitmap_buffer_writer->data(), array->null_bitmap()->data(), \
+             array->null_bitmap()->size());                              \
+      builder->set_null_bitmap_(                                         \
+          std::shared_ptr<BlobWriter>(std::move(bitmap_buffer_writer))); \
+    } else {                                                             \
+      builder->set_null_bitmap_(Blob::MakeEmpty(client));                \
+    }                                                                    \
+  }
+#endif
+
+/**
+ * @brief NumericArrayBuilder is designed for building Arrow numeric arrays
+ *
+ * @tparam T
+ */
+template <typename T>
+class NumericArrayBuilder : public NumericArrayBaseBuilder<T> {
+ public:
+  using ArrayType = typename ConvertToArrowType<T>::ArrayType;
+
+  NumericArrayBuilder(Client& client, std::shared_ptr<ArrayType> array)
+      : NumericArrayBaseBuilder<T>(client), array_(array) {}
+
+  std::shared_ptr<ArrayType> GetArray() { return array_; }
+
+  Status Build(Client& client) override {
+    std::unique_ptr<BlobWriter> buffer_writer;
+    RETURN_ON_ERROR(client.CreateBlob(array_->values()->size(), buffer_writer));
+    memcpy(buffer_writer->data(), array_->values()->data(),
+           array_->values()->size());
+
+    this->set_length_(array_->length());
+    this->set_null_count_(array_->null_count());
+    this->set_offset_(array_->offset());
+    this->set_buffer_(std::shared_ptr<BlobWriter>(std::move(buffer_writer)));
+    BUILD_NULL_BITMAP(this, array_);
+    return Status::OK();
+  }
+
+ private:
+  std::shared_ptr<ArrayType> array_;
+};
+
+/**
+ * @brief BooleanArrayBuilder is designed for constructing  Arrow arrays of
+ * boolean data type
+ *
+ */
+class BooleanArrayBuilder : public BooleanArrayBaseBuilder {
+ public:
+  using ArrayType = typename ConvertToArrowType<bool>::ArrayType;
+
+  BooleanArrayBuilder(Client& client, std::shared_ptr<ArrayType> array)
+      : BooleanArrayBaseBuilder(client), array_(array) {}
+
+  std::shared_ptr<ArrayType> GetArray() { return array_; }
+
+  Status Build(Client& client) override {
+    std::unique_ptr<BlobWriter> buffer_writer;
+    RETURN_ON_ERROR(client.CreateBlob(array_->values()->size(), buffer_writer));
+    memcpy(buffer_writer->data(), array_->values()->data(),
+           array_->values()->size());
+
+    this->set_length_(array_->length());
+    this->set_null_count_(array_->null_count());
+    this->set_offset_(array_->offset());
+    this->set_buffer_(std::shared_ptr<BlobWriter>(std::move(buffer_writer)));
+    BUILD_NULL_BITMAP(this, array_);
+    return Status::OK();
+  }
+
+ private:
+  std::shared_ptr<ArrayType> array_;
+};
+
+/**
+ * @brief BaseBinaryArray is designed for constructing  Arrow arrays of
+ * binary data type
+ *
+ */
+template <typename ArrayType>
+class BaseBinaryArrayBuilder : public BaseBinaryArrayBaseBuilder<ArrayType> {
+ public:
+  BaseBinaryArrayBuilder(Client& client, std::shared_ptr<ArrayType> array)
+      : BaseBinaryArrayBaseBuilder<ArrayType>(client), array_(array) {}
+
+  std::shared_ptr<ArrayType> GetArray() { return array_; }
+
+  Status Build(Client& client) override {
+    {
+      std::unique_ptr<BlobWriter> buffer_writer;
+      RETURN_ON_ERROR(
+          client.CreateBlob(array_->value_offsets()->size(), buffer_writer));
+      memcpy(buffer_writer->data(), array_->value_offsets()->data(),
+             array_->value_offsets()->size());
+
+      this->set_buffer_offsets_(
+          std::shared_ptr<BlobWriter>(std::move(buffer_writer)));
+    }
+    {
+      std::unique_ptr<BlobWriter> buffer_writer;
+      RETURN_ON_ERROR(
+          client.CreateBlob(array_->value_data()->size(), buffer_writer));
+      memcpy(buffer_writer->data(), array_->value_data()->data(),
+             array_->value_data()->size());
+
+      this->set_buffer_data_(
+          std::shared_ptr<BlobWriter>(std::move(buffer_writer)));
+    }
+    this->set_length_(array_->length());
+    this->set_null_count_(array_->null_count());
+    this->set_offset_(array_->offset());
+    BUILD_NULL_BITMAP(this, array_);
+    return Status::OK();
+  }
+
+ private:
+  std::shared_ptr<ArrayType> array_;
+};
+
+using BinaryArrayBuilder = BaseBinaryArrayBuilder<arrow::BinaryArray>;
+using LargeBinaryArrayBuilder = BaseBinaryArrayBuilder<arrow::LargeBinaryArray>;
+using StringArrayBuilder = BaseBinaryArrayBuilder<arrow::StringArray>;
+using LargeStringArrayBuilder = BaseBinaryArrayBuilder<arrow::LargeStringArray>;
+
+/**
+ * @brief FixedSizeBinaryArrayBuilder is designed for constructing Arrow arrays
+ * of a fixed-size binary data type
+ *
+ */
+class FixedSizeBinaryArrayBuilder : public FixedSizeBinaryArrayBaseBuilder {
+ public:
+  FixedSizeBinaryArrayBuilder(
+      Client& client, std::shared_ptr<arrow::FixedSizeBinaryArray> array)
+      : FixedSizeBinaryArrayBaseBuilder(client), array_(array) {}
+
+  std::shared_ptr<arrow::FixedSizeBinaryArray> GetArray() { return array_; }
+
+  Status Build(Client& client) override {
+    VINEYARD_ASSERT(array_->length() == 0 || array_->values()->size() != 0,
+                    "Invalid array values");
+
+    std::unique_ptr<BlobWriter> buffer_writer;
+    RETURN_ON_ERROR(client.CreateBlob(array_->values()->size(), buffer_writer));
+    memcpy(buffer_writer->data(), array_->values()->data(),
+           array_->values()->size());
+
+    this->set_byte_width_(array_->byte_width());
+    this->set_length_(array_->length());
+    this->set_null_count_(array_->null_count());
+    this->set_offset_(array_->offset());
+    this->set_buffer_(std::shared_ptr<BlobWriter>(std::move(buffer_writer)));
+    BUILD_NULL_BITMAP(this, array_);
+    return Status::OK();
+  }
+
+ private:
+  std::shared_ptr<arrow::FixedSizeBinaryArray> array_;
+};
+
+/**
+ * @brief NullArrayBuilder is used for generating Arrow arrays of null data type
+ *
+ */
+class NullArrayBuilder : public NullArrayBaseBuilder {
+ public:
+  NullArrayBuilder(Client& client, std::shared_ptr<arrow::NullArray> array)
+      : NullArrayBaseBuilder(client), array_(array) {}
+
+  std::shared_ptr<arrow::NullArray> GetArray() { return array_; }
+
+  Status Build(Client& client) override {
+    this->set_length_(array_->length());
+    return Status::OK();
+  }
+
+ private:
+  std::shared_ptr<arrow::NullArray> array_;
+};
+
+namespace detail {
+
+template <typename T>
+inline std::shared_ptr<ObjectBuilder> BuildNumericArray(
+    Client& client,
+    std::shared_ptr<typename ConvertToArrowType<T>::ArrayType> arr) {
+  return std::make_shared<NumericArrayBuilder<T>>(client, arr);
+}
+
+inline std::shared_ptr<ObjectBuilder> BuildArray(
+    Client& client, std::shared_ptr<arrow::Array> array) {
+  if (auto arr =
+          std::dynamic_pointer_cast<ConvertToArrowType<int8_t>::ArrayType>(
+              array)) {
+    return BuildNumericArray<int8_t>(client, arr);
+  }
+  if (auto arr =
+          std::dynamic_pointer_cast<ConvertToArrowType<uint8_t>::ArrayType>(
+              array)) {
+    return BuildNumericArray<uint8_t>(client, arr);
+  }
+  if (auto arr =
+          std::dynamic_pointer_cast<ConvertToArrowType<int16_t>::ArrayType>(
+              array)) {
+    return BuildNumericArray<int16_t>(client, arr);
+  }
+  if (auto arr =
+          std::dynamic_pointer_cast<ConvertToArrowType<uint16_t>::ArrayType>(
+              array)) {
+    return BuildNumericArray<uint16_t>(client, arr);
+  }
+  if (auto arr =
+          std::dynamic_pointer_cast<ConvertToArrowType<int32_t>::ArrayType>(
+              array)) {
+    return BuildNumericArray<int32_t>(client, arr);
+  }
+  if (auto arr =
+          std::dynamic_pointer_cast<ConvertToArrowType<uint32_t>::ArrayType>(
+              array)) {
+    return BuildNumericArray<uint32_t>(client, arr);
+  }
+  if (auto arr =
+          std::dynamic_pointer_cast<ConvertToArrowType<int64_t>::ArrayType>(
+              array)) {
+    return BuildNumericArray<int64_t>(client, arr);
+  }
+  if (auto arr =
+          std::dynamic_pointer_cast<ConvertToArrowType<uint64_t>::ArrayType>(
+              array)) {
+    return BuildNumericArray<uint64_t>(client, arr);
+  }
+  if (auto arr =
+          std::dynamic_pointer_cast<ConvertToArrowType<float>::ArrayType>(
+              array)) {
+    return BuildNumericArray<float>(client, arr);
+  }
+  if (auto arr =
+          std::dynamic_pointer_cast<ConvertToArrowType<double>::ArrayType>(
+              array)) {
+    return BuildNumericArray<double>(client, arr);
+  }
+  if (auto arr =
+          std::dynamic_pointer_cast<arrow::FixedSizeBinaryArray>(array)) {
+    return std::make_shared<FixedSizeBinaryArrayBuilder>(client, arr);
+  }
+  /*
+  if (auto arr = std::dynamic_pointer_cast<arrow::StringArray>(array)) {
+    return std::make_shared<StringArrayBuilder>(client, arr);
+  }
+  if (auto arr = std::dynamic_pointer_cast<arrow::LargeStringArray>(array)) {
+    return std::make_shared<LargeStringArrayBuilder>(client, arr);
+  }
+  */
+  if (auto arr = std::dynamic_pointer_cast<arrow::NullArray>(array)) {
+    return std::make_shared<NullArrayBuilder>(client, arr);
+  }
+  VINEYARD_ASSERT(nullptr != nullptr,
+                  "Unsupported array type: " + array->type()->ToString());
+  return nullptr;
+}
+
+}  // namespace detail
+
+/**
+ * @brief SchemaProxyBuilder is used for initiating proxies for the schemas
+ *
+ */
+class SchemaProxyBuilder : public SchemaProxyBaseBuilder {
+ public:
+  SchemaProxyBuilder(Client& client, std::shared_ptr<arrow::Schema> schema)
+      : SchemaProxyBaseBuilder(client), schema_(schema) {}
+
+ public:
+  Status Build(Client& client) override {
+    std::shared_ptr<arrow::Buffer> schema_buffer;
+#if defined(ARROW_VERSION) && ARROW_VERSION < 17000
+    RETURN_ON_ARROW_ERROR(arrow::ipc::SerializeSchema(
+        *schema_, nullptr, arrow::default_memory_pool(), &schema_buffer));
+#elif defined(ARROW_VERSION) && ARROW_VERSION < 2000000
+    RETURN_ON_ARROW_ERROR_AND_ASSIGN(
+        schema_buffer, arrow::ipc::SerializeSchema(
+                           *schema_, nullptr, arrow::default_memory_pool()));
+#else
+    RETURN_ON_ARROW_ERROR_AND_ASSIGN(
+        schema_buffer,
+        arrow::ipc::SerializeSchema(*schema_, arrow::default_memory_pool()));
+#endif
+    std::unique_ptr<BlobWriter> schema_writer;
+    RETURN_ON_ERROR(client.CreateBlob(schema_buffer->size(), schema_writer));
+    memcpy(schema_writer->data(), schema_buffer->data(), schema_buffer->size());
+
+    this->set_buffer_(std::shared_ptr<BlobWriter>(std::move(schema_writer)));
+    return Status::OK();
+  }
+
+ private:
+  std::shared_ptr<arrow::Schema> schema_;
+};
+
+/**
+ * @brief RecordBatchBuilder is used for generating the batch of rows of
+ columns
+ * of equal length
+ *
+ */
+class RecordBatchBuilder : public RecordBatchBaseBuilder {
+ public:
+  RecordBatchBuilder(Client& client, std::shared_ptr<arrow::RecordBatch> batch)
+      : RecordBatchBaseBuilder(client), batch_(batch) {}
+
+  Status Build(Client& client) override {
+    this->set_column_num_(batch_->num_columns());
+    this->set_row_num_(batch_->num_rows());
+    this->set_batch_schema_(
+        std::make_shared<SchemaProxyBuilder>(client, batch_->schema()));
+    for (int64_t idx = 0; idx < batch_->num_columns(); ++idx) {
+      this->add_columns_(detail::BuildArray(client, batch_->column(idx)));
+    }
+    return Status::OK();
+  }
+
+ private:
+  std::shared_ptr<arrow::RecordBatch> batch_;
+};
+
+}  // namespace v2
+
+}  // namespace vineyard
+
+#endif  // MODULES_BASIC_DS_ARROW_V2_H_

--- a/modules/basic/ds/arrow-v2.vineyard-mod
+++ b/modules/basic/ds/arrow-v2.vineyard-mod
@@ -1,0 +1,318 @@
+/** Copyright 2020-2021 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef MODULES_BASIC_DS_ARROW_MOD_H_
+#define MODULES_BASIC_DS_ARROW_MOD_H_
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "arrow/io/memory.h"
+#include "arrow/ipc/reader.h"
+#include "arrow/ipc/writer.h"
+#include "arrow/record_batch.h"
+#include "arrow/table.h"
+#include "arrow/type.h"
+#include "arrow/util/config.h"
+#include "arrow/util/vector.h"
+
+#include "basic/ds/arrow_utils.h"
+#include "client/client.h"
+#include "client/ds/blob.h"
+
+namespace vineyard {
+
+namespace v2 {
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
+#endif
+
+/// The arrays in vineyard is a wrapper of arrow arrays, in order to
+/// Simplify the Build and Construct process.
+
+template <typename T>
+class NumericArrayBaseBuilder;
+
+template <typename T>
+class NumericArray : public ConvertToArrowType<T>::ArrayType,
+                     public Registered<NumericArray<T>> {
+ public:
+  using ArrayType = typename ConvertToArrowType<T>::ArrayType;
+
+  NumericArray() : ConvertToArrowType<T>::ArrayType() {}
+
+  void PostConstruct(const ObjectMeta& meta) override {
+    this->SetData(arrow::ArrayData::Make(
+        ConvertToArrowType<T>::TypeValue(), length_,
+        {null_bitmap_->Buffer(), buffer_->Buffer()}, null_count_, offset_));
+  }
+
+ private:
+  __attribute__((annotate("codegen"))) size_t length_;
+  __attribute__((annotate("codegen"))) int64_t null_count_, offset_;
+  __attribute__((annotate("codegen:Blob*"))) std::shared_ptr<Blob> buffer_,
+      null_bitmap_;
+
+  friend class Client;
+  friend class NumericArrayBaseBuilder<T>;
+};
+
+class BooleanArrayBaseBuilder;
+
+class BooleanArray : public ConvertToArrowType<bool>::ArrayType,
+                     public Registered<BooleanArray> {
+ public:
+  using ArrayType = typename ConvertToArrowType<bool>::ArrayType;
+
+  BooleanArray() : ConvertToArrowType<bool>::ArrayType() {}
+
+  void PostConstruct(const ObjectMeta& meta) override {
+    this->SetData(arrow::ArrayData::Make(
+        ConvertToArrowType<bool>::TypeValue(), length_,
+        {null_bitmap_->Buffer(), buffer_->Buffer()}, null_count_, offset_));
+  }
+
+ private:
+  __attribute__((annotate("codegen"))) size_t length_;
+  __attribute__((annotate("codegen"))) int64_t null_count_, offset_;
+  __attribute__((annotate("codegen:Blob*"))) std::shared_ptr<Blob> buffer_,
+      null_bitmap_;
+
+  friend class Client;
+  friend class BooleanArrayBaseBuilder;
+};
+
+/// Binary array
+
+template <typename ArrayType>
+class BaseBinaryArrayBaseBuilder;
+
+template <typename ArrayType>
+class BaseBinaryArray : public ArrayType,
+                        public Registered<BaseBinaryArray<ArrayType>> {
+ public:
+  BaseBinaryArray() : ArrayType() {}
+
+  void PostConstruct(const ObjectMeta& meta) override {
+    this->SetData(arrow::ArrayData::Make(
+        arrow::binary(), length_,
+        {null_bitmap_->Buffer(), buffer_offsets_->Buffer(),
+         buffer_data_->Buffer()},
+        null_count_, offset_));
+  }
+
+ private:
+  __attribute__((annotate("codegen"))) size_t length_;
+  __attribute__((annotate("codegen"))) int64_t null_count_, offset_;
+  __attribute__((annotate("codegen:Blob*"))) std::shared_ptr<Blob> buffer_data_,
+      buffer_offsets_, null_bitmap_;
+
+  friend class Client;
+  friend class BaseBinaryArrayBaseBuilder<ArrayType>;
+};
+
+/*
+using BinaryArray = BaseBinaryArray<arrow::BinaryArray>;
+using LargeBinaryArray = BaseBinaryArray<arrow::LargeBinaryArray>;
+using StringArray = BaseBinaryArray<arrow::StringArray>;
+using LargeStringArray = BaseBinaryArray<arrow::LargeStringArray>;
+*/
+
+class FixedSizeBinaryArrayBaseBuilder;
+
+class FixedSizeBinaryArray : public arrow::FixedSizeBinaryArray,
+                             public Registered<FixedSizeBinaryArray> {
+ public:
+  FixedSizeBinaryArray()
+      : arrow::FixedSizeBinaryArray(arrow::fixed_size_binary(0), 0, nullptr) {}
+
+  void PostConstruct(const ObjectMeta& meta) override {
+    this->SetData(arrow::ArrayData::Make(
+        arrow::fixed_size_binary(this->byte_width_), length_,
+        {null_bitmap_->Buffer(), buffer_->Buffer()}, null_count_, offset_));
+  }
+
+ private:
+  __attribute__((annotate("codegen"))) int32_t byte_width_;
+  __attribute__((annotate("codegen"))) size_t length_;
+  __attribute__((annotate("codegen"))) int64_t null_count_, offset_;
+  __attribute__((annotate("codegen:Blob*"))) std::shared_ptr<Blob> buffer_,
+      null_bitmap_;
+
+  friend class Client;
+  friend class FixedSizeBinaryArrayBaseBuilder;
+};
+
+/// Null array
+
+class NullArrayBaseBuilder;
+
+class NullArray : public arrow::NullArray, public Registered<NullArray> {
+ public:
+  using ArrayType = arrow::NullArray;
+
+  NullArray() : arrow::NullArray(0) {}
+
+  void PostConstruct(const ObjectMeta& meta) override {
+    this->arrow::Array::SetData(
+        arrow::ArrayData::Make(arrow::null(), length_, {nullptr}, length_));
+  }
+
+ private:
+  __attribute__((annotate("codegen"))) size_t length_;
+
+  friend class Client;
+  friend class NullArrayBaseBuilder;
+};
+
+class SchemaProxyBaseBuilder;
+
+class SchemaProxy : public Registered<SchemaProxy> {
+ public:
+  SchemaProxy() {}
+
+  void PostConstruct(const ObjectMeta& meta) override {
+    arrow::io::BufferReader reader(this->buffer_->Buffer());
+#if defined(ARROW_VERSION) && ARROW_VERSION < 17000
+    CHECK_ARROW_ERROR(arrow::ipc::ReadSchema(&reader, nullptr, &this->schema_));
+#else
+    CHECK_ARROW_ERROR_AND_ASSIGN(this->schema_,
+                                 arrow::ipc::ReadSchema(&reader, nullptr));
+#endif
+  }
+
+  std::shared_ptr<arrow::Schema> const& schema() const { return schema_; }
+
+ private:
+  __attribute__((annotate("codegen:Blob*"))) std::shared_ptr<Blob> buffer_;
+
+  std::shared_ptr<arrow::Schema> schema_;
+
+  friend class Client;
+  friend class SchemaProxyBaseBuilder;
+};
+
+class RecordBatchBaseBuilder;
+
+class RecordBatch : public arrow::RecordBatch, public Registered<RecordBatch> {
+ public:
+  RecordBatch()
+      : arrow::RecordBatch(EmptyTableBuilder::EmptySchema(), int64_t{0}) {}
+
+  void PostConstruct(const ObjectMeta& meta) override {
+    for (size_t idx = 0; idx < columns_.size(); ++idx) {
+      auto array = std::dynamic_pointer_cast<arrow::Array>(columns_[idx]);
+      boxed_columns_.emplace_back(array);
+      boxed_data_columns_.emplace_back(array->data());
+    }
+    schema_ = batch_schema_.schema();
+    num_rows_ = row_num_;
+  }
+
+  // n.b.: refer to `arrow::SimpleRecordBatch` in record_batch.cc.
+
+  const std::vector<std::shared_ptr<arrow::Array>>& columns() const override {
+    return boxed_columns_;
+  }
+
+  std::shared_ptr<arrow::Array> column(int i) const override {
+    return boxed_columns_.at(i);
+  }
+
+  std::shared_ptr<arrow::ArrayData> column_data(int i) const override {
+    return boxed_data_columns_.at(i);
+  }
+
+  const arrow::ArrayDataVector& column_data() const override {
+    return boxed_data_columns_;
+  }
+
+  arrow::Result<std::shared_ptr<arrow::RecordBatch>> AddColumn(
+      int i, const std::shared_ptr<arrow::Field>& field,
+      const std::shared_ptr<arrow::Array>& column) const override {
+    ARROW_ASSIGN_OR_RAISE(auto new_schema, schema_->AddField(i, field));
+    return arrow::RecordBatch::Make(
+        std::move(new_schema), num_rows_,
+        arrow::internal::AddVectorElement(boxed_data_columns_, i,
+                                          column->data()));
+  }
+
+  arrow::Result<std::shared_ptr<arrow::RecordBatch>> SetColumn(
+      int i, const std::shared_ptr<arrow::Field>& field,
+      const std::shared_ptr<arrow::Array>& column) const override {
+    ARROW_ASSIGN_OR_RAISE(auto new_schema, schema_->SetField(i, field));
+    return arrow::RecordBatch::Make(
+        std::move(new_schema), num_rows_,
+        arrow::internal::ReplaceVectorElement(boxed_data_columns_, i,
+                                              column->data()));
+  }
+
+  arrow::Result<std::shared_ptr<arrow::RecordBatch>> RemoveColumn(
+      int i) const override {
+    ARROW_ASSIGN_OR_RAISE(auto new_schema, schema_->RemoveField(i));
+    return arrow::RecordBatch::Make(
+        std::move(new_schema), num_rows_,
+        arrow::internal::DeleteVectorElement(boxed_data_columns_, i));
+  }
+
+  std::shared_ptr<arrow::RecordBatch> ReplaceSchemaMetadata(
+      const std::shared_ptr<const arrow::KeyValueMetadata>& metadata)
+      const override {
+    auto new_schema = schema_->WithMetadata(metadata);
+    return arrow::RecordBatch::Make(std::move(new_schema), num_rows_,
+                                    boxed_data_columns_);
+  }
+
+  std::shared_ptr<arrow::RecordBatch> Slice(int64_t offset,
+                                            int64_t length) const override {
+    std::vector<std::shared_ptr<arrow::Array>> arrays;
+    arrays.reserve(num_columns());
+    for (const auto& field : boxed_columns_) {
+      arrays.emplace_back(field->Slice(offset, length));
+    }
+    int64_t num_rows = std::min(num_rows_ - offset, length);
+    return arrow::RecordBatch::Make(schema_, num_rows, std::move(arrays));
+  }
+
+ private:
+  __attribute__((annotate("codegen"))) size_t column_num_ = 0;
+  __attribute__((annotate("codegen"))) size_t row_num_ = 0;
+  __attribute__((annotate("codegen:SchemaProxy"))) SchemaProxy batch_schema_;
+  __attribute__((annotate("codegen:[Object*]")))
+  std::vector<std::shared_ptr<Object>>
+      columns_;
+
+  // Caching casted boxed array data
+  mutable std::vector<std::shared_ptr<arrow::Array>> boxed_columns_;
+  mutable std::vector<std::shared_ptr<arrow::ArrayData>> boxed_data_columns_;
+
+  friend class Client;
+  friend class RecordBatchBaseBuilder;
+};
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+}  // namespace v2
+
+}  // namespace vineyard
+
+#endif  // MODULES_BASIC_DS_ARROW_MOD_H_

--- a/test/arrow_data_structure_v2_test.cc
+++ b/test/arrow_data_structure_v2_test.cc
@@ -1,0 +1,73 @@
+/** Copyright 2020-2021 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "arrow/status.h"
+#include "arrow/stl.h"
+#include "arrow/util/config.h"
+#include "arrow/util/io_util.h"
+#include "arrow/util/logging.h"
+
+#include "basic/ds/arrow-v2.h"
+#include "client/client.h"
+#include "client/ds/object_meta.h"
+#include "common/util/logging.h"
+
+using namespace vineyard;  // NOLINT(build/namespaces)
+
+int main(int argc, char** argv) {
+  if (argc < 2) {
+    printf("usage ./arrow_data_structure_test <ipc_socket>");
+    return 1;
+  }
+  std::string ipc_socket = std::string(argv[1]);
+
+  Client client;
+  VINEYARD_CHECK_OK(client.Connect(ipc_socket));
+  LOG(INFO) << "Connected to IPCServer: " << ipc_socket;
+
+  {
+    LOG(INFO) << "#########  Double Test #############";
+    arrow::DoubleBuilder b1;
+    CHECK_ARROW_ERROR(b1.AppendValues({1.5, 2.5, 3.5, 4.5}));
+    CHECK_ARROW_ERROR(b1.AppendNull());
+    CHECK_ARROW_ERROR(b1.AppendValues({5.5}));
+    std::shared_ptr<arrow::DoubleArray> a1;
+    CHECK_ARROW_ERROR(b1.Finish(&a1));
+    v2::NumericArrayBuilder<double> array_builder(client, a1);
+    auto r1 = std::dynamic_pointer_cast<v2::NumericArray<double>>(
+        array_builder.Seal(client));
+    VINEYARD_CHECK_OK(client.Persist(r1->id()));
+    ObjectID id = r1->id();
+
+    auto r2 = std::dynamic_pointer_cast<v2::NumericArray<double>>(
+        client.GetObject(id));
+    // auto internal_array =
+    // std::static_pointer_cast<ConvertToArrowType<double>::ArrayType>(r2);
+    auto internal_array = r2;
+    // LOG(INFO) << a1->ToString();
+    // LOG(INFO) << internal_array->ToString();
+    CHECK(internal_array->Equals(*a1));
+
+    LOG(INFO) << "Passed double array wrapper tests...";
+  }
+
+  client.Disconnect();
+
+  return 0;
+}


### PR DESCRIPTION
What do these changes do?
-------------------------

To show the potential for better/cleaner integration of vineyard with existing compute engines.

See `arrow_data_structure_v2_test.cc`, the `DoubleArray` that comes from vineyard (return by `client.get()`) can directly use any public method of `arrow::DoubleArray`.

Related issue number
--------------------

N/A

