### PR TITLE
Fixes the `:` in LC_RPATH on Mac.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,13 @@ message(STATUS "Setting the allocator to vineyardd as '${WITH_ALLOCATOR}'.")
 
 # reference: https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling#always-full-rpath
 set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/lib64")
+if(APPLE)
+    # the LC_RPATH on Mac seems doesn't support multiple path (seperated with ':seperated with `:`)
+    # fortunately, we just need to take care `lib` on Mac.
+    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+else()
+    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/lib64")
+endif()
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC \


### PR DESCRIPTION
What do these changes do?
-------------------------

The LC_RPATH on Mac seems doesn't support multiple path (seperated with ':seperated with `:`), fortunately, we just need to take care `lib` on Mac.

Related issue number
--------------------

N/A

