### PR TITLE
Check if timestamp type using type id, rather than .Equals().

### DIFF
--- a/.github/workflows/build-vineyardd-and-wheels-macos.yaml
+++ b/.github/workflows/build-vineyardd-and-wheels-macos.yaml
@@ -196,7 +196,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-10.15]
-        python: [3.6, 3.7, 3.8, 3.9]
+        python: [3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/modules/graph/fragment/property_graph_utils.h
+++ b/modules/graph/fragment/property_graph_utils.h
@@ -709,10 +709,7 @@ inline boost::leaf::result<std::shared_ptr<arrow::Schema>> TypeLoosen(
     if (res->Equals(arrow::date64())) {
       res = arrow::int64();
     }
-    if (res->Equals(arrow::timestamp(arrow::TimeUnit::SECOND)) ||
-        res->Equals(arrow::timestamp(arrow::TimeUnit::MILLI)) ||
-        res->Equals(arrow::timestamp(arrow::TimeUnit::MICRO)) ||
-        res->Equals(arrow::timestamp(arrow::TimeUnit::NANO))) {
+    if (res->id() == arrow::Type::TIMESTAMP) {
       res = arrow::int64();
     }
     if (res->Equals(arrow::int64())) {


### PR DESCRIPTION

<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

Timestamp type has two field: unit and timezone.

<!-- Please give a short brief about these changes. -->


Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes https://github.com/v6d-io/v6d/issues/658

