### PR TITLE
Fixes the typing hint under Python 3.8.

### DIFF
--- a/.github/workflows/build-compatibility.yml
+++ b/.github/workflows/build-compatibility.yml
@@ -152,7 +152,7 @@ jobs:
 
           mkdir build
           cd build
-          cmake .. -DCMAKE_BUILD_TYPE=Debug \
+          cmake .. -DCMAKE_BUILD_TYPE=Release \
                    -DBUILD_SHARED_LIBS=ON \
                    -DBUILD_VINEYARD_COVERAGE=ON \
                    -DBUILD_VINEYARD_PYTHON_BINDINGS=ON \

--- a/charts/vineyard/Chart.yaml
+++ b/charts/vineyard/Chart.yaml
@@ -30,10 +30,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.15
+version: 0.3.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.3.15
+appVersion: 0.3.16
 

--- a/modules/io/python/drivers/io/adaptors/deserializer.py
+++ b/modules/io/python/drivers/io/adaptors/deserializer.py
@@ -51,8 +51,8 @@ def copy_bytestream_to_blob(client, bs: ByteStream, blob: BlobBuilder):
 
 
 class ReconstructExecututor(BaseStreamExecutor):
-    def __init__(self, client, task_queue: ConcurrentQueue[Tuple[ByteStream, str, Union[BlobBuilder, Blob]]],
-                 result_queue: ConcurrentQueue[Tuple[ObjectID, Blob]]) -> None:
+    def __init__(self, client, task_queue: "ConcurrentQueue[Tuple[ByteStream, str, Union[BlobBuilder, Blob]]]",
+                 result_queue: "ConcurrentQueue[Tuple[ObjectID, Blob]]") -> None:
         self._client = client
         self._task_queue = task_queue
         self._result_queue = result_queue
@@ -75,8 +75,8 @@ class ReconstructExecututor(BaseStreamExecutor):
         return processed_blobs, processed_bytes
 
 
-def traverse_to_prepare(client, stream_id: ObjectID, queue: ConcurrentQueue[Tuple[ByteStream, Union[BlobBuilder,
-                                                                                                    Blob]]]):
+def traverse_to_prepare(client, stream_id: ObjectID,
+                        queue: "ConcurrentQueue[Tuple[ByteStream, Union[BlobBuilder, Blob]]]"):
     stream = client.get(stream_id)
     if isinstance(stream, StreamCollection):
         for s in stream.streams:
@@ -133,11 +133,11 @@ def deserialize(vineyard_socket, object_id):
         report_error("Each worker should have only one local stream")
         sys.exit(-1)
 
-    queue: ConcurrentQueue[Tuple[ByteStream, Union[BlobBuilder, Blob]]] = ConcurrentQueue()
+    queue: "ConcurrentQueue[Tuple[ByteStream, Union[BlobBuilder, Blob]]]" = ConcurrentQueue()
     traverse_to_prepare(client, streams[0].id, queue)
 
     # serve as a stream id -> blob id mapping
-    rqueue: ConcurrentQueue[Tuple[ObjectID, str, Blob]] = ConcurrentQueue()
+    rqueue: "ConcurrentQueue[Tuple[ObjectID, str, Blob]]" = ConcurrentQueue()
 
     # copy blobs
     executor = ThreadStreamExecutor(ReconstructExecututor,

--- a/modules/io/python/drivers/io/adaptors/read_bytes_collection.py
+++ b/modules/io/python/drivers/io/adaptors/read_bytes_collection.py
@@ -83,7 +83,7 @@ class ReadToByteStreamExecutor(BaseStreamExecutor):
     def __init__(self,
                  client,
                  fs: AbstractFileSystem,
-                 task_queue: ConcurrentQueue[Tuple[ByteStream, str]],
+                 task_queue: "ConcurrentQueue[Tuple[ByteStream, str]]",
                  chunk_size: int = CHUNK_SIZE):
         self._client = client
         self._fs = fs
@@ -105,7 +105,7 @@ class ReadToByteStreamExecutor(BaseStreamExecutor):
         return processed_blobs, processed_bytes
 
 
-def read_stream_collections(client, fs: AbstractFileSystem, queue: ConcurrentQueue[Tuple[ByteStream, str]],
+def read_stream_collections(client, fs: AbstractFileSystem, queue: "ConcurrentQueue[Tuple[ByteStream, str]]",
                             base_prefix: str, prefix: str):
     metadata_path = os.path.join(prefix, 'metadata.json')
     blob_path = os.path.join(prefix, 'blob')
@@ -145,7 +145,7 @@ def read_bytes_collection(vineyard_socket, prefix, storage_options, proc_num, pr
     worker_prefix = os.path.join(prefix_path, '%s-%s' % (proc_num, proc_index))
 
     logger.info("start creating blobs ...")
-    queue: ConcurrentQueue[Tuple[ByteStream, str]] = ConcurrentQueue()
+    queue: "ConcurrentQueue[Tuple[ByteStream, str]]" = ConcurrentQueue()
     stream_id = read_stream_collections(client, fs, queue, worker_prefix, worker_prefix)
     report_success(stream_id)
 

--- a/modules/io/python/drivers/io/adaptors/serializer.py
+++ b/modules/io/python/drivers/io/adaptors/serializer.py
@@ -60,7 +60,7 @@ def serialize_blob_to_stream(stream: ByteStream, blob: memoryview, chunk_size: i
 
 
 class SerializeExecutor(BaseStreamExecutor):
-    def __init__(self, task_queue: ConcurrentQueue[Tuple[ByteStream, memoryview]], chunk_size: int = CHUNK_SIZE):
+    def __init__(self, task_queue: "ConcurrentQueue[Tuple[ByteStream, memoryview]]", chunk_size: int = CHUNK_SIZE):
         self._task_queue = task_queue
         self._chunk_size = chunk_size
 
@@ -77,7 +77,7 @@ class SerializeExecutor(BaseStreamExecutor):
         return processed_bytes, processed_blobs
 
 
-def traverse_to_serialize(client, meta: ObjectMeta, queue: ConcurrentQueue[Tuple[ByteStream, memoryview]],
+def traverse_to_serialize(client, meta: ObjectMeta, queue: "ConcurrentQueue[Tuple[ByteStream, memoryview]]",
                           path: str) -> ObjectID:
     ''' Returns:
             The generated stream or stream collection id.
@@ -117,7 +117,7 @@ def serialize(vineyard_socket, object_id):
     client = vineyard.connect(vineyard_socket)
     meta = client.get_meta(object_id)
 
-    queue: ConcurrentQueue[Tuple[ByteStream, memoryview]] = ConcurrentQueue()
+    queue: "ConcurrentQueue[Tuple[ByteStream, memoryview]]" = ConcurrentQueue()
     serilaized_id = traverse_to_serialize(client, meta, queue, '')
 
     # object id done

--- a/modules/io/python/drivers/io/adaptors/write_bytes_collection.py
+++ b/modules/io/python/drivers/io/adaptors/write_bytes_collection.py
@@ -72,7 +72,7 @@ def write_byte_stream(client, stream: ByteStream, prefix: str, storage_options: 
 
 
 class WriteBytesExecutor(BaseStreamExecutor):
-    def __init__(self, client, prefix, storage_options: Dict, task_queue: ConcurrentQueue[ObjectID]):
+    def __init__(self, client, prefix, storage_options: Dict, task_queue: "ConcurrentQueue[ObjectID]"):
         self._client = client
         self._prefix = prefix
         self._storage_options = storage_options
@@ -95,7 +95,7 @@ class WriteBytesExecutor(BaseStreamExecutor):
         return processed_blobs, processed_bytes
 
 
-def write_stream_collections(client, stream_id: ObjectID, blob_queue: ConcurrentQueue[ObjectID], worker_prefix: str,
+def write_stream_collections(client, stream_id: ObjectID, blob_queue: "ConcurrentQueue[ObjectID]", worker_prefix: str,
                              storage_options: Dict):
     streams = client.get(stream_id)
     if isinstance(streams, StreamCollection):
@@ -125,7 +125,7 @@ def write_bytes_collection(vineyard_socket, prefix, stream_id, storage_options, 
     worker_prefix = os.path.join(prefix, '%s-%s' % (proc_num, proc_index))
 
     # collect all blobs, and prepare metadata
-    queue: ConcurrentQueue[ObjectID] = ConcurrentQueue()
+    queue: "ConcurrentQueue[ObjectID]" = ConcurrentQueue()
     write_stream_collections(client, streams[0].id, queue, worker_prefix, storage_options)
 
     # write streams to file


### PR DESCRIPTION
What do these changes do?
-------------------------

Python 3.8 (on Ubuntu 20.04) doesn't support such syntax.

Related issue number
--------------------

N/A

