### PR TITLE
Avoid using `__rdtsc` on non-x86_64 platforms (e.g., Apple M1).

### DIFF
--- a/src/common/util/uuid.h
+++ b/src/common/util/uuid.h
@@ -16,9 +16,12 @@ limitations under the License.
 #ifndef SRC_COMMON_UTIL_UUID_H_
 #define SRC_COMMON_UTIL_UUID_H_
 
+#if defined(__x86_64__)
 #include <immintrin.h>
 #include <x86intrin.h>
+#endif
 
+#include <cstdlib>
 #include <limits>
 #include <string>
 
@@ -64,11 +67,21 @@ inline ObjectID GenerateBlobID(const uintptr_t ptr) {
 constexpr inline ObjectID EmptyBlobID() { return 0x8000000000000000UL; }
 
 inline ObjectID GenerateObjectID() {
+#if defined(__x86_64__)
   return 0x7FFFFFFFFFFFFFFFUL & static_cast<uint64_t>(__rdtsc());
+#else
+  return 0x7FFFFFFFFFFFFFFFUL &
+         static_cast<uint64_t>(rand());  // NOLINT(runtime/threadsafe_fn)
+#endif
 }
 
 inline ObjectID GenerateSignature() {
+#if defined(__x86_64__)
   return 0x7FFFFFFFFFFFFFFFUL & static_cast<uint64_t>(__rdtsc());
+#else
+  return 0x7FFFFFFFFFFFFFFFUL &
+         static_cast<uint64_t>(rand());  // NOLINT(runtime/threadsafe_fn)
+#endif
 }
 
 inline bool IsBlob(ObjectID id) { return id & 0x8000000000000000UL; }

--- a/src/server/services/meta_service.h
+++ b/src/server/services/meta_service.h
@@ -17,6 +17,7 @@ limitations under the License.
 #define SRC_SERVER_SERVICES_META_SERVICE_H_
 
 #include <chrono>
+#include <cstdlib>
 #include <iostream>
 #include <map>
 #include <memory>
@@ -365,8 +366,14 @@ class IMetaService {
             int64_t timestamp = GetTimestamp();
 
             instances_list_.clear();
+#if defined(__x86_64__)
             uint64_t self_host_id = static_cast<uint64_t>(gethostid()) |
                                     static_cast<uint64_t>(__rdtsc());
+#else
+            uint64_t self_host_id =
+                static_cast<uint64_t>(gethostid()) |
+                static_cast<uint64_t>(rand());  // NOLINT(runtime/threadsafe_fn)
+#endif
             if (tree.contains("instances") && !tree["instances"].is_null()) {
               for (auto& instance : json::iterator_wrapper(tree["instances"])) {
                 auto id = static_cast<InstanceID>(


### PR DESCRIPTION
What do these changes do?
-------------------------

Using `rand()` instead.

