### PR TITLE
Fixes the type convension between C++ and Python.

### DIFF
--- a/python/client.cc
+++ b/python/client.cc
@@ -617,6 +617,6 @@ void bind_client(py::module& mod) {
                 rpc_endpoint);
           },
           "(host, port)"_a);
-}
+}  // NOLINT(readability/fn_size)
 
 }  // namespace vineyard

--- a/python/vineyard/data/utils.py
+++ b/python/vineyard/data/utils.py
@@ -55,17 +55,11 @@ def normalize_cpptype(dtype):
     if dtype.name == 'int32':
         return 'int'
     if dtype.name == 'uint32':
-        return 'unsigned int'
+        return 'uint32'
     if dtype.name == 'int64':
-        if platform.system() == 'Linux':
-            return 'long'
-        else:
-            return 'long long'
+        return 'int64'
     if dtype.name == 'uint64':
-        if platform.system() == 'Linux':
-            return 'unsigned long'
-        else:
-            return 'unsigned long long'
+        return 'uint64'
     if dtype.name == 'float32':
         return 'float'
     if dtype.name == 'float64':


### PR DESCRIPTION

What do these changes do?
-------------------------

To make sure the typename generated by Python is understandable in C++ SDK.


Related issue number
--------------------

Fixes N/A

