### PR TITLE
Java SDK: persist, names and tables and more array types.

### DIFF
--- a/java/core/src/main/java/io/v6d/core/client/Client.java
+++ b/java/core/src/main/java/io/v6d/core/client/Client.java
@@ -16,6 +16,7 @@ package io.v6d.core.client;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
+import io.v6d.core.client.ds.Object;
 import io.v6d.core.client.ds.ObjectMeta;
 import io.v6d.core.common.util.InstanceID;
 import io.v6d.core.common.util.ObjectID;
@@ -48,6 +49,26 @@ public abstract class Client {
 
     public abstract Collection<ObjectMeta> listMetaData(String pattern, boolean regex, int limit)
             throws VineyardException;
+
+    public abstract void persist(ObjectID id) throws VineyardException;
+
+    public void persist(ObjectMeta meta) throws VineyardException {
+        this.persist(meta.getId());
+    }
+
+    public void persist(Object object) throws VineyardException {
+        this.persist(object.getId());
+    }
+
+    public abstract void putName(ObjectID id, String name) throws VineyardException;
+
+    public abstract ObjectID getName(String name, boolean wait) throws VineyardException;
+
+    public ObjectID getName(String name) throws VineyardException {
+        return getName(name, false);
+    }
+
+    public abstract void dropName(String name) throws VineyardException;
 
     public boolean connected() {
         return false;

--- a/java/core/src/main/java/io/v6d/core/client/IPCClient.java
+++ b/java/core/src/main/java/io/v6d/core/client/IPCClient.java
@@ -171,6 +171,43 @@ public class IPCClient extends Client {
         return metadatas;
     }
 
+    @Override
+    public void persist(ObjectID id) throws VineyardException {
+        val root = mapper_.createObjectNode();
+        PersistRequest.put(root, id);
+        this.doWrite(root);
+        val reply = new PersistReply();
+        reply.get(this.doReadJson());
+    }
+
+    @Override
+    public void putName(ObjectID id, String name) throws VineyardException {
+        val root = mapper_.createObjectNode();
+        PutNameRequest.put(root, id, name);
+        this.doWrite(root);
+        val reply = new PutNameReply();
+        reply.get(this.doReadJson());
+    }
+
+    @Override
+    public ObjectID getName(String name, boolean wait) throws VineyardException {
+        val root = mapper_.createObjectNode();
+        GetNameRequest.put(root, name, wait);
+        this.doWrite(root);
+        val reply = new GetNameReply();
+        reply.get(this.doReadJson());
+        return reply.getId();
+    }
+
+    @Override
+    public void dropName(String name) throws VineyardException {
+        val root = mapper_.createObjectNode();
+        DropNameRequest.put(root, name);
+        this.doWrite(root);
+        val reply = new DropNameReply();
+        reply.get(this.doReadJson());
+    }
+
     public Buffer createBuffer(long size) throws VineyardException {
         val root = mapper_.createObjectNode();
         CreateBufferRequest.put(root, size);

--- a/java/core/src/main/java/io/v6d/core/client/ds/ObjectMeta.java
+++ b/java/core/src/main/java/io/v6d/core/client/ds/ObjectMeta.java
@@ -177,6 +177,14 @@ public class ObjectMeta {
         this.meta.put("id", id.toString());
     }
 
+    public boolean hasName() {
+        return this.meta.has("__name");
+    }
+
+    public String getName() {
+        return this.meta.get("__name").textValue();
+    }
+
     public Signature getSignature() {
         return new Signature(this.getLongValue("signature"));
     }
@@ -243,7 +251,7 @@ public class ObjectMeta {
     }
 
     public String getStringValue(String key) {
-        return this.meta.get(key).asText();
+        return this.meta.get(key).textValue();
     }
 
     public void setValue(String key, String value) {
@@ -357,11 +365,16 @@ public class ObjectMeta {
                 .toString();
     }
 
+    @SneakyThrows(JsonProcessingException.class)
+    public String toPrettyString() {
+        return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(meta);
+    }
+
     private void findAllBuffers(ObjectNode meta) throws VineyardException {
         if (meta == null || meta.isEmpty()) {
             return;
         }
-        ObjectID member = ObjectID.fromString(meta.get("id").asText());
+        ObjectID member = ObjectID.fromString(meta.get("id").textValue());
         if (member.isBlob()) {
             if (meta.get("instance_id").asLong() == this.instanceId.value()) {
                 this.buffers.emplace(member);

--- a/java/core/src/main/java/io/v6d/core/common/util/InstanceID.java
+++ b/java/core/src/main/java/io/v6d/core/common/util/InstanceID.java
@@ -14,11 +14,12 @@
  */
 package io.v6d.core.common.util;
 
+import lombok.*;
 import lombok.EqualsAndHashCode;
 
 /** Vineyard InstanceID definition. */
 @EqualsAndHashCode(callSuper = false)
-public class InstanceID {
+public class InstanceID implements Comparable {
     private long id = -1L;
 
     public static InstanceID UnspecifiedInstanceID = new InstanceID(-1L);
@@ -38,5 +39,11 @@ public class InstanceID {
     @Override
     public String toString() {
         return String.format("o%016x", id);
+    }
+
+    @Override
+    public int compareTo(Object o) {
+        val other = (InstanceID) o;
+        return (int) (this.id - other.id);
     }
 }

--- a/java/core/src/main/java/io/v6d/core/common/util/ObjectID.java
+++ b/java/core/src/main/java/io/v6d/core/common/util/ObjectID.java
@@ -14,11 +14,12 @@
  */
 package io.v6d.core.common.util;
 
+import lombok.*;
 import lombok.EqualsAndHashCode;
 
 /** Vineyard ObjectID definition. */
 @EqualsAndHashCode(callSuper = false)
-public class ObjectID {
+public class ObjectID implements Comparable {
     private long id = -1L;
 
     public static ObjectID InvalidObjectID = new ObjectID(-1L);
@@ -44,5 +45,11 @@ public class ObjectID {
     @Override
     public String toString() {
         return String.format("o%016x", id);
+    }
+
+    @Override
+    public int compareTo(Object o) {
+        val other = (ObjectID) o;
+        return (int) (this.id - other.id);
     }
 }

--- a/java/core/src/main/java/io/v6d/core/common/util/Protocol.java
+++ b/java/core/src/main/java/io/v6d/core/common/util/Protocol.java
@@ -194,4 +194,77 @@ public class Protocol {
             root.put("limit", limit);
         }
     }
+
+    @Data
+    public static class PersistRequest extends Request {
+        public static void put(ObjectNode root, ObjectID id) {
+            root.put("type", "persist_request");
+            root.put("id", id.value());
+        }
+    }
+
+    @Data
+    @EqualsAndHashCode(callSuper = false)
+    public static class PersistReply extends Reply {
+        @Override
+        public void get(JsonNode root) throws VineyardException {
+            check(root, "persist_reply");
+        }
+    }
+
+    @Data
+    public static class PutNameRequest extends Request {
+        public static void put(ObjectNode root, ObjectID id, String name) {
+            root.put("type", "put_name_request");
+            root.put("object_id", id.value());
+            root.put("name", name);
+        }
+    }
+
+    @Data
+    @EqualsAndHashCode(callSuper = false)
+    public static class PutNameReply extends Reply {
+        @Override
+        public void get(JsonNode root) throws VineyardException {
+            check(root, "put_name_reply");
+        }
+    }
+
+    @Data
+    public static class GetNameRequest extends Request {
+        public static void put(ObjectNode root, String name, boolean wait) {
+            root.put("type", "get_name_request");
+            root.put("name", name);
+            root.put("wait", wait);
+        }
+    }
+
+    @Data
+    @EqualsAndHashCode(callSuper = false)
+    public static class GetNameReply extends Reply {
+        private ObjectID id;
+
+        @Override
+        public void get(JsonNode root) throws VineyardException {
+            check(root, "get_name_reply");
+            this.id = new ObjectID(root.get("object_id").longValue());
+        }
+    }
+
+    @Data
+    public static class DropNameRequest extends Request {
+        public static void put(ObjectNode root, String name) {
+            root.put("type", "drop_name_request");
+            root.put("name", name);
+        }
+    }
+
+    @Data
+    @EqualsAndHashCode(callSuper = false)
+    public static class DropNameReply extends Reply {
+        @Override
+        public void get(JsonNode root) throws VineyardException {
+            check(root, "drop_name_reply");
+        }
+    }
 }

--- a/java/core/src/test/java/io/v6d/core/client/IPCClientTest.java
+++ b/java/core/src/test/java/io/v6d/core/client/IPCClientTest.java
@@ -119,4 +119,36 @@ public class IPCClientTest {
             assertEquals(metadata.getTypename(), "vineyard::Scalar<std::string>");
         }
     }
+
+    @Test
+    public void testPersist() throws VineyardException {
+        val builder = new StringObjectBuilder("abcde");
+        val result = builder.seal(client);
+        assertFalse(result.isPersist());
+        client.persist(result);
+
+        val target = client.getMetaData(result.getId());
+        assertTrue(target.isPersist());
+    }
+
+    @Test
+    public void testNames() throws VineyardException {
+        val builder = new StringObjectBuilder("abcde");
+        val result = builder.seal(client);
+
+        VineyardException exp =
+                assertThrows(
+                        VineyardException.Invalid.class,
+                        () -> {
+                            client.putName(result.getId(), "test_name");
+                        });
+
+        client.persist(result);
+        client.putName(result.getId(), "test_name");
+
+        assertEquals(result.getId(), client.getName("test_name"));
+        val target = client.getMetaData(result.getId());
+        assertTrue(target.hasName());
+        assertEquals("test_name", target.getName());
+    }
 }

--- a/java/modules/basic/src/main/java/io/v6d/modules/basic/arrow/Arrow.java
+++ b/java/modules/basic/src/main/java/io/v6d/modules/basic/arrow/Arrow.java
@@ -27,6 +27,7 @@ public final class Arrow {
     public static final Logger logger = LoggerFactory.getLogger(Arrow.class);
 
     public static class Type {
+        public static final ArrowType Null = new ArrowType.Null();
         public static final ArrowType Int = new ArrowType.Int(32, true);
         public static final ArrowType UInt = new ArrowType.Int(32, false);
         public static final ArrowType Int64 = new ArrowType.Int(64, true);
@@ -36,9 +37,13 @@ public final class Arrow {
         public static final ArrowType Double =
                 new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE);
         public static final ArrowType Boolean = new ArrowType.Bool();
+        public static final ArrowType VarChar = new ArrowType.LargeUtf8();
+        public static final ArrowType VarBinary = new ArrowType.LargeBinary();
     }
 
     public static class FieldType {
+        public static final org.apache.arrow.vector.types.pojo.FieldType Null =
+                new org.apache.arrow.vector.types.pojo.FieldType(false, Type.Null, null);
         public static final org.apache.arrow.vector.types.pojo.FieldType Int =
                 new org.apache.arrow.vector.types.pojo.FieldType(false, Arrow.Type.Int, null);
         public static final org.apache.arrow.vector.types.pojo.FieldType UInt =
@@ -53,14 +58,25 @@ public final class Arrow {
                 new org.apache.arrow.vector.types.pojo.FieldType(false, Type.Double, null);
         public static final org.apache.arrow.vector.types.pojo.FieldType Boolean =
                 new org.apache.arrow.vector.types.pojo.FieldType(false, Type.Boolean, null);
+        public static final org.apache.arrow.vector.types.pojo.FieldType VarChar =
+                new org.apache.arrow.vector.types.pojo.FieldType(false, Type.VarChar, null);
+        public static final org.apache.arrow.vector.types.pojo.FieldType VarBinary =
+                new org.apache.arrow.vector.types.pojo.FieldType(false, Type.VarBinary, null);
     }
 
-    public static Field makePlainField(
+    public static Field makeField(
             String name, org.apache.arrow.vector.types.pojo.FieldType fieldType) {
         return new Field(name, fieldType, ImmutableList.of());
     }
 
+    public static Field makeField(String name, ArrowType type) {
+        return new Field(
+                name,
+                new org.apache.arrow.vector.types.pojo.FieldType(false, type, null),
+                ImmutableList.of());
+    }
+
     public static void instantiate() {
-        RecordBatch.instantiate();
+        Table.instantiate();
     }
 }

--- a/java/modules/basic/src/main/java/io/v6d/modules/basic/arrow/BooleanArray.java
+++ b/java/modules/basic/src/main/java/io/v6d/modules/basic/arrow/BooleanArray.java
@@ -14,30 +14,29 @@
  */
 package io.v6d.modules.basic.arrow;
 
+import static io.v6d.modules.basic.arrow.Arrow.logger;
+
 import com.google.common.base.Objects;
 import io.v6d.core.client.ds.Object;
 import io.v6d.core.client.ds.ObjectFactory;
 import io.v6d.core.client.ds.ObjectMeta;
 import java.util.Arrays;
-import lombok.val;
-import org.apache.arrow.vector.BigIntVector;
+import lombok.*;
+import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.ipc.message.ArrowFieldNode;
 
 /** Hello world! */
-public class Int64Array extends Array {
-    private BigIntVector array;
+public class BooleanArray extends Array {
+    private BitVector array;
 
     public static void instantiate() {
-        ObjectFactory.getFactory()
-                .register("vineyard::NumericArray<int64>", new Int64ArrayResolver());
-        ObjectFactory.getFactory()
-                .register("vineyard::NumericArray<uint64>", new Int64ArrayResolver());
+        ObjectFactory.getFactory().register("vineyard::BooleanArray", new BooleanArrayResolver());
     }
 
-    public Int64Array(final ObjectMeta meta, Buffer buffer, long length) {
+    public BooleanArray(final ObjectMeta meta, Buffer buffer, long length) {
         super(meta);
-        this.array = new BigIntVector("", Arrow.default_allocator);
+        this.array = new BitVector("", Arrow.default_allocator);
         this.array.loadFieldBuffers(
                 new ArrowFieldNode(length, 0), Arrays.asList(null, buffer.getBuffer()));
     }
@@ -59,7 +58,7 @@ public class Int64Array extends Array {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        Int64Array that = (Int64Array) o;
+        BooleanArray that = (BooleanArray) o;
         return Objects.equal(array, that.array);
     }
 
@@ -69,10 +68,11 @@ public class Int64Array extends Array {
     }
 }
 
-class Int64ArrayResolver extends ObjectFactory.Resolver {
+class BooleanArrayResolver extends ObjectFactory.Resolver {
     @Override
     public Object resolve(final ObjectMeta meta) {
+        logger.debug("boolean array resolver: from metadata {}", meta);
         val buffer = (Buffer) ObjectFactory.getFactory().resolve(meta.getMemberMeta("buffer_"));
-        return new Int64Array(meta, buffer, meta.getLongValue("length_"));
+        return new BooleanArray(meta, buffer, meta.getLongValue("length_"));
     }
 }

--- a/java/modules/basic/src/main/java/io/v6d/modules/basic/arrow/BooleanArrayBuilder.java
+++ b/java/modules/basic/src/main/java/io/v6d/modules/basic/arrow/BooleanArrayBuilder.java
@@ -20,16 +20,16 @@ import io.v6d.core.client.ds.ObjectMeta;
 import io.v6d.core.common.util.VineyardException;
 import java.util.Arrays;
 import lombok.*;
+import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.FieldVector;
-import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.ipc.message.ArrowFieldNode;
 
-public class DoubleArrayBuilder implements ArrayBuilder {
+public class BooleanArrayBuilder implements ArrayBuilder {
     private BufferBuilder buffer;
-    private Float8Vector array;
+    private BitVector array;
 
-    public DoubleArrayBuilder(IPCClient client, long length) throws VineyardException {
-        this.array = new Float8Vector("", Arrow.default_allocator);
+    public BooleanArrayBuilder(IPCClient client, long length) throws VineyardException {
+        this.array = new BitVector("", Arrow.default_allocator);
         this.buffer = new BufferBuilder(client, this.array.getBufferSizeFor((int) length));
         this.array.loadFieldBuffers(
                 new ArrowFieldNode(length, 0), Arrays.asList(null, buffer.getBuffer()));
@@ -42,7 +42,7 @@ public class DoubleArrayBuilder implements ArrayBuilder {
     public ObjectMeta seal(Client client) throws VineyardException {
         this.build(client);
         val meta = ObjectMeta.empty();
-        meta.setTypename("vineyard::NumericArray<double>");
+        meta.setTypename("vineyard::BooleanArray");
         meta.setNBytes(array.getBufferSizeFor(array.getValueCount()));
         meta.setValue("length_", array.getValueCount());
         meta.setValue("null_count_", 0);
@@ -57,7 +57,7 @@ public class DoubleArrayBuilder implements ArrayBuilder {
         return this.array;
     }
 
-    void set(int index, double value) {
-        this.array.set(index, value);
+    void set(int index, boolean value) {
+        this.array.set(index, value ? 1 : 0);
     }
 }

--- a/java/modules/basic/src/main/java/io/v6d/modules/basic/arrow/FloatArrayBuilder.java
+++ b/java/modules/basic/src/main/java/io/v6d/modules/basic/arrow/FloatArrayBuilder.java
@@ -29,8 +29,8 @@ public class FloatArrayBuilder implements ArrayBuilder {
     private Float4Vector array;
 
     public FloatArrayBuilder(IPCClient client, long length) throws VineyardException {
-        this.buffer = new BufferBuilder(client, length * 4);
         this.array = new Float4Vector("", Arrow.default_allocator);
+        this.buffer = new BufferBuilder(client, this.array.getBufferSizeFor((int) length));
         this.array.loadFieldBuffers(
                 new ArrowFieldNode(length, 0), Arrays.asList(null, buffer.getBuffer()));
     }
@@ -43,9 +43,12 @@ public class FloatArrayBuilder implements ArrayBuilder {
         this.build(client);
         val meta = ObjectMeta.empty();
         meta.setTypename("vineyard::NumericArray<float>");
-        meta.setNBytes(array.getBufferSizeFor(1));
+        meta.setNBytes(array.getBufferSizeFor(array.getValueCount()));
         meta.setValue("length_", array.getValueCount());
+        meta.setValue("null_count_", 0);
+        meta.setValue("offset_", 0);
         meta.addMember("buffer_", buffer.seal(client));
+        meta.addMember("null_bitmap_", BufferBuilder.empty(client));
         return client.createMetaData(meta);
     }
 

--- a/java/modules/basic/src/main/java/io/v6d/modules/basic/arrow/Int32Array.java
+++ b/java/modules/basic/src/main/java/io/v6d/modules/basic/arrow/Int32Array.java
@@ -31,6 +31,8 @@ public class Int32Array extends Array {
     public static void instantiate() {
         ObjectFactory.getFactory()
                 .register("vineyard::NumericArray<int>", new Int32ArrayResolver());
+        ObjectFactory.getFactory()
+                .register("vineyard::NumericArray<uint>", new Int32ArrayResolver());
     }
 
     public Int32Array(ObjectMeta meta, Buffer buffer, long length) {

--- a/java/modules/basic/src/main/java/io/v6d/modules/basic/arrow/Int32ArrayBuilder.java
+++ b/java/modules/basic/src/main/java/io/v6d/modules/basic/arrow/Int32ArrayBuilder.java
@@ -29,8 +29,8 @@ public class Int32ArrayBuilder implements ArrayBuilder {
     private IntVector array;
 
     public Int32ArrayBuilder(IPCClient client, long length) throws VineyardException {
-        this.buffer = new BufferBuilder(client, length * 4);
         this.array = new IntVector("", Arrow.default_allocator);
+        this.buffer = new BufferBuilder(client, this.array.getBufferSizeFor((int) length));
         this.array.loadFieldBuffers(
                 new ArrowFieldNode(length, 0), Arrays.asList(null, buffer.getBuffer()));
     }
@@ -43,9 +43,12 @@ public class Int32ArrayBuilder implements ArrayBuilder {
         this.build(client);
         val meta = ObjectMeta.empty();
         meta.setTypename("vineyard::NumericArray<int>");
-        meta.setNBytes(array.getBufferSizeFor(1));
+        meta.setNBytes(array.getBufferSizeFor(array.getValueCount()));
         meta.setValue("length_", array.getValueCount());
+        meta.setValue("null_count_", 0);
+        meta.setValue("offset_", 0);
         meta.addMember("buffer_", buffer.seal(client));
+        meta.addMember("null_bitmap_", BufferBuilder.empty(client));
         return client.createMetaData(meta);
     }
 

--- a/java/modules/basic/src/main/java/io/v6d/modules/basic/arrow/Int64ArrayBuilder.java
+++ b/java/modules/basic/src/main/java/io/v6d/modules/basic/arrow/Int64ArrayBuilder.java
@@ -29,8 +29,8 @@ public class Int64ArrayBuilder implements ArrayBuilder {
     private BigIntVector array;
 
     public Int64ArrayBuilder(IPCClient client, long length) throws VineyardException {
-        this.buffer = new BufferBuilder(client, length * 8);
         this.array = new BigIntVector("", Arrow.default_allocator);
+        this.buffer = new BufferBuilder(client, this.array.getBufferSizeFor((int) length));
         this.array.loadFieldBuffers(
                 new ArrowFieldNode(length, 0), Arrays.asList(null, buffer.getBuffer()));
     }
@@ -43,9 +43,12 @@ public class Int64ArrayBuilder implements ArrayBuilder {
         this.build(client);
         val meta = ObjectMeta.empty();
         meta.setTypename("vineyard::NumericArray<int64>");
-        meta.setNBytes(array.getBufferSizeFor(1));
+        meta.setNBytes(array.getBufferSizeFor(array.getValueCount()));
         meta.setValue("length_", array.getValueCount());
+        meta.setValue("null_count_", 0);
+        meta.setValue("offset_", 0);
         meta.addMember("buffer_", buffer.seal(client));
+        meta.addMember("null_bitmap_", BufferBuilder.empty(client));
         return client.createMetaData(meta);
     }
 

--- a/java/modules/basic/src/main/java/io/v6d/modules/basic/arrow/NullArray.java
+++ b/java/modules/basic/src/main/java/io/v6d/modules/basic/arrow/NullArray.java
@@ -14,36 +14,30 @@
  */
 package io.v6d.modules.basic.arrow;
 
+import static io.v6d.modules.basic.arrow.Arrow.logger;
+
 import com.google.common.base.Objects;
 import io.v6d.core.client.ds.Object;
 import io.v6d.core.client.ds.ObjectFactory;
 import io.v6d.core.client.ds.ObjectMeta;
 import java.util.Arrays;
-import lombok.val;
-import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.NullVector;
 import org.apache.arrow.vector.ipc.message.ArrowFieldNode;
 
 /** Hello world! */
-public class Int64Array extends Array {
-    private BigIntVector array;
+public class NullArray extends Array {
+    private NullVector array;
 
     public static void instantiate() {
-        ObjectFactory.getFactory()
-                .register("vineyard::NumericArray<int64>", new Int64ArrayResolver());
-        ObjectFactory.getFactory()
-                .register("vineyard::NumericArray<uint64>", new Int64ArrayResolver());
+        ObjectFactory.getFactory().register("vineyard::NullArray", new NUllArrayResolver());
     }
 
-    public Int64Array(final ObjectMeta meta, Buffer buffer, long length) {
+    public NullArray(final ObjectMeta meta, long length) {
         super(meta);
-        this.array = new BigIntVector("", Arrow.default_allocator);
-        this.array.loadFieldBuffers(
-                new ArrowFieldNode(length, 0), Arrays.asList(null, buffer.getBuffer()));
-    }
-
-    public double get(int index) {
-        return this.array.get(index);
+        this.array = new NullVector();
+        this.array.loadFieldBuffers(new ArrowFieldNode(length, 0), Arrays.asList());
+        this.array.setValueCount((int) length);
     }
 
     @Override
@@ -59,8 +53,7 @@ public class Int64Array extends Array {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        Int64Array that = (Int64Array) o;
-        return Objects.equal(array, that.array);
+        return this.length() == ((NullArray) o).length();
     }
 
     @Override
@@ -69,10 +62,10 @@ public class Int64Array extends Array {
     }
 }
 
-class Int64ArrayResolver extends ObjectFactory.Resolver {
+class NUllArrayResolver extends ObjectFactory.Resolver {
     @Override
     public Object resolve(final ObjectMeta meta) {
-        val buffer = (Buffer) ObjectFactory.getFactory().resolve(meta.getMemberMeta("buffer_"));
-        return new Int64Array(meta, buffer, meta.getLongValue("length_"));
+        logger.debug("null array resolver: from metadata {}", meta);
+        return new NullArray(meta, meta.getLongValue("length_"));
     }
 }

--- a/java/modules/basic/src/main/java/io/v6d/modules/basic/arrow/SchemaBuilder.java
+++ b/java/modules/basic/src/main/java/io/v6d/modules/basic/arrow/SchemaBuilder.java
@@ -47,6 +47,11 @@ public class SchemaBuilder implements ObjectBuilder {
         return builder;
     }
 
+    public static SchemaBuilder fromSchema(io.v6d.modules.basic.arrow.Schema schema) {
+        // FIXME: should be able to reusing
+        return fromSchema(schema.getSchema());
+    }
+
     public void addField(final Field field) {
         fields.add(field);
     }

--- a/java/modules/basic/src/main/java/io/v6d/modules/basic/arrow/StringArrayBuilder.java
+++ b/java/modules/basic/src/main/java/io/v6d/modules/basic/arrow/StringArrayBuilder.java
@@ -1,0 +1,78 @@
+/** Copyright 2020-2021 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.v6d.modules.basic.arrow;
+
+import io.v6d.core.client.Client;
+import io.v6d.core.client.IPCClient;
+import io.v6d.core.client.ds.ObjectMeta;
+import io.v6d.core.common.util.VineyardException;
+import lombok.*;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.LargeVarCharVector;
+import org.apache.arrow.vector.util.Text;
+
+public class StringArrayBuilder implements ArrayBuilder {
+    private LargeVarCharVector array;
+
+    private BufferBuilder data_buffer_builder;
+    private BufferBuilder offset_buffer_builder;
+
+    public StringArrayBuilder(IPCClient client, final LargeVarCharVector vector)
+            throws VineyardException {
+        this.array = vector;
+    }
+
+    public StringArrayBuilder(IPCClient client, long length) throws VineyardException {
+        this.array = new LargeVarCharVector("", Arrow.default_allocator);
+        this.array.setValueCount((int) length);
+    }
+
+    @Override
+    public void build(Client client) throws VineyardException {
+        // FIXME the builder is a IPCClient, but RPCClient should be able work as well
+        this.data_buffer_builder =
+                new BufferBuilder((IPCClient) client, this.array.getDataBuffer());
+        this.offset_buffer_builder =
+                new BufferBuilder((IPCClient) client, this.array.getOffsetBuffer());
+    }
+
+    @Override
+    public ObjectMeta seal(Client client) throws VineyardException {
+        this.build(client);
+        val meta = ObjectMeta.empty();
+        meta.setTypename("vineyard::BaseBinaryArray<arrow::LargeStringArray>");
+        meta.setNBytes(array.getBufferSizeFor(array.getValueCount()));
+        meta.setValue("length_", array.getValueCount());
+        meta.setValue("null_count_", 0);
+        meta.setValue("offset_", 0);
+        meta.addMember("buffer_data_", data_buffer_builder.seal(client));
+        meta.addMember("buffer_offsets_", offset_buffer_builder.seal(client));
+        meta.addMember("null_bitmap_", BufferBuilder.empty(client));
+        return client.createMetaData(meta);
+    }
+
+    void set(int index, String value) {
+        this.array.setSafe(index, value.getBytes());
+    }
+
+    void set(int index, Text value) {
+        this.array.set(index, value);
+    }
+
+    @Override
+    public FieldVector getArray() {
+        return this.array;
+    }
+}

--- a/java/modules/basic/src/main/java/io/v6d/modules/basic/arrow/Table.java
+++ b/java/modules/basic/src/main/java/io/v6d/modules/basic/arrow/Table.java
@@ -1,0 +1,121 @@
+/** Copyright 2020-2021 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.v6d.modules.basic.arrow;
+
+import com.google.common.base.Objects;
+import io.v6d.core.client.ds.Object;
+import io.v6d.core.client.ds.ObjectFactory;
+import io.v6d.core.client.ds.ObjectMeta;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import lombok.val;
+import org.apache.arrow.vector.VectorSchemaRoot;
+
+/** Hello world! */
+public class Table extends Object {
+    private final int rows;
+    private final int columns;
+    private final Schema schema;
+    private final List<RecordBatch> batches;
+
+    public static void instantiate() {
+        RecordBatch.instantiate();
+        ObjectFactory.getFactory().register("vineyard::Table", new TableResolver());
+    }
+
+    public Table(
+            final ObjectMeta meta,
+            Schema schema,
+            int rows,
+            int columns,
+            List<RecordBatch> batches) {
+        super(meta);
+        this.schema = schema;
+        this.rows = rows;
+        this.columns = columns;
+        this.batches = batches;
+    }
+
+    public Schema getSchema() {
+        return schema;
+    }
+
+    public int getRows() {
+        return rows;
+    }
+
+    public int getColumns() {
+        return columns;
+    }
+
+    public List<RecordBatch> getBatches() {
+        return batches;
+    }
+
+    public RecordBatch getBatch(int index) {
+        return batches.get(index);
+    }
+
+    public VectorSchemaRoot getArrowBatch(int index) {
+        return batches.get(index).getBatch();
+    }
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Table that = (Table) o;
+        if (this.batches.size() != that.batches.size()) {
+            return false;
+        }
+        for (int index = 0; index < this.batches.size(); ++index) {
+            if (!Objects.equal(this.batches.get(index), that.batches.get(index))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(batches);
+    }
+}
+
+class TableResolver extends ObjectFactory.Resolver {
+    @Override
+    public Object resolve(final ObjectMeta meta) {
+        val ncol = meta.getIntValue("num_columns_");
+        val nrow = meta.getIntValue("num_rows_");
+        val nbatch = meta.getIntValue("batch_num_");
+
+        val schema = (Schema) new SchemaResolver().resolve(meta.getMemberMeta("schema_"));
+
+        val batches =
+                IntStream.range(0, nbatch)
+                        .mapToObj(
+                                index -> {
+                                    val batch = meta.getMemberMeta("__batches_-" + index);
+                                    return (RecordBatch) ObjectFactory.getFactory().resolve(batch);
+                                })
+                        .collect(Collectors.toList());
+        return new Table(meta, schema, nrow, ncol, batches);
+    }
+}

--- a/java/modules/basic/src/main/java/io/v6d/modules/basic/arrow/TableBuilder.java
+++ b/java/modules/basic/src/main/java/io/v6d/modules/basic/arrow/TableBuilder.java
@@ -1,0 +1,89 @@
+/** Copyright 2020-2021 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.v6d.modules.basic.arrow;
+
+import static java.util.Objects.requireNonNull;
+
+import io.v6d.core.client.Client;
+import io.v6d.core.client.IPCClient;
+import io.v6d.core.client.ds.ObjectBase;
+import io.v6d.core.client.ds.ObjectBuilder;
+import io.v6d.core.client.ds.ObjectMeta;
+import io.v6d.core.common.util.VineyardException;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import lombok.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TableBuilder implements ObjectBuilder {
+    private Logger logger = LoggerFactory.getLogger(TableBuilder.class);
+
+    private final SchemaBuilder schemaBuilder;
+    private final List<ObjectBase> batches;
+
+    public TableBuilder(
+            final IPCClient client,
+            final SchemaBuilder schemaBuilder,
+            final List<RecordBatchBuilder> batchBuilders) {
+        this.schemaBuilder = requireNonNull(schemaBuilder, "schema is null");
+        this.batches = new ArrayList<>(requireNonNull(batchBuilders, "batches are null"));
+    }
+
+    public TableBuilder(final IPCClient client, final SchemaBuilder schemaBuilder) {
+        this.schemaBuilder = requireNonNull(schemaBuilder, "schema is null");
+        this.batches = new LinkedList<>();
+    }
+
+    public void addBatch(RecordBatch batch) {
+        this.batches.add(batch);
+    }
+
+    public void addBatch(RecordBatchBuilder builder) {
+        this.batches.add(builder);
+    }
+
+    public List<ObjectBase> getBatches() {
+        return this.batches;
+    }
+
+    public int getBatchSize() {
+        return this.batches.size();
+    }
+
+    @Override
+    public void build(Client client) throws VineyardException {}
+
+    @Override
+    public ObjectMeta seal(Client client) throws VineyardException {
+        this.build(client);
+
+        val meta = ObjectMeta.empty();
+
+        meta.setTypename("vineyard::RecordBatch");
+        meta.setValue("batch_num_", batches.size());
+        meta.setValue("num_rows_", -1);
+        meta.setValue("num_columns_", schemaBuilder.getFields().size());
+        meta.addMember("schema_", schemaBuilder.seal(client));
+
+        for (int index = 0; index < batches.size(); ++index) {
+            meta.addMember("__batches_-" + index, batches.get(index).seal(client));
+        }
+        meta.setNBytes(0); // FIXME
+
+        return client.createMetaData(meta);
+    }
+}

--- a/java/modules/basic/src/main/java/io/v6d/modules/basic/columnar/ColumnarData.java
+++ b/java/modules/basic/src/main/java/io/v6d/modules/basic/columnar/ColumnarData.java
@@ -41,11 +41,17 @@ import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.IntervalDayVector;
 import org.apache.arrow.vector.IntervalYearVector;
+import org.apache.arrow.vector.LargeVarBinaryVector;
+import org.apache.arrow.vector.LargeVarCharVector;
 import org.apache.arrow.vector.NullVector;
 import org.apache.arrow.vector.SmallIntVector;
 import org.apache.arrow.vector.TimeStampMicroTZVector;
 import org.apache.arrow.vector.TimeStampMicroVector;
 import org.apache.arrow.vector.TinyIntVector;
+import org.apache.arrow.vector.UInt1Vector;
+import org.apache.arrow.vector.UInt2Vector;
+import org.apache.arrow.vector.UInt4Vector;
+import org.apache.arrow.vector.UInt8Vector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.VarBinaryVector;
 import org.apache.arrow.vector.VarCharVector;
@@ -62,12 +68,20 @@ public class ColumnarData {
             accessor = new BooleanAccessor((BitVector) vector);
         } else if (vector instanceof TinyIntVector) {
             accessor = new ByteAccessor((TinyIntVector) vector);
+        } else if (vector instanceof UInt1Vector) {
+            accessor = new UByteAccessor((UInt1Vector) vector);
         } else if (vector instanceof SmallIntVector) {
             accessor = new ShortAccessor((SmallIntVector) vector);
+        } else if (vector instanceof UInt2Vector) {
+            accessor = new UShortAccessor((UInt2Vector) vector);
         } else if (vector instanceof IntVector) {
             accessor = new IntAccessor((IntVector) vector);
+        } else if (vector instanceof UInt4Vector) {
+            accessor = new UIntAccessor((UInt4Vector) vector);
         } else if (vector instanceof BigIntVector) {
             accessor = new LongAccessor((BigIntVector) vector);
+        } else if (vector instanceof UInt8Vector) {
+            accessor = new ULongAccessor((UInt8Vector) vector);
         } else if (vector instanceof Float4Vector) {
             accessor = new FloatAccessor((Float4Vector) vector);
         } else if (vector instanceof Float8Vector) {
@@ -76,8 +90,12 @@ public class ColumnarData {
             accessor = new DecimalAccessor((DecimalVector) vector);
         } else if (vector instanceof VarCharVector) {
             accessor = new StringAccessor((VarCharVector) vector);
+        } else if (vector instanceof LargeVarCharVector) {
+            accessor = new LargeStringAccessor((LargeVarCharVector) vector);
         } else if (vector instanceof VarBinaryVector) {
             accessor = new BinaryAccessor((VarBinaryVector) vector);
+        } else if (vector instanceof LargeVarBinaryVector) {
+            accessor = new LargeBinaryAccessor((LargeVarBinaryVector) vector);
         } else if (vector instanceof DateDayVector) {
             accessor = new DateAccessor((DateDayVector) vector);
         } else if (vector instanceof TimeStampMicroTZVector) {
@@ -94,6 +112,14 @@ public class ColumnarData {
             throw new UnsupportedOperationException(
                     "array type is not supported yet: " + vector.getClass());
         }
+    }
+
+    public ArrowVectorAccessor getAccessor() {
+        return accessor;
+    }
+
+    public ValueVector getVector() {
+        return accessor.getVector();
     }
 
     public boolean hasNull() {
@@ -114,6 +140,10 @@ public class ColumnarData {
 
     public boolean isNullAt(int rowId) {
         return accessor.isNullAt(rowId);
+    }
+
+    public Object getObject(int rowId) {
+        return accessor.getObject(rowId);
     }
 
     public boolean getBoolean(int rowId) {
@@ -172,6 +202,10 @@ public class ColumnarData {
             this.vector = vector;
         }
 
+        public final ValueVector getVector() {
+            return vector;
+        }
+
         final boolean isNullAt(int rowId) {
             return vector.isNull(rowId);
         }
@@ -186,6 +220,10 @@ public class ColumnarData {
 
         final void close() {
             vector.close();
+        }
+
+        Object getObject(int rowId) {
+            throw new UnsupportedOperationException();
         }
 
         boolean getBoolean(int rowId) {
@@ -240,6 +278,11 @@ public class ColumnarData {
         }
 
         @Override
+        Object getObject(int rowId) {
+            return getBoolean(rowId);
+        }
+
+        @Override
         final boolean getBoolean(int rowId) {
             return accessor.get(rowId) == 1;
         }
@@ -252,6 +295,31 @@ public class ColumnarData {
         ByteAccessor(TinyIntVector vector) {
             super(vector);
             this.accessor = vector;
+        }
+
+        @Override
+        Object getObject(int rowId) {
+            return getByte(rowId);
+        }
+
+        @Override
+        final byte getByte(int rowId) {
+            return accessor.get(rowId);
+        }
+    }
+
+    private static class UByteAccessor extends ArrowVectorAccessor {
+
+        private final UInt1Vector accessor;
+
+        UByteAccessor(UInt1Vector vector) {
+            super(vector);
+            this.accessor = vector;
+        }
+
+        @Override
+        Object getObject(int rowId) {
+            return getByte(rowId);
         }
 
         @Override
@@ -270,8 +338,33 @@ public class ColumnarData {
         }
 
         @Override
+        Object getObject(int rowId) {
+            return getShort(rowId);
+        }
+
+        @Override
         final short getShort(int rowId) {
             return accessor.get(rowId);
+        }
+    }
+
+    private static class UShortAccessor extends ArrowVectorAccessor {
+
+        private final UInt2Vector accessor;
+
+        UShortAccessor(UInt2Vector vector) {
+            super(vector);
+            this.accessor = vector;
+        }
+
+        @Override
+        Object getObject(int rowId) {
+            return getShort(rowId);
+        }
+
+        @Override
+        final short getShort(int rowId) {
+            return (short) accessor.get(rowId);
         }
     }
 
@@ -282,6 +375,31 @@ public class ColumnarData {
         IntAccessor(IntVector vector) {
             super(vector);
             this.accessor = vector;
+        }
+
+        @Override
+        Object getObject(int rowId) {
+            return getInt(rowId);
+        }
+
+        @Override
+        final int getInt(int rowId) {
+            return accessor.get(rowId);
+        }
+    }
+
+    private static class UIntAccessor extends ArrowVectorAccessor {
+
+        private final UInt4Vector accessor;
+
+        UIntAccessor(UInt4Vector vector) {
+            super(vector);
+            this.accessor = vector;
+        }
+
+        @Override
+        Object getObject(int rowId) {
+            return getInt(rowId);
         }
 
         @Override
@@ -300,6 +418,31 @@ public class ColumnarData {
         }
 
         @Override
+        Object getObject(int rowId) {
+            return getLong(rowId);
+        }
+
+        @Override
+        final long getLong(int rowId) {
+            return accessor.get(rowId);
+        }
+    }
+
+    private static class ULongAccessor extends ArrowVectorAccessor {
+
+        private final UInt8Vector accessor;
+
+        ULongAccessor(UInt8Vector vector) {
+            super(vector);
+            this.accessor = vector;
+        }
+
+        @Override
+        Object getObject(int rowId) {
+            return getLong(rowId);
+        }
+
+        @Override
         final long getLong(int rowId) {
             return accessor.get(rowId);
         }
@@ -312,6 +455,11 @@ public class ColumnarData {
         FloatAccessor(Float4Vector vector) {
             super(vector);
             this.accessor = vector;
+        }
+
+        @Override
+        Object getObject(int rowId) {
+            return getFloat(rowId);
         }
 
         @Override
@@ -330,6 +478,11 @@ public class ColumnarData {
         }
 
         @Override
+        Object getObject(int rowId) {
+            return getDouble(rowId);
+        }
+
+        @Override
         final double getDouble(int rowId) {
             return accessor.get(rowId);
         }
@@ -342,6 +495,11 @@ public class ColumnarData {
         DecimalAccessor(DecimalVector vector) {
             super(vector);
             this.accessor = vector;
+        }
+
+        @Override
+        Object getObject(int rowId) {
+            return getDecimal(rowId, 24, 8);
         }
 
         @Override
@@ -361,6 +519,32 @@ public class ColumnarData {
         }
 
         @Override
+        Object getObject(int rowId) {
+            return getUTF8String(rowId);
+        }
+
+        @Override
+        final Text getUTF8String(int rowId) {
+            return accessor.getObject(rowId);
+        }
+    }
+
+    private static class LargeStringAccessor extends ArrowVectorAccessor {
+
+        private final LargeVarCharVector accessor;
+        private final NullableVarCharHolder stringResult = new NullableVarCharHolder();
+
+        LargeStringAccessor(LargeVarCharVector vector) {
+            super(vector);
+            this.accessor = vector;
+        }
+
+        @Override
+        Object getObject(int rowId) {
+            return getUTF8String(rowId);
+        }
+
+        @Override
         final Text getUTF8String(int rowId) {
             return accessor.getObject(rowId);
         }
@@ -373,6 +557,31 @@ public class ColumnarData {
         BinaryAccessor(VarBinaryVector vector) {
             super(vector);
             this.accessor = vector;
+        }
+
+        @Override
+        Object getObject(int rowId) {
+            return getBinary(rowId);
+        }
+
+        @Override
+        final byte[] getBinary(int rowId) {
+            return accessor.getObject(rowId);
+        }
+    }
+
+    private static class LargeBinaryAccessor extends ArrowVectorAccessor {
+
+        private final LargeVarBinaryVector accessor;
+
+        LargeBinaryAccessor(LargeVarBinaryVector vector) {
+            super(vector);
+            this.accessor = vector;
+        }
+
+        @Override
+        Object getObject(int rowId) {
+            return getBinary(rowId);
         }
 
         @Override
@@ -391,6 +600,11 @@ public class ColumnarData {
         }
 
         @Override
+        Object getObject(int rowId) {
+            return getInt(rowId);
+        }
+
+        @Override
         final int getInt(int rowId) {
             return accessor.get(rowId);
         }
@@ -406,6 +620,11 @@ public class ColumnarData {
         }
 
         @Override
+        Object getObject(int rowId) {
+            return getLong(rowId);
+        }
+
+        @Override
         final long getLong(int rowId) {
             return accessor.get(rowId);
         }
@@ -418,6 +637,11 @@ public class ColumnarData {
         TimestampNTZAccessor(TimeStampMicroVector vector) {
             super(vector);
             this.accessor = vector;
+        }
+
+        @Override
+        Object getObject(int rowId) {
+            return getLong(rowId);
         }
 
         @Override
@@ -443,6 +667,11 @@ public class ColumnarData {
         }
 
         @Override
+        Object getObject(int rowId) {
+            return getInt(rowId);
+        }
+
+        @Override
         int getInt(int rowId) {
             return accessor.get(rowId);
         }
@@ -456,6 +685,11 @@ public class ColumnarData {
         IntervalDayAccessor(IntervalDayVector vector) {
             super(vector);
             this.accessor = vector;
+        }
+
+        @Override
+        Object getObject(int rowId) {
+            return getLong(rowId);
         }
 
         @Override


### PR DESCRIPTION


What do these changes do?
-------------------------

+ Implments the `client.persist` and `client.{put,get,drop}_name` API
+ Implments more array types and arrow table type.

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #227 

