### PR TITLE
Fixes the detection of GCC compiler.

### DIFF
--- a/src/common/util/typename.h
+++ b/src/common/util/typename.h
@@ -19,7 +19,9 @@ limitations under the License.
 #include <functional>
 #include <string>
 
-#if defined(__GNUC__) && defined(__GNUC_MINOR__) && defined(__GNUC_PATCHLEVEL__)
+// See also: https://stackoverflow.com/a/55926503/5080177
+//
+#if defined(__GNUC__) && !defined(__llvm__) && !defined(__INTEL_COMPILER)
 #define __VINEYARD_GCC_VERSION \
   (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 #endif


### PR DESCRIPTION
See also: https://stackoverflow.com/questions/38499462/how-to-tell-clang-to-stop-pretending-to-be-other-compilers.

Signed-off-by: Tao He <linzhu.ht@alibaba-inc.com>
