### PR TITLE
Find the longest match when possible.

### DIFF
--- a/python/vineyard/core/utils.py
+++ b/python/vineyard/core/utils.py
@@ -30,9 +30,9 @@ def find_most_precise_match(typename, candidates):
             entry is the candidate item, e.g., resolver or driver method.
     '''
     if candidates:
-        for prefix, candidate in candidates.items():
+        for prefix in reversed(candidates):  # requires further optimization
             if typename.startswith(prefix):
-                return prefix, candidate
+                return prefix, candidates[prefix]
     return None, None
 
 

--- a/python/vineyard/io/serialization.py
+++ b/python/vineyard/io/serialization.py
@@ -19,7 +19,6 @@
 import logging
 from urllib.parse import urlparse
 
-import vineyard
 from ..core.driver import registerize
 
 logger = logging.getLogger('vineyard')

--- a/python/vineyard/io/stream.py
+++ b/python/vineyard/io/stream.py
@@ -20,7 +20,6 @@ import logging
 import traceback
 from urllib.parse import urlparse
 
-import vineyard
 from ..core.driver import registerize
 
 logger = logging.getLogger('vineyard')


### PR DESCRIPTION
What do these changes do?
-------------------------

For given typename in metadata `vineyard::DataFrameStream`, we should try `vineyard::DataFrameStream` first, then `vineyard::DataFrame`, as the resolver works in a prefix- mode.

Related issue number
--------------------

N/A

