### PR TITLE
Fixes the buffer size when building arrow string arrays.

### DIFF
--- a/java/modules/basic/src/main/java/io/v6d/modules/basic/arrow/BufferBuilder.java
+++ b/java/modules/basic/src/main/java/io/v6d/modules/basic/arrow/BufferBuilder.java
@@ -46,13 +46,18 @@ public class BufferBuilder implements ObjectBuilder {
     }
 
     public BufferBuilder(IPCClient client, final ArrowBuf buffer) throws VineyardException {
-        this.buffer = client.createBuffer(buffer.capacity());
+        this(client, buffer, buffer.capacity());
+        logger.warn(
+                "Construct buffer builder without explicit size is dangerous, will over commit the memory");
+    }
+
+    public BufferBuilder(IPCClient client, final ArrowBuf buffer, final long capacity)
+            throws VineyardException {
+        this.buffer = client.createBuffer(capacity);
         this.arrowBuf = buffer;
-        if (buffer.capacity() > 0) {
+        if (capacity > 0) {
             MemoryUtil.UNSAFE.copyMemory(
-                    this.arrowBuf.memoryAddress(),
-                    this.buffer.getPointer(),
-                    this.arrowBuf.capacity());
+                    this.arrowBuf.memoryAddress(), this.buffer.getPointer(), capacity);
         }
     }
 

--- a/java/modules/basic/src/main/java/io/v6d/modules/basic/arrow/StringArrayBuilder.java
+++ b/java/modules/basic/src/main/java/io/v6d/modules/basic/arrow/StringArrayBuilder.java
@@ -41,11 +41,18 @@ public class StringArrayBuilder implements ArrayBuilder {
 
     @Override
     public void build(Client client) throws VineyardException {
-        // FIXME the builder is a IPCClient, but RPCClient should be able work as well
+        val offset_buffer_size = (this.array.getValueCount() + 1) * LargeVarCharVector.OFFSET_WIDTH;
+        val offset_buffer = this.array.getOffsetBuffer();
+
+        val data_buffer_size =
+                offset_buffer.getLong(
+                        ((long) this.array.getValueCount()) * LargeVarCharVector.OFFSET_WIDTH);
+        val data_buffer = this.array.getDataBuffer();
+
         this.data_buffer_builder =
-                new BufferBuilder((IPCClient) client, this.array.getDataBuffer());
+                new BufferBuilder((IPCClient) client, data_buffer, data_buffer_size);
         this.offset_buffer_builder =
-                new BufferBuilder((IPCClient) client, this.array.getOffsetBuffer());
+                new BufferBuilder((IPCClient) client, offset_buffer, offset_buffer_size);
     }
 
     @Override


### PR DESCRIPTION


What do these changes do?
-------------------------

Use the true size, rather than capacity.

Related issue number
--------------------

Fixes #227 

