### PR TITLE
Fixes `envvars` and make VINEYARD_USE_LOCAL_REGISTRY copying the original ones

### DIFF
--- a/python/vineyard/__init__.py
+++ b/python/vineyard/__init__.py
@@ -61,6 +61,8 @@ def envvars(key, value=None, append=False):
     for k, v in original_items.items():
         if v is not None:
             os.environ[k] = v
+        else:
+            del os.environ[k]
 
 
 def _init_global_context():

--- a/src/client/ds/object_factory.h
+++ b/src/client/ds/object_factory.h
@@ -70,18 +70,17 @@ class ObjectFactory {
    */
   template <typename T>
   static bool Register() {
+    const std::string name = type_name<T>();
 #ifndef NDEBUG
     static bool __trace = !read_env("VINEYARD_TRACE_REGISTRY").empty();
     if (__trace) {
       // See: Note [std::cerr instead of DVLOG()]
-      std::cerr << "vineyard: register data type: " << type_name<T>()
-                << std::endl;
+      std::cerr << "vineyard: register data type: " << name << std::endl;
     }
 #endif
     auto& known_types = getKnownTypes();
     // the explicit `static_cast` is used to help overloading resolution.
-    known_types.emplace(type_name<T>(),
-                        static_cast<object_initializer_t>(&T::Create));
+    known_types[name] = static_cast<object_initializer_t>(&T::Create);
     return true;
   }
 


### PR DESCRIPTION

What do these changes do?
-------------------------

The `vineyard.envvars` doesn't restore the environemnt variables when exiting from the context, leading to bugs on Mac for learning engine in GraphScope.

See also alibaba/GraphScope#954

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

N/A

