### PR TITLE
Fixes the typing of `DataframeStream`'s name and the "params_" field name

### DIFF
--- a/docs/notes/getting-started.rst
+++ b/docs/notes/getting-started.rst
@@ -153,7 +153,7 @@ Open a local file as a dataframe stream
      >>> from vineyard.io.stream import open
      >>> stream = open('file://twitter.e')
      >>> stream.typename
-     vineyard::DataFrameStream
+     vineyard::DataframeStream
 
 In practice, the file may be stored in an NFS, and we want to read the file in
 parallel to further speed up the IO process.

--- a/modules/io/python/drivers/io/adaptors/dump_dataframe.py
+++ b/modules/io/python/drivers/io/adaptors/dump_dataframe.py
@@ -19,12 +19,12 @@
 import sys
 
 import vineyard
-from vineyard.io.dataframe import DataFrameStream
+from vineyard.io.dataframe import DataframeStream
 
 
 def dump_dataframe(vineyard_socket, stream_id):
     client = vineyard.connect(vineyard_socket)
-    stream: DataFrameStream = client.get(stream_id)
+    stream: DataframeStream = client.get(stream_id)
     stream_reader = stream.open_reader(client)
 
     print('metadata: %s', stream.params)

--- a/modules/io/python/drivers/io/adaptors/parse_bytes_to_dataframe.py
+++ b/modules/io/python/drivers/io/adaptors/parse_bytes_to_dataframe.py
@@ -26,7 +26,7 @@ import pyarrow.csv
 import vineyard
 from vineyard.data.utils import normalize_arrow_dtype
 from vineyard.io.byte import ByteStream
-from vineyard.io.dataframe import DataFrameStream
+from vineyard.io.dataframe import DataframeStream
 from vineyard.io.utils import report_error, report_exception, report_success
 
 logger = logging.getLogger('vineyard')
@@ -110,7 +110,7 @@ def parse_bytes(vineyard_socket, stream_id, proc_num, proc_index):
             arrow_column_types[columns[i]] = normalize_arrow_dtype(column_type)
     convert_options.column_types = arrow_column_types
 
-    stream = DataFrameStream.new(client, params=instream.params)
+    stream = DataframeStream.new(client, params=instream.params)
     client.persist(stream.id)
     report_success(stream.id)
 

--- a/modules/io/python/drivers/io/adaptors/parse_dataframe_to_bytes.py
+++ b/modules/io/python/drivers/io/adaptors/parse_dataframe_to_bytes.py
@@ -23,7 +23,7 @@ import traceback
 import pyarrow as pa
 import vineyard
 from vineyard.io.byte import ByteStream
-from vineyard.io.dataframe import DataFrameStream
+from vineyard.io.dataframe import DataframeStream
 from vineyard.io.utils import report_exception, report_success
 
 
@@ -32,7 +32,7 @@ def parse_dataframe(vineyard_socket, stream_id, proc_num, proc_index):
     streams = client.get(stream_id)
     if len(streams) != proc_num or streams[proc_index] is None:
         raise ValueError(f"Fetch stream error with proc_num={proc_num},proc_index={proc_index}")
-    instream: DataFrameStream = streams[proc_index]
+    instream: DataframeStream = streams[proc_index]
     stream_reader = instream.open_reader(client)
 
     generate_header_row = instream.params.get("header_row", None) == "1"

--- a/modules/io/python/drivers/io/adaptors/read_bytes.py
+++ b/modules/io/python/drivers/io/adaptors/read_bytes.py
@@ -31,7 +31,6 @@ import pyarrow as pa
 
 import vineyard
 from vineyard.io.byte import ByteStream
-from vineyard.io.dataframe import DataFrameStream
 from vineyard.io.utils import report_error, report_exception, report_success
 
 try:
@@ -189,8 +188,8 @@ def read_bytes(
                         vineyard.memory_copy(chunk, 0, buffer)
             writer.finish()
         except Exception:
+            report_exception()
             if writer is not None:
-                report_exception()
                 writer.fail()
 
 

--- a/modules/io/python/drivers/io/adaptors/read_orc.py
+++ b/modules/io/python/drivers/io/adaptors/read_orc.py
@@ -29,7 +29,7 @@ import pyarrow as pa
 import pyorc
 
 import vineyard
-from vineyard.io.dataframe import DataFrameStream
+from vineyard.io.dataframe import DataframeStream
 from vineyard.io.utils import report_success
 
 try:
@@ -127,7 +127,7 @@ def read_orc(
     if read_options:
         raise ValueError("Reading ORC doesn't support read options.")
     client = vineyard.connect(vineyard_socket)
-    stream = DataFrameStream.new(client)
+    stream = DataframeStream.new(client)
     client.persist(stream.id)
     report_success(stream.id)
 

--- a/modules/io/python/drivers/io/adaptors/read_vineyard_dataframe.py
+++ b/modules/io/python/drivers/io/adaptors/read_vineyard_dataframe.py
@@ -23,7 +23,7 @@ from urllib.parse import urlparse
 
 import pyarrow as pa
 import vineyard
-from vineyard.io.dataframe import DataFrameStream
+from vineyard.io.dataframe import DataframeStream
 from vineyard.io.utils import report_exception, report_success
 
 
@@ -35,7 +35,7 @@ def read_vineyard_dataframe(vineyard_socket, path, storage_options, read_options
     params["header_row"] = "1" if read_options.get("header_row", False) else "0"
     params["delimiter"] = bytes(read_options.get("delimiter", ","), "utf-8").decode("unicode_escape")
 
-    stream = DataFrameStream.new(client, params)
+    stream = DataframeStream.new(client, params)
     client.persist(stream.id)
     report_success(stream.id)
 
@@ -47,7 +47,7 @@ def read_vineyard_dataframe(vineyard_socket, path, storage_options, read_options
         df_id = vineyard.ObjectID(name)
     dataframes = client.get(df_id)
 
-    writer: DataFrameStream.Writer = stream.open_writer(client)
+    writer: DataframeStream.Writer = stream.open_writer(client)
 
     try:
         for df in dataframes:

--- a/modules/io/python/drivers/io/adaptors/write_orc.py
+++ b/modules/io/python/drivers/io/adaptors/write_orc.py
@@ -24,8 +24,7 @@ import fsspec
 import pyarrow as pa
 import pyorc
 import vineyard
-from vineyard.io.dataframe import DataFrameStream
-from vineyard.io.stream import read, write
+from vineyard.io.dataframe import DataframeStream
 
 
 def orc_type(field):
@@ -64,7 +63,7 @@ def write_orc(vineyard_socket, path, stream_id, storage_options, write_options, 
     streams = client.get(stream_id)
     if len(streams) != proc_num or streams[proc_index] is None:
         raise ValueError(f"Fetch stream error with proc_num={proc_num},proc_index={proc_index}")
-    instream: DataFrameStream = streams[proc_index]
+    instream: DataframeStream = streams[proc_index]
     reader = instream.open_reader(client)
 
     writer = None

--- a/modules/io/python/drivers/io/adaptors/write_vineyard_dataframe.py
+++ b/modules/io/python/drivers/io/adaptors/write_vineyard_dataframe.py
@@ -21,7 +21,7 @@ import sys
 
 import pyarrow as pa
 import vineyard
-from vineyard.io.dataframe import DataFrameStream
+from vineyard.io.dataframe import DataframeStream
 from vineyard.io.utils import report_success
 
 
@@ -30,7 +30,7 @@ def write_vineyard_dataframe(vineyard_socket, stream_id, proc_num, proc_index):
     streams = client.get(stream_id)
     if len(streams) != proc_num or streams[proc_index] is None:
         raise ValueError(f"Fetch stream error with proc_num={proc_num},proc_index={proc_index}")
-    instream: DataFrameStream = streams[proc_index]
+    instream: DataframeStream = streams[proc_index]
     stream_reader = instream.open_reader(client)
 
     idx = 0

--- a/modules/io/python/drivers/io/stream.py
+++ b/modules/io/python/drivers/io/stream.py
@@ -110,8 +110,12 @@ class ParallelStreamLauncher(ScriptLauncher):
         for proc in self._procs:
             if proc.status == LauncherStatus.FAILED and \
                     (proc.exit_code is not None and proc.exit_code != 0):
+                if isinstance(proc.command, list):
+                    cmd = ' '.join(proc.command)
+                else:
+                    cmd = proc.command
                 messages.append("Failed to launch job [%s], exited with %r: %s" %
-                                (proc.command, proc.exit_code, ''.join(proc.error_message)))
+                                (cmd, proc.exit_code, ''.join(proc.error_message)))
         if messages:
             raise RuntimeError("Subprocesses failed with the following error: \n%s" % ('\n\n'.join(messages)))
 

--- a/python/vineyard/io/byte.py
+++ b/python/vineyard/io/byte.py
@@ -101,7 +101,7 @@ class ByteStream(BaseStream):
         meta['typename'] = 'vineyard::ByteStream'
         if params is None:
             params = dict()
-        meta['params'] = params
+        meta['params_'] = params
         meta = client.create_metadata(meta)
         client.create_stream(meta.id)
         return ByteStream(meta, params)
@@ -162,8 +162,8 @@ class ByteStream(BaseStream):
 
 def byte_stream_resolver(obj):
     meta = obj.meta
-    if 'params' in meta:
-        params = json.loads(meta['params'])
+    if 'params_' in meta:
+        params = json.loads(meta['params_'])
     else:
         params = dict
     return ByteStream(obj.meta, params)

--- a/python/vineyard/io/dataframe.py
+++ b/python/vineyard/io/dataframe.py
@@ -21,10 +21,10 @@
 .. code:: python
 
     # create a builder, then seal it as stream
-    >>> stream = DataFrameStream.new(client)
+    >>> stream = DataframeStream.new(client)
     >>> stream = builder.seal(client)
     >>> stream
-    DataFrameStream <o0001e09ddd98fd70>
+    DataframeStream <o0001e09ddd98fd70>
 
     # use write to put chunks
     >>> writer = stream.open_writer(client)
@@ -79,7 +79,7 @@ from .._C import memory_copy, ObjectID, ObjectMeta, StreamDrainedException
 from .stream import BaseStream
 
 
-class DataFrameStream(BaseStream):
+class DataframeStream(BaseStream):
     def __init__(self, meta: ObjectMeta, params: Dict = None):
         super().__init__(meta)
         self._params = params
@@ -89,15 +89,15 @@ class DataFrameStream(BaseStream):
         return self._params
 
     @staticmethod
-    def new(client, params: Dict = None) -> "DataFrameStream":
+    def new(client, params: Dict = None) -> "DataframeStream":
         meta = ObjectMeta()
-        meta['typename'] = 'vineyard::DataFrameStream'
+        meta['typename'] = 'vineyard::DataframeStream'
         if params is None:
             params = dict()
-        meta['params'] = params
+        meta['params_'] = params
         meta = client.create_metadata(meta)
         client.create_stream(meta.id)
-        return DataFrameStream(meta, params)
+        return DataframeStream(meta, params)
 
     class Reader(BaseStream.Reader):
         def __init__(self, client, stream: ObjectID):
@@ -149,21 +149,21 @@ class DataFrameStream(BaseStream):
             return self._client.stop_stream(self._stream, False)
 
     def _open_new_reader(self, client):
-        return DataFrameStream.Reader(client, self.id)
+        return DataframeStream.Reader(client, self.id)
 
     def _open_new_writer(self, client):
-        return DataFrameStream.Writer(client, self.id)
+        return DataframeStream.Writer(client, self.id)
 
 
 def dataframe_stream_resolver(obj):
     meta = obj.meta
-    if 'params' in meta:
-        params = json.loads(meta['params'])
+    if 'params_' in meta:
+        params = json.loads(meta['params_'])
     else:
         params = dict
-    return DataFrameStream(obj.meta, params)
+    return DataframeStream(obj.meta, params)
 
 
 def register_dataframe_stream_types(builder_ctx, resolver_ctx):
     if resolver_ctx is not None:
-        resolver_ctx.register('vineyard::DataFrameStream', dataframe_stream_resolver)
+        resolver_ctx.register('vineyard::DataframeStream', dataframe_stream_resolver)

--- a/python/vineyard/io/recordbatch.py
+++ b/python/vineyard/io/recordbatch.py
@@ -41,19 +41,19 @@ class RecordBatchStream(BaseStream):
         meta['typename'] = 'vineyard::RecordBatchStream'
         if params is None:
             params = dict()
-        meta['params'] = params
+        meta['params_'] = params
         meta = client.create_metadata(meta)
         client.create_stream(meta.id)
-        return RecordBatchStream(client, meta, params)
+        return RecordBatchStream(meta, params)
 
 
 def recordbatch_stream_resolver(obj, resolver):
     meta = obj.meta
-    if 'params' in meta:
-        params = json.loads(meta['params'])
+    if 'params_' in meta:
+        params = json.loads(meta['params_'])
     else:
         params = dict
-    return RecordBatchStream(meta)
+    return RecordBatchStream(meta, params)
 
 
 def register_recordbatch_stream_types(builder_ctx, resolver_ctx):

--- a/python/vineyard/io/tests/test_stream.py
+++ b/python/vineyard/io/tests/test_stream.py
@@ -27,7 +27,7 @@ import numpy as np
 from vineyard.core import default_builder_context, default_resolver_context
 from vineyard.data import register_builtin_types
 from vineyard.io.byte import ByteStream
-from vineyard.io.dataframe import DataFrameStream
+from vineyard.io.dataframe import DataframeStream
 from vineyard.io.recordbatch import RecordBatchStream
 
 register_builtin_types(default_builder_context, default_resolver_context)

--- a/python/vineyard/launcher/script.py
+++ b/python/vineyard/launcher/script.py
@@ -120,8 +120,12 @@ class ScriptLauncher(Launcher):
         r = super(ScriptLauncher, self).wait(timeout=period)
         if r is not None:
             return r
+        if isinstance(self._cmd, list):
+            cmd = ' '.join(self._cmd)
+        else:
+            cmd = self._cmd
         raise RuntimeError('Failed to launch job [%s], exited with %r: %s' %
-                           (self._cmd, self._proc.poll(), ''.join(self._err_message)))
+                           (cmd, self._proc.poll(), ''.join(self._err_message)))
 
     def read_output(self, stdout):
         while self._proc.poll() is None:


### PR DESCRIPTION


What do these changes do?
-------------------------

To keep backwards compatibility of ABIs.


Related issue number
--------------------

N/A, follow-up work for #628.

