### PR TITLE
Don't reuse registry to avoid ABI conflicts.

### DIFF
--- a/src/client/ds/blob.cc
+++ b/src/client/ds/blob.cc
@@ -24,12 +24,6 @@ limitations under the License.
 
 namespace vineyard {
 
-Blob::Blob() {
-  this->id_ = InvalidObjectID();
-  this->size_ = std::numeric_limits<size_t>::max();
-  this->buffer_ = nullptr;
-}
-
 size_t Blob::size() const { return allocated_size(); }
 
 size_t Blob::allocated_size() const { return size_; }

--- a/src/client/ds/blob.h
+++ b/src/client/ds/blob.h
@@ -16,6 +16,7 @@ limitations under the License.
 #ifndef SRC_CLIENT_DS_BLOB_H_
 #define SRC_CLIENT_DS_BLOB_H_
 
+#include <limits>
 #include <map>
 #include <memory>
 #include <set>
@@ -120,7 +121,11 @@ class Blob : public Registered<Blob> {
   /**
    * The default constructor is only used in BlobWriter.
    */
-  Blob();
+  Blob() {
+    this->id_ = InvalidObjectID();
+    this->size_ = std::numeric_limits<size_t>::max();
+    this->buffer_ = nullptr;
+  }
 
   const std::shared_ptr<arrow::Buffer>& BufferUnsafe() const;
 

--- a/src/client/ds/object_factory.cc
+++ b/src/client/ds/object_factory.cc
@@ -162,15 +162,8 @@ __instantize__registry(vineyard_registry_handler_t& handler,
       getter());
 
   if (!read_env("VINEYARD_USE_LOCAL_REGISTRY").empty()) {
-#ifndef NDEBUG
-    for (auto const& item : *registry) {
-      std::cerr << "vineyard: borrowing constructor: " << item.first
-                << std::endl;
-    }
-#endif
     return new std::unordered_map<std::string,
-                                  ObjectFactory::object_initializer_t>(
-        *registry);
+                                  ObjectFactory::object_initializer_t>();
   }
   return registry;
 }


### PR DESCRIPTION
And move `Blob::Blob()` to `.h` file to make sure `vineyard::Blob` being registered on Mac.