### PR TITLE
Check the arguments before using it to construct the vector.

### DIFF
--- a/modules/graph/fragment/property_graph_utils.h
+++ b/modules/graph/fragment/property_graph_utils.h
@@ -673,6 +673,10 @@ inline boost::leaf::result<std::shared_ptr<arrow::Schema>> TypeLoosen(
       }
     }
   }
+  if (field_num == -1) {
+    RETURN_GS_ERROR(ErrorCode::kInvalidOperationError,
+                    "No table available for normalizing schemas");
+  }
   if (field_num == 0) {
     RETURN_GS_ERROR(ErrorCode::kInvalidOperationError, "Every schema is empty");
   }


### PR DESCRIPTION
What do these changes do?
-------------------------

Deliver meaningful error messages to user and avoid things like `bad_alloc` exception.

Related issue number
--------------------

Related to alibaba/GraphScope#1281.

