### PR TITLE
Fixes for backwards compatibility on Ubuntu 18.04.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -675,7 +675,6 @@ if(BUILD_VINEYARD_TESTS)
         add_test(${T_NAME}, ${T_NAME})
         add_dependencies(vineyard_tests ${T_NAME})
 
-        target_compile_options(${T_NAME} PRIVATE "-std=c++17")
         if(${T_NAME} STREQUAL "delete_test" OR ${T_NAME} STREQUAL "rpc_delete_test")
             target_compile_options(${T_NAME} PRIVATE "-fno-access-control")
         endif()


### PR DESCRIPTION

What do these changes do?
-------------------------

<!-- Please give a short brief about these changes. -->
No need for `-std=c++17` when building tests.

Related issue number
--------------------

See also https://github.com/nlohmann/json/issues/3203