### PR TITLE
Avoid duplicate `join()`, as `__del__` will call join as well.

### DIFF
--- a/modules/io/python/drivers/io/stream.py
+++ b/modules/io/python/drivers/io/stream.py
@@ -79,6 +79,7 @@ class ParallelStreamLauncher(ScriptLauncher):
 
         self._streams = []
         self._procs: List[StreamLauncher] = []
+        self._stopped = False
 
     def run(self, *args, **kwargs):
         """Execute a job to read as a vineyard stream or write a vineyard stream to
@@ -114,6 +115,10 @@ class ParallelStreamLauncher(ScriptLauncher):
                 self._procs.append(launcher)
 
     def join(self):
+        if self._stopped:
+            return
+        self._stopped = True
+
         for proc in self._procs:
             proc.join()
 
@@ -140,6 +145,10 @@ class ParallelStreamLauncher(ScriptLauncher):
             )
 
     def dispose(self, desired=True):
+        if self._stopped:
+            return
+        self._stopped = True
+
         for proc in self._procs:
             proc.dispose()
 

--- a/python/vineyard/launcher/script.py
+++ b/python/vineyard/launcher/script.py
@@ -43,6 +43,7 @@ class ScriptLauncher(Launcher):
 
         self._err_message = None
         self._exit_code = None
+        self._stopped = False
 
     @property
     def command(self):
@@ -158,6 +159,10 @@ class ScriptLauncher(Launcher):
         self._err_message.extend(stderr.readlines())
 
     def join(self):
+        if self._stopped:
+            return
+        self._stopped = True
+
         self._exit_code = self._proc.wait()
         if self._exit_code != 0:
             self._status = LauncherStatus.FAILED
@@ -169,6 +174,10 @@ class ScriptLauncher(Launcher):
         self._listen_err_thrd.join()
 
     def dispose(self, desired=True):
+        if self._stopped:
+            return
+        self._stopped = True
+
         if self._status == LauncherStatus.RUNNING:
             try:
                 self._proc.terminate()


### PR DESCRIPTION
What do these changes do?
-------------------------

Part of alibaba/GraphScope#1281.

The `join()` might be called for more than one times, if error occurs.