### PR TITLE
Add an optional `handlers` arguments to allow capturing the underlying I/O errors.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -90,7 +90,7 @@ jobs:
 
           # install python packages for codegen, and io adaptors
           sudo pip3 install -U Pygments>=2.4.1
-          sudo pip3 install libclang parsec sphinx sphinx_rtd_theme docutils==0.16 breathe nbsphinx gcovr pytest hdfs3 numpy>=0.18.5
+          sudo pip3 install -U libclang parsec sphinx sphinx_rtd_theme docutils==0.16 breathe nbsphinx gcovr pytest hdfs3 numpy>=0.18.5
 
           # install linters
           sudo pip3 install black isort flake8

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ option(USE_STATIC_BOOST_LIBS "Build with static-linked boost libraries" OFF)
 option(USE_EXTERNAL_ETCD_LIBS "Build with external etcd-cpp-apiv3 library rather than the submodule one" ON)
 option(USE_EXTERNAL_TBB_LIBS "Build with external tbb library rather than the submodule one" ON)
 option(USE_ASAN "Using address sanitizer to check memory accessing" OFF)
+option(USE_INCLUDE_WHAT_YOU_USE "Simply the intra-module dependencies with iwyu" OFF)
 option(USE_JSON_DIAGNOSTICS "Using json diagnostics to check the validity of metadata" OFF)
 
 option(BUILD_VINEYARD_SERVER "Build vineyard's server" ON)
@@ -75,6 +76,15 @@ else()
         COMMAND echo "ccache not found."
     )
 endif(ccache_EXECUTABLE)
+
+if(USE_INCLUDE_WHAT_YOU_USE AND NOT CMAKE_CXX_INCLUDE_WHAT_YOU_USE)
+    find_program(iwyu_EXECUTABLE include-what-you-use)
+    if(iwyu_EXECUTABLE)
+        set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE ${iwyu_EXECUTABLE})
+    else()
+        message(WARNING "Failed to locate iwyu, please specify with -DCMAKE_CXX_INCLUDE_WHAT_YOU_USE instead")
+    endif()
+endif()
 
 set(DEFAUTL_ALLOCATOR "dlmalloc")
 set(WITH_ALLOCATOR "${DEFAUTL_ALLOCATOR}" CACHE

--- a/modules/migrate/flags.h
+++ b/modules/migrate/flags.h
@@ -18,8 +18,6 @@ limitations under the License.
 
 #include <gflags/gflags.h>
 
-#include "migrate/flags.h"
-
 namespace vineyard {
 
 DECLARE_uint64(migration_port);

--- a/src/server/async/socket_server.h
+++ b/src/server/async/socket_server.h
@@ -28,7 +28,6 @@ limitations under the License.
 #include "boost/asio.hpp"
 
 #include "common/util/protocols.h"
-#include "server/async/socket_server.h"
 #include "server/server/vineyard_server.h"
 
 namespace vineyard {


### PR DESCRIPTION
What do these changes do?
-------------------------

Expose the internal process handlers to the caller to make it joinable for inspecting errors.

Related issue number
--------------------

Fixes alibaba/GraphScope#1281.

