### PR TITLE
Fixes resolvers for pd.DataFrame that contains `DatetimeArray`s.

### DIFF
--- a/python/vineyard/data/tests/test_dataframe.py
+++ b/python/vineyard/data/tests/test_dataframe.py
@@ -99,6 +99,19 @@ def test_dataframe_with_sparse_array_mixed_columns(vineyard_client):
     pd.testing.assert_frame_equal(df, vineyard_client.get(object_id))
 
 
+def test_dataframe_with_datetime(vineyard_client):
+    # GH-575
+    dates = [
+        pd.Timestamp("2012-05-01"),
+        pd.Timestamp("2012-05-02"),
+        pd.Timestamp("2012-05-03"),
+    ]
+    pd.DataFrame(pd.Series(dates))
+    df = pd.DataFrame(pd.Series(dates))
+    object_id = vineyard_client.put(df)
+    pd.testing.assert_frame_equal(df, vineyard_client.get(object_id))
+
+
 def test_dataframe_reusing(vineyard_client):
     nparr = np.ones(1000)
     df = pd.DataFrame({"x": nparr})


### PR DESCRIPTION
What do these changes do?
-------------------------

Fixes the corner cases for resolving `pd.DataFrame` that contains `DatetimeArray`s.

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #575
