### PR TITLE
Fixes the name matcher for flags when showing help information. 

### DIFF
--- a/.github/workflows/build-vineyardd-and-wheels-macos.yaml
+++ b/.github/workflows/build-vineyardd-and-wheels-macos.yaml
@@ -14,10 +14,7 @@
 
 name: Build Packages for MacOS
 
-on:
-  push:
-    tags:
-      - 'v*'
+on: [push]
 
 jobs:
   build-vineyardd:
@@ -157,6 +154,10 @@ jobs:
 
           make vineyardd -j`nproc`
           cp ./bin/vineyardd ../vineyardd
+
+      - name: Setup tmate session
+        if: true
+        uses: mxschmitt/action-tmate@v2
 
       - name: Package vineyardd artifact on MacOS
         run: |

--- a/.github/workflows/build-vineyardd-and-wheels-macos.yaml
+++ b/.github/workflows/build-vineyardd-and-wheels-macos.yaml
@@ -14,7 +14,10 @@
 
 name: Build Packages for MacOS
 
-on: [push]
+on:
+  push:
+    tags:
+      - 'v*'
 
 jobs:
   build-vineyardd:
@@ -154,10 +157,6 @@ jobs:
 
           make vineyardd -j`nproc`
           cp ./bin/vineyardd ../vineyardd
-
-      - name: Setup tmate session
-        if: true
-        uses: mxschmitt/action-tmate@v2
 
       - name: Package vineyardd artifact on MacOS
         run: |

--- a/docker/Dockerfile.vineyardd
+++ b/docker/Dockerfile.vineyardd
@@ -16,12 +16,12 @@ FROM docker.pkg.github.com/v6d-io/v6d/vineyardd-alpine-builder:20210929 as build
 
 # target: docker.pkg.github.com/v6d-io/v6d/vineyardd:alpine-latest
 
-ADD . /work/libvineyard
+ADD . /work/v6d
 
 # FIXME It is still not clear why the first run of cmake will fail.
 
 # patch cpprestsdk to drop boost::regex dependency.
-RUN cd /work/libvineyard && \
+RUN cd /work/v6d && \
     sed -i 's/Boost::regex//g' thirdparty/cpprestsdk/Release/cmake/cpprest_find_boost.cmake && \
     sed -i 's/regex//g' thirdparty/cpprestsdk/Release/cmake/cpprest_find_boost.cmake
 
@@ -32,9 +32,9 @@ RUN cd /tmp && \
     chmod +x wait-for-it.sh && \
     curl -LO https://github.com/etcd-io/etcd/releases/download/v3.4.13/etcd-v3.4.13-linux-amd64.tar.gz && \
     tar zxvf etcd-v3.4.13-linux-amd64.tar.gz && \
-    cd /work/libvineyard && \
-    mkdir -p /work/libvineyard/build && \
-    cd /work/libvineyard/build && \
+    cd /work/v6d && \
+    mkdir -p /work/v6d/build && \
+    cd /work/v6d/build && \
     cmake .. -DCMAKE_BUILD_TYPE=Release \
          -DBUILD_SHARED_LIBS=OFF \
          -DUSE_STATIC_BOOST_LIBS=ON \
@@ -59,7 +59,7 @@ RUN apk add --no-cache bash
 COPY --from=builder /tmp/dumb-init_1.2.2_amd64 /usr/bin/dumb-init
 COPY --from=builder /tmp/wait-for-it.sh /usr/bin/wait-for-it.sh
 COPY --from=builder /tmp/etcd-v3.4.13-linux-amd64/etcd /usr/bin/etcd
-COPY --from=builder /work/libvineyard/build/bin/vineyardd /usr/local/bin/vineyardd
+COPY --from=builder /work/v6d/build/bin/vineyardd /usr/local/bin/vineyardd
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/usr/local/bin/vineyardd"]

--- a/docker/pypa/Dockerfile.manylinux1-wheel
+++ b/docker/pypa/Dockerfile.manylinux1-wheel
@@ -23,9 +23,9 @@ FROM docker.pkg.github.com/v6d-io/v6d/vineyard-manylinux1:20210929
 #   - cp39-cp39
 ARG python
 
-ADD . /work/libvineyard
+ADD . /work/v6d
 
-RUN cd /work/libvineyard && \
+RUN cd /work/v6d && \
     mkdir build && \
     cd build && \
     export PATH=$PATH:/opt/python/$python/bin && \
@@ -48,12 +48,12 @@ RUN cd /work/libvineyard && \
     make vineyard_client_python -j2 && \
     cd .. && \
     /opt/python/$python/bin/python setup.py bdist_wheel && \
-    export LD_LIBRARY_PATH=/work/libvineyard/build/lib:$LD_LIBRARY_PATH && \
+    export LD_LIBRARY_PATH=/work/v6d/build/lib:$LD_LIBRARY_PATH && \
     for pylibs in /opt/_internal/tools/lib/*; \
         do sed -i 's/p.error/logger.warning/g' $pylibs/site-packages/auditwheel/main_repair.py; \
     done && \
     for wheel in `ls dist/*`; do auditwheel repair -w fixed_wheels $wheel; done && \
     cd /work && \
     mkdir -p fixed_wheels/ && \
-    mv /work/libvineyard/fixed_wheels/* /work/fixed_wheels/ && \
-    rm -rf /work/libvineyard
+    mv /work/v6d/fixed_wheels/* /work/fixed_wheels/ && \
+    rm -rf /work/v6d

--- a/src/server/vineyardd.cc
+++ b/src/server/vineyardd.cc
@@ -79,7 +79,7 @@ int main(int argc, char* argv[]) {
   vineyard::flags::ParseCommandLineNonHelpFlags(&argc, &argv, false);
   if (FLAGS_help) {
     FLAGS_help = false;
-    FLAGS_helpmatch = "vineyard";
+    FLAGS_helpmatch = "v6d";
   }
   vineyard::flags::HandleCommandLineHelpFlags();
 


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

Use `v6d` to serve as the flags filter when showing help message to make sure `vineyardd --help` only shows informations that related to vineyardd binary.


Related issue number
--------------------

Fixes #616

