### PR TITLE
Arrow: simplify the include statements and keep TU consistents.

### DIFF
--- a/benchmark/alloc_test/bench_allocator.cpp
+++ b/benchmark/alloc_test/bench_allocator.cpp
@@ -43,6 +43,7 @@
 #include <thread>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 #include "glog/logging.h"
 
 #include "basic/ds/array.h"

--- a/benchmark/alloc_test/bench_allocator.cpp
+++ b/benchmark/alloc_test/bench_allocator.cpp
@@ -42,8 +42,7 @@
 #include <string>
 #include <thread>
 
-#include "arrow/status.h"
-#include "arrow/util/io_util.h"
+#include "arrow/api.h"
 #include "glog/logging.h"
 
 #include "basic/ds/array.h"

--- a/modules/basic/ds/arrow.h
+++ b/modules/basic/ds/arrow.h
@@ -22,6 +22,10 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
+#include "arrow/api.h"
+#include "arrow/io/api.h"
+#include "arrow/ipc/api.h"
+
 #include "basic/ds/arrow.vineyard.h"
 #include "basic/ds/arrow_utils.h"
 #include "client/client.h"

--- a/modules/basic/ds/arrow.vineyard-mod
+++ b/modules/basic/ds/arrow.vineyard-mod
@@ -23,6 +23,8 @@ limitations under the License.
 #include <vector>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
+#include "arrow/ipc/api.h"
 
 #include "basic/ds/arrow_utils.h"
 #include "client/client.h"

--- a/modules/basic/ds/arrow.vineyard-mod
+++ b/modules/basic/ds/arrow.vineyard-mod
@@ -22,10 +22,7 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-#include "arrow/io/memory.h"
-#include "arrow/ipc/reader.h"
-#include "arrow/ipc/writer.h"
-#include "arrow/util/config.h"
+#include "arrow/api.h"
 
 #include "basic/ds/arrow_utils.h"
 #include "client/client.h"

--- a/modules/basic/ds/arrow_utils.cc
+++ b/modules/basic/ds/arrow_utils.cc
@@ -15,12 +15,7 @@ limitations under the License.
 
 #include "basic/ds/arrow_utils.h"
 
-#include "arrow/io/memory.h"
-#include "arrow/ipc/options.h"
-#include "arrow/ipc/reader.h"
-#include "arrow/ipc/writer.h"
-#include "arrow/record_batch.h"
-#include "arrow/util/config.h"
+#include "arrow/api.h"
 
 namespace vineyard {
 

--- a/modules/basic/ds/arrow_utils.cc
+++ b/modules/basic/ds/arrow_utils.cc
@@ -16,6 +16,8 @@ limitations under the License.
 #include "basic/ds/arrow_utils.h"
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
+#include "arrow/ipc/api.h"
 
 namespace vineyard {
 

--- a/modules/basic/ds/arrow_utils.h
+++ b/modules/basic/ds/arrow_utils.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include <vector>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 #include "glog/logging.h"
 
 #include "basic/ds/types.h"

--- a/modules/basic/ds/arrow_utils.h
+++ b/modules/basic/ds/arrow_utils.h
@@ -21,18 +21,7 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-#include "arrow/array.h"
-#include "arrow/array/builder_binary.h"
-#include "arrow/array/builder_nested.h"
-#include "arrow/array/builder_primitive.h"
-#include "arrow/buffer.h"
-#include "arrow/io/memory.h"
-#include "arrow/ipc/reader.h"
-#include "arrow/ipc/writer.h"
-#include "arrow/table.h"
-#include "arrow/table_builder.h"
-#include "arrow/type.h"
-#include "arrow/util/config.h"
+#include "arrow/api.h"
 #include "glog/logging.h"
 
 #include "basic/ds/types.h"

--- a/modules/basic/ds/dataframe.vineyard-mod
+++ b/modules/basic/ds/dataframe.vineyard-mod
@@ -28,6 +28,7 @@ limitations under the License.
 #include <vector>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "basic/ds/array.vineyard.h"
 #include "basic/ds/arrow.vineyard.h"

--- a/modules/basic/ds/dataframe.vineyard-mod
+++ b/modules/basic/ds/dataframe.vineyard-mod
@@ -27,8 +27,7 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-#include "arrow/util/config.h"
-#include "arrow/util/key_value_metadata.h"
+#include "arrow/api.h"
 
 #include "basic/ds/array.vineyard.h"
 #include "basic/ds/arrow.vineyard.h"

--- a/modules/basic/ds/tensor.h
+++ b/modules/basic/ds/tensor.h
@@ -27,9 +27,7 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-#include "arrow/record_batch.h"
-#include "arrow/table.h"
-#include "arrow/tensor.h"
+#include "arrow/api.h"
 
 #include "basic/ds/array.h"
 #include "basic/ds/tensor.vineyard.h"

--- a/modules/basic/ds/tensor.h
+++ b/modules/basic/ds/tensor.h
@@ -28,6 +28,7 @@ limitations under the License.
 #include <vector>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "basic/ds/array.h"
 #include "basic/ds/tensor.vineyard.h"

--- a/modules/basic/ds/tensor.vineyard-mod
+++ b/modules/basic/ds/tensor.vineyard-mod
@@ -27,6 +27,7 @@ limitations under the License.
 #include <vector>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "basic/ds/array.vineyard.h"
 #include "basic/ds/types.h"

--- a/modules/basic/ds/tensor.vineyard-mod
+++ b/modules/basic/ds/tensor.vineyard-mod
@@ -26,9 +26,7 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-#include "arrow/record_batch.h"
-#include "arrow/table.h"
-#include "arrow/tensor.h"
+#include "arrow/api.h"
 
 #include "basic/ds/array.vineyard.h"
 #include "basic/ds/types.h"

--- a/modules/basic/ds/types.h
+++ b/modules/basic/ds/types.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include <string>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "common/util/json.h"
 

--- a/modules/basic/ds/types.h
+++ b/modules/basic/ds/types.h
@@ -21,7 +21,7 @@ limitations under the License.
 #include <iostream>
 #include <string>
 
-#include "arrow/type.h"
+#include "arrow/api.h"
 
 #include "common/util/json.h"
 

--- a/modules/basic/stream/byte_stream.cc
+++ b/modules/basic/stream/byte_stream.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include <vector>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "basic/ds/arrow_utils.h"
 #include "client/client.h"

--- a/modules/basic/stream/byte_stream.cc
+++ b/modules/basic/stream/byte_stream.cc
@@ -20,8 +20,7 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-#include "arrow/builder.h"
-#include "arrow/status.h"
+#include "arrow/api.h"
 
 #include "basic/ds/arrow_utils.h"
 #include "client/client.h"

--- a/modules/basic/stream/dataframe_stream.cc
+++ b/modules/basic/stream/dataframe_stream.cc
@@ -20,8 +20,9 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-#include "arrow/util/config.h"
-#include "arrow/util/key_value_metadata.h"
+#include "arrow/api.h"
+#include "arrow/io/api.h"
+#include "arrow/ipc/api.h"
 
 #include "client/client.h"
 #include "client/ds/blob.h"

--- a/modules/basic/stream/dataframe_stream.vineyard-mod
+++ b/modules/basic/stream/dataframe_stream.vineyard-mod
@@ -21,8 +21,8 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-#include "arrow/util/config.h"
-#include "arrow/util/key_value_metadata.h"
+#include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "basic/ds/dataframe.vineyard.h"
 #include "client/client.h"

--- a/modules/basic/stream/recordbatch_stream.cc
+++ b/modules/basic/stream/recordbatch_stream.cc
@@ -20,8 +20,8 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-#include "arrow/util/config.h"
-#include "arrow/util/key_value_metadata.h"
+#include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "basic/ds/arrow.h"
 #include "client/client.h"

--- a/modules/basic/stream/recordbatch_stream.vineyard-mod
+++ b/modules/basic/stream/recordbatch_stream.vineyard-mod
@@ -21,8 +21,8 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-#include "arrow/util/config.h"
-#include "arrow/util/key_value_metadata.h"
+#include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "basic/ds/arrow.vineyard.h"
 #include "basic/ds/dataframe.vineyard.h"

--- a/modules/fuse/adaptors/formats.h
+++ b/modules/fuse/adaptors/formats.h
@@ -16,6 +16,7 @@ limitations under the License.
 #ifndef MODULES_FUSE_ADAPTORS_FORMATS_H_
 #define MODULES_FUSE_ADAPTORS_FORMATS_H_
 
+#include "fuse/adaptors/arrow.h"
 #include "fuse/adaptors/orc.h"
 #include "fuse/adaptors/parquet.h"
 

--- a/modules/fuse/adaptors/parquet.cc
+++ b/modules/fuse/adaptors/parquet.cc
@@ -20,8 +20,7 @@ limitations under the License.
 #include <limits>
 #include <memory>
 
-#include "arrow/io/memory.h"
-#include "arrow/util/logging.h"
+#include "arrow/api.h"
 #include "parquet/api/reader.h"
 #include "parquet/api/schema.h"
 #include "parquet/api/writer.h"

--- a/modules/fuse/adaptors/parquet.cc
+++ b/modules/fuse/adaptors/parquet.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include <memory>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 #include "parquet/api/reader.h"
 #include "parquet/api/schema.h"
 #include "parquet/api/writer.h"

--- a/modules/fuse/test/fuse_test.cc
+++ b/modules/fuse/test/fuse_test.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include <thread>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "basic/ds/array.h"
 #include "client/client.h"

--- a/modules/fuse/test/fuse_test.cc
+++ b/modules/fuse/test/fuse_test.cc
@@ -19,9 +19,7 @@ limitations under the License.
 #include <string>
 #include <thread>
 
-#include "arrow/status.h"
-#include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/api.h"
 
 #include "basic/ds/array.h"
 #include "client/client.h"

--- a/modules/graph/fragment/arrow_fragment.h
+++ b/modules/graph/fragment/arrow_fragment.h
@@ -25,9 +25,7 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-#include "arrow/table.h"
-#include "arrow/util/config.h"
-#include "arrow/util/key_value_metadata.h"
+#include "arrow/api.h"
 #include "boost/algorithm/string.hpp"
 
 #include "grape/graph/adj_list.h"

--- a/modules/graph/fragment/arrow_fragment.h
+++ b/modules/graph/fragment/arrow_fragment.h
@@ -26,6 +26,7 @@ limitations under the License.
 #include <vector>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 #include "boost/algorithm/string.hpp"
 
 #include "grape/graph/adj_list.h"

--- a/modules/graph/fragment/graph_schema.cc
+++ b/modules/graph/fragment/graph_schema.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include <vector>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 #include "glog/logging.h"
 
 #include "common/util/json.h"

--- a/modules/graph/fragment/graph_schema.h
+++ b/modules/graph/fragment/graph_schema.h
@@ -28,6 +28,7 @@ limitations under the License.
 #include <vector>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 #include "boost/leaf.hpp"
 
 #include "common/util/json.h"

--- a/modules/graph/fragment/property_graph_utils.h
+++ b/modules/graph/fragment/property_graph_utils.h
@@ -25,6 +25,9 @@ limitations under the License.
 #include <vector>
 
 #include "arrow/api.h"
+#include "arrow/compute/api.h"
+#include "arrow/io/api.h"
+#include "arrow/ipc/api.h"
 #include "boost/leaf.hpp"
 
 #include "grape/serialization/in_archive.h"

--- a/modules/graph/fragment/property_graph_utils.h
+++ b/modules/graph/fragment/property_graph_utils.h
@@ -24,10 +24,7 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-#include "arrow/builder.h"
-#include "arrow/compute/api.h"
-#include "arrow/util/config.h"
-#include "arrow/util/key_value_metadata.h"
+#include "arrow/api.h"
 #include "boost/leaf.hpp"
 
 #include "grape/serialization/in_archive.h"

--- a/modules/graph/loader/arrow_fragment_loader.h
+++ b/modules/graph/loader/arrow_fragment_loader.h
@@ -27,6 +27,7 @@ limitations under the License.
 #include <vector>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "grape/worker/comm_spec.h"
 

--- a/modules/graph/loader/arrow_fragment_loader.h
+++ b/modules/graph/loader/arrow_fragment_loader.h
@@ -26,8 +26,7 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-#include "arrow/util/config.h"
-#include "arrow/util/key_value_metadata.h"
+#include "arrow/api.h"
 
 #include "grape/worker/comm_spec.h"
 

--- a/modules/graph/loader/basic_arrow_fragment_loader.h
+++ b/modules/graph/loader/basic_arrow_fragment_loader.h
@@ -25,6 +25,7 @@ limitations under the License.
 #include <vector>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 #include "client/client.h"
 #include "grape/worker/comm_spec.h"
 #include "io/io/i_io_adaptor.h"

--- a/modules/graph/loader/basic_arrow_fragment_loader.h
+++ b/modules/graph/loader/basic_arrow_fragment_loader.h
@@ -24,7 +24,7 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-#include "arrow/util/config.h"
+#include "arrow/api.h"
 #include "client/client.h"
 #include "grape/worker/comm_spec.h"
 #include "io/io/i_io_adaptor.h"

--- a/modules/graph/test/vertex_map_string_test.cc
+++ b/modules/graph/test/vertex_map_string_test.cc
@@ -20,7 +20,7 @@ limitations under the License.
 #include <string>
 #include <vector>
 
-#include "arrow/util/config.h"
+#include "arrow/api.h"
 #include "glog/logging.h"
 
 #include "client/client.h"

--- a/modules/graph/test/vertex_map_string_test.cc
+++ b/modules/graph/test/vertex_map_string_test.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include <vector>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 #include "glog/logging.h"
 
 #include "client/client.h"

--- a/modules/graph/test/vertex_map_test.cc
+++ b/modules/graph/test/vertex_map_test.cc
@@ -20,7 +20,7 @@ limitations under the License.
 #include <string>
 #include <vector>
 
-#include "arrow/util/config.h"
+#include "arrow/api.h"
 #include "glog/logging.h"
 
 #include "client/client.h"

--- a/modules/graph/test/vertex_map_test.cc
+++ b/modules/graph/test/vertex_map_test.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include <vector>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 #include "glog/logging.h"
 
 #include "client/client.h"

--- a/modules/graph/utils/context_protocols.h
+++ b/modules/graph/utils/context_protocols.h
@@ -19,7 +19,7 @@ limitations under the License.
 #include <memory>
 #include <string>
 
-#include "arrow/type.h"
+#include "arrow/api.h"
 
 namespace vineyard {
 

--- a/modules/graph/utils/context_protocols.h
+++ b/modules/graph/utils/context_protocols.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include <string>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 
 namespace vineyard {
 

--- a/modules/graph/utils/table_shuffler.h
+++ b/modules/graph/utils/table_shuffler.h
@@ -25,6 +25,7 @@ limitations under the License.
 #include <vector>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 #include "boost/leaf.hpp"
 
 #include "grape/communication/sync_comm.h"

--- a/modules/graph/utils/table_shuffler.h
+++ b/modules/graph/utils/table_shuffler.h
@@ -24,9 +24,7 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-#include "arrow/buffer.h"
-#include "arrow/table.h"
-#include "arrow/util/config.h"
+#include "arrow/api.h"
 #include "boost/leaf.hpp"
 
 #include "grape/communication/sync_comm.h"

--- a/modules/graph/utils/table_shuffler_beta.h
+++ b/modules/graph/utils/table_shuffler_beta.h
@@ -26,6 +26,8 @@ limitations under the License.
 #include <vector>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
+#include "arrow/ipc/api.h"
 #include "boost/leaf.hpp"
 
 #include "grape/communication/sync_comm.h"

--- a/modules/graph/utils/table_shuffler_beta.h
+++ b/modules/graph/utils/table_shuffler_beta.h
@@ -25,13 +25,7 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-#include "arrow/buffer.h"
-#include "arrow/io/memory.h"
-#include "arrow/ipc/dictionary.h"
-#include "arrow/ipc/reader.h"
-#include "arrow/ipc/writer.h"
-#include "arrow/type.h"
-#include "arrow/util/string_view.h"
+#include "arrow/api.h"
 #include "boost/leaf.hpp"
 
 #include "grape/communication/sync_comm.h"

--- a/modules/io/io/i_io_adaptor.h
+++ b/modules/io/io/i_io_adaptor.h
@@ -21,7 +21,7 @@ limitations under the License.
 #include <unordered_map>
 #include <vector>
 
-#include "arrow/table.h"
+#include "arrow/api.h"
 
 #include "common/util/status.h"
 

--- a/modules/io/io/i_io_adaptor.h
+++ b/modules/io/io/i_io_adaptor.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include <vector>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "common/util/status.h"
 

--- a/modules/io/io/io_factory.cc
+++ b/modules/io/io/io_factory.cc
@@ -28,6 +28,7 @@ limitations under the License.
 #include <vector>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 #include "boost/algorithm/string.hpp"
 #include "glog/logging.h"
 

--- a/modules/io/io/io_factory.cc
+++ b/modules/io/io/io_factory.cc
@@ -27,8 +27,7 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-#include "arrow/status.h"
-#include "arrow/util/uri.h"
+#include "arrow/api.h"
 #include "boost/algorithm/string.hpp"
 #include "glog/logging.h"
 

--- a/modules/io/io/io_factory.cc
+++ b/modules/io/io/io_factory.cc
@@ -29,6 +29,7 @@ limitations under the License.
 
 #include "arrow/api.h"
 #include "arrow/io/api.h"
+#include "arrow/util/uri.h"
 #include "boost/algorithm/string.hpp"
 #include "glog/logging.h"
 

--- a/modules/io/io/local_io_adaptor.cc
+++ b/modules/io/io/local_io_adaptor.cc
@@ -25,13 +25,7 @@ limitations under the License.
 #include <string>
 #include <vector>
 
-#include "arrow/csv/api.h"
-#include "arrow/filesystem/api.h"
-#include "arrow/io/api.h"
-#include "arrow/result.h"
-#include "arrow/status.h"
-#include "arrow/util/config.h"
-#include "arrow/util/uri.h"
+#include "arrow/api.h"
 
 #include "boost/algorithm/string.hpp"
 #include "glog/logging.h"

--- a/modules/io/io/local_io_adaptor.cc
+++ b/modules/io/io/local_io_adaptor.cc
@@ -26,6 +26,9 @@ limitations under the License.
 #include <vector>
 
 #include "arrow/api.h"
+#include "arrow/csv/api.h"
+#include "arrow/filesystem/api.h"
+#include "arrow/io/api.h"
 
 #include "boost/algorithm/string.hpp"
 #include "glog/logging.h"

--- a/modules/io/io/local_io_adaptor.cc
+++ b/modules/io/io/local_io_adaptor.cc
@@ -29,6 +29,7 @@ limitations under the License.
 #include "arrow/csv/api.h"
 #include "arrow/filesystem/api.h"
 #include "arrow/io/api.h"
+#include "arrow/util/uri.h"
 
 #include "boost/algorithm/string.hpp"
 #include "glog/logging.h"

--- a/modules/io/io/local_io_adaptor.h
+++ b/modules/io/io/local_io_adaptor.h
@@ -23,8 +23,6 @@ limitations under the License.
 #include <vector>
 
 #include "arrow/api.h"
-#include "arrow/filesystem/api.h"
-#include "arrow/io/api.h"
 
 #include "common/util/functions.h"
 #include "common/util/status.h"

--- a/modules/io/io/local_io_adaptor.h
+++ b/modules/io/io/local_io_adaptor.h
@@ -23,6 +23,8 @@ limitations under the License.
 #include <vector>
 
 #include "arrow/api.h"
+#include "arrow/filesystem/api.h"
+#include "arrow/io/api.h"
 
 #include "common/util/functions.h"
 #include "common/util/status.h"

--- a/modules/migrate/object_migration.h
+++ b/modules/migrate/object_migration.h
@@ -26,6 +26,7 @@ limitations under the License.
 #include "boost/asio.hpp"
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 #include "glog/logging.h"
 
 #include "client/client.h"

--- a/modules/migrate/object_migration.h
+++ b/modules/migrate/object_migration.h
@@ -25,9 +25,7 @@ limitations under the License.
 
 #include "boost/asio.hpp"
 
-#include "arrow/status.h"
-#include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/api.h"
 #include "glog/logging.h"
 
 #include "client/client.h"

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -25,6 +25,7 @@ limitations under the License.
 #include <vector>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "client/client_base.h"
 #include "client/ds/i_object.h"

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -24,7 +24,7 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-#include "arrow/buffer.h"
+#include "arrow/api.h"
 
 #include "client/client_base.h"
 #include "client/ds/i_object.h"
@@ -182,30 +182,6 @@ class Client : public ClientBase {
   Status CreateBlob(size_t size, std::unique_ptr<BlobWriter>& blob);
 
   /**
-   * @brief Get a blob from vineyard server. When obtaining blobs from vineyard
-   * server, the memory address in the server process will be mmapped to the
-   * client's process to share the memory.
-   *
-   * @param id Object id for the blob to get.
-   * @param blob: The result immutable blob will be set in `blob`. Note that
-   * blob is special, since it can be get as immutable object before sealing.
-   *
-   * @return Status that indicates whether the create action has succeeded.
-   */
-  Status GetBlob(const ObjectID id, Payload& object);
-
-  /**
-   * @brief Get a set of blobs from vineyard server. See also `GetBlob`.
-   *
-   * @param ids Object ids for the blobs to get.
-   * @param blobs: The result immutable blobs will be added to `blobs`.
-   *
-   * @return Status that indicates whether the create action has succeeded.
-   */
-  Status GetBlobs(const std::vector<ObjectID>& ids,
-                  std::vector<std::shared_ptr<Blob>>& blobs);
-
-  /**
    * @brief Allocate a chunk of given size in vineyard for a stream. When the
    * request cannot be statisfied immediately, e.g., vineyard doesn't have
    * enough memory or the specified has accumulated too many chunks, the request
@@ -219,6 +195,9 @@ class Client : public ClientBase {
    */
   Status GetNextStreamChunk(ObjectID const id, size_t const size,
                             std::unique_ptr<arrow::MutableBuffer>& blob);
+
+  // bring the overloadings in parent class to current scope.
+  using ClientBase::PullNextStreamChunk;
 
   /**
    * @brief Pull a chunk from a stream. When there's no more chunk available in
@@ -380,8 +359,27 @@ class Client : public ClientBase {
   Status CreateBuffer(const size_t size, ObjectID& id, Payload& payload,
                       std::shared_ptr<arrow::MutableBuffer>& buffer);
 
+  /**
+   * @brief Get a blob from vineyard server. When obtaining blobs from vineyard
+   * server, the memory address in the server process will be mmapped to the
+   * client's process to share the memory.
+   *
+   * @param id Object id for the blob to get.
+   * @param buffer: The result immutable blob will be set in `blob`. Note that
+   * blob is special, since it can be get as immutable object before sealing.
+   *
+   * @return Status that indicates whether the create action has succeeded.
+   */
   Status GetBuffer(const ObjectID id, std::shared_ptr<arrow::Buffer>& buffer);
 
+  /**
+   * @brief Get a set of blobs from vineyard server. See also `GetBuffer`.
+   *
+   * @param ids Object ids for the blobs to get.
+   * @param buffers: The result immutable blobs will be added to `buffers`.
+   *
+   * @return Status that indicates whether the create action has succeeded.
+   */
   Status GetBuffers(
       const std::set<ObjectID>& ids,
       std::map<ObjectID, std::shared_ptr<arrow::Buffer>>& buffers);

--- a/src/client/ds/blob.h
+++ b/src/client/ds/blob.h
@@ -25,6 +25,7 @@ limitations under the License.
 #include <utility>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "client/ds/i_object.h"
 #include "common/memory/payload.h"

--- a/src/client/ds/blob.h
+++ b/src/client/ds/blob.h
@@ -24,7 +24,7 @@ limitations under the License.
 #include <unordered_map>
 #include <utility>
 
-#include "arrow/buffer.h"
+#include "arrow/api.h"
 
 #include "client/ds/i_object.h"
 #include "common/memory/payload.h"

--- a/src/client/ds/object_meta.h
+++ b/src/client/ds/object_meta.h
@@ -25,6 +25,7 @@ limitations under the License.
 #include <vector>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "common/util/boost.h"
 #include "common/util/json.h"

--- a/src/client/ds/object_meta.h
+++ b/src/client/ds/object_meta.h
@@ -24,7 +24,7 @@ limitations under the License.
 #include <unordered_map>
 #include <vector>
 
-#include "arrow/buffer.h"
+#include "arrow/api.h"
 
 #include "common/util/boost.h"
 #include "common/util/json.h"

--- a/src/common/util/status.h
+++ b/src/common/util/status.h
@@ -33,6 +33,7 @@
 #include <utility>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "common/util/boost.h"
 #include "common/util/json.h"

--- a/src/common/util/status.h
+++ b/src/common/util/status.h
@@ -32,7 +32,8 @@
 #include <string>
 #include <utility>
 
-#include "arrow/status.h"
+#include "arrow/api.h"
+
 #include "common/util/boost.h"
 #include "common/util/json.h"
 #include "common/util/macros.h"

--- a/src/server/async/ipc_server.h
+++ b/src/server/async/ipc_server.h
@@ -19,9 +19,7 @@ limitations under the License.
 #include <memory>
 #include <string>
 
-#include "arrow/status.h"
-#include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/api.h"
 
 #include "boost/asio.hpp"
 

--- a/src/server/async/ipc_server.h
+++ b/src/server/async/ipc_server.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include <string>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "boost/asio.hpp"
 

--- a/test/allocator_test.cc
+++ b/test/allocator_test.cc
@@ -22,6 +22,7 @@ limitations under the License.
 #include <thread>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "basic/ds/array.h"
 #include "client/allocator.h"

--- a/test/allocator_test.cc
+++ b/test/allocator_test.cc
@@ -21,8 +21,7 @@ limitations under the License.
 #include <string>
 #include <thread>
 
-#include "arrow/status.h"
-#include "arrow/util/io_util.h"
+#include "arrow/api.h"
 
 #include "basic/ds/array.h"
 #include "client/allocator.h"

--- a/test/array_test.cc
+++ b/test/array_test.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <thread>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "basic/ds/array.h"
 #include "client/client.h"

--- a/test/array_test.cc
+++ b/test/array_test.cc
@@ -17,9 +17,7 @@ limitations under the License.
 #include <string>
 #include <thread>
 
-#include "arrow/status.h"
-#include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/api.h"
 
 #include "basic/ds/array.h"
 #include "client/client.h"

--- a/test/arrow_data_structure_test.cc
+++ b/test/arrow_data_structure_test.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <thread>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "basic/ds/arrow.h"
 #include "client/client.h"

--- a/test/arrow_data_structure_test.cc
+++ b/test/arrow_data_structure_test.cc
@@ -17,11 +17,7 @@ limitations under the License.
 #include <string>
 #include <thread>
 
-#include "arrow/status.h"
-#include "arrow/stl.h"
-#include "arrow/util/config.h"
-#include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/api.h"
 
 #include "basic/ds/arrow.h"
 #include "client/client.h"

--- a/test/arrow_data_structure_test.cc
+++ b/test/arrow_data_structure_test.cc
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include "arrow/api.h"
 #include "arrow/io/api.h"
+#include "arrow/stl.h"
 
 #include "basic/ds/arrow.h"
 #include "client/client.h"

--- a/test/clear_test.cc
+++ b/test/clear_test.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <thread>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "basic/ds/array.h"
 #include "client/client.h"

--- a/test/clear_test.cc
+++ b/test/clear_test.cc
@@ -17,9 +17,7 @@ limitations under the License.
 #include <string>
 #include <thread>
 
-#include "arrow/status.h"
-#include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/api.h"
 
 #include "basic/ds/array.h"
 #include "client/client.h"

--- a/test/custom_vector_test.cc
+++ b/test/custom_vector_test.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <thread>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "client/client.h"
 #include "client/ds/blob.h"

--- a/test/custom_vector_test.cc
+++ b/test/custom_vector_test.cc
@@ -17,9 +17,7 @@ limitations under the License.
 #include <string>
 #include <thread>
 
-#include "arrow/status.h"
-#include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/api.h"
 
 #include "client/client.h"
 #include "client/ds/blob.h"

--- a/test/dataframe_test.cc
+++ b/test/dataframe_test.cc
@@ -17,9 +17,7 @@ limitations under the License.
 #include <string>
 #include <thread>
 
-#include "arrow/status.h"
-#include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/api.h"
 
 #include "basic/ds/dataframe.h"
 #include "client/client.h"

--- a/test/dataframe_test.cc
+++ b/test/dataframe_test.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <thread>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "basic/ds/dataframe.h"
 #include "client/client.h"

--- a/test/deep_copy_test.cc
+++ b/test/deep_copy_test.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <thread>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "basic/ds/array.h"
 #include "client/client.h"

--- a/test/deep_copy_test.cc
+++ b/test/deep_copy_test.cc
@@ -17,9 +17,7 @@ limitations under the License.
 #include <string>
 #include <thread>
 
-#include "arrow/status.h"
-#include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/api.h"
 
 #include "basic/ds/array.h"
 #include "client/client.h"

--- a/test/delete_test.cc
+++ b/test/delete_test.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include <unordered_map>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "basic/ds/array.h"
 #include "basic/ds/pair.h"

--- a/test/delete_test.cc
+++ b/test/delete_test.cc
@@ -23,9 +23,7 @@ limitations under the License.
 #include <thread>
 #include <unordered_map>
 
-#include "arrow/status.h"
-#include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/api.h"
 
 #include "basic/ds/array.h"
 #include "basic/ds/pair.h"

--- a/test/get_object_test.cc
+++ b/test/get_object_test.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <thread>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "basic/ds/array.h"
 #include "client/client.h"

--- a/test/get_object_test.cc
+++ b/test/get_object_test.cc
@@ -17,9 +17,7 @@ limitations under the License.
 #include <string>
 #include <thread>
 
-#include "arrow/status.h"
-#include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/api.h"
 
 #include "basic/ds/array.h"
 #include "client/client.h"

--- a/test/get_wait_test.cc
+++ b/test/get_wait_test.cc
@@ -18,9 +18,7 @@ limitations under the License.
 #include <string>
 #include <thread>
 
-#include "arrow/status.h"
-#include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/api.h"
 
 #include "basic/ds/scalar.h"
 #include "client/client.h"

--- a/test/get_wait_test.cc
+++ b/test/get_wait_test.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include <thread>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "basic/ds/scalar.h"
 #include "client/client.h"

--- a/test/global_object_test.cc
+++ b/test/global_object_test.cc
@@ -17,9 +17,7 @@ limitations under the License.
 #include <string>
 #include <thread>
 
-#include "arrow/status.h"
-#include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/api.h"
 
 #include "basic/ds/dataframe.h"
 #include "basic/ds/tensor.h"

--- a/test/global_object_test.cc
+++ b/test/global_object_test.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <thread>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "basic/ds/dataframe.h"
 #include "basic/ds/tensor.h"

--- a/test/hashmap_test.cc
+++ b/test/hashmap_test.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <thread>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "basic/ds/array.h"
 #include "basic/ds/hashmap.h"

--- a/test/hashmap_test.cc
+++ b/test/hashmap_test.cc
@@ -17,9 +17,7 @@ limitations under the License.
 #include <string>
 #include <thread>
 
-#include "arrow/status.h"
-#include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/api.h"
 
 #include "basic/ds/array.h"
 #include "basic/ds/hashmap.h"

--- a/test/invalid_connect_test.cc
+++ b/test/invalid_connect_test.cc
@@ -18,9 +18,8 @@ limitations under the License.
 #include <string>
 #include <thread>
 
-#include "arrow/status.h"
-#include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "basic/ds/array.h"
 #include "client/client.h"

--- a/test/jemalloc_test.cc
+++ b/test/jemalloc_test.cc
@@ -21,8 +21,8 @@ limitations under the License.
 #include <string>
 #include <thread>
 
-#include "arrow/status.h"
-#include "arrow/util/io_util.h"
+#include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "basic/ds/array.h"
 #include "client/allocator.h"

--- a/test/large_meta_test.cc
+++ b/test/large_meta_test.cc
@@ -17,9 +17,8 @@ limitations under the License.
 #include <string>
 #include <thread>
 
-#include "arrow/status.h"
-#include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "basic/ds/array.h"
 #include "basic/ds/hashmap.h"

--- a/test/list_object_test.cc
+++ b/test/list_object_test.cc
@@ -17,9 +17,8 @@ limitations under the License.
 #include <string>
 #include <thread>
 
-#include "arrow/status.h"
-#include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "basic/ds/tensor.h"
 #include "client/client.h"

--- a/test/persist_test.cc
+++ b/test/persist_test.cc
@@ -17,9 +17,8 @@ limitations under the License.
 #include <string>
 #include <thread>
 
-#include "arrow/status.h"
-#include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "basic/ds/array.h"
 #include "client/client.h"

--- a/test/rpc_delete_test.cc
+++ b/test/rpc_delete_test.cc
@@ -23,9 +23,8 @@ limitations under the License.
 #include <thread>
 #include <unordered_map>
 
-#include "arrow/status.h"
-#include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "basic/ds/array.h"
 #include "basic/ds/pair.h"

--- a/test/rpc_get_object_test.cc
+++ b/test/rpc_get_object_test.cc
@@ -17,9 +17,8 @@ limitations under the License.
 #include <string>
 #include <thread>
 
-#include "arrow/status.h"
-#include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "basic/ds/array.h"
 #include "client/client.h"

--- a/test/rpc_test.cc
+++ b/test/rpc_test.cc
@@ -17,9 +17,8 @@ limitations under the License.
 #include <string>
 #include <thread>
 
-#include "arrow/status.h"
-#include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "basic/ds/array.h"
 #include "client/client.h"

--- a/test/scalar_test.cc
+++ b/test/scalar_test.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <thread>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "basic/ds/scalar.h"
 #include "basic/ds/types.h"

--- a/test/scalar_test.cc
+++ b/test/scalar_test.cc
@@ -17,9 +17,7 @@ limitations under the License.
 #include <string>
 #include <thread>
 
-#include "arrow/status.h"
-#include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/api.h"
 
 #include "basic/ds/scalar.h"
 #include "basic/ds/types.h"

--- a/test/server_status_test.cc
+++ b/test/server_status_test.cc
@@ -20,9 +20,8 @@ limitations under the License.
 #include <thread>
 #include <vector>
 
-#include "arrow/status.h"
-#include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "client/client.h"
 #include "client/ds/object_meta.h"

--- a/test/shallow_copy_test.cc
+++ b/test/shallow_copy_test.cc
@@ -17,9 +17,8 @@ limitations under the License.
 #include <string>
 #include <thread>
 
-#include "arrow/status.h"
-#include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "basic/ds/array.h"
 #include "client/client.h"

--- a/test/shared_memory_test.cc
+++ b/test/shared_memory_test.cc
@@ -17,9 +17,8 @@ limitations under the License.
 #include <string>
 #include <thread>
 
-#include "arrow/status.h"
-#include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "basic/ds/array.h"
 #include "client/client.h"

--- a/test/stream_test.cc
+++ b/test/stream_test.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include <unordered_map>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "basic/stream/byte_stream.h"
 #include "basic/stream/dataframe_stream.h"

--- a/test/stream_test.cc
+++ b/test/stream_test.cc
@@ -18,9 +18,7 @@ limitations under the License.
 #include <thread>
 #include <unordered_map>
 
-#include "arrow/status.h"
-#include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/api.h"
 
 #include "basic/stream/byte_stream.h"
 #include "basic/stream/dataframe_stream.h"

--- a/test/tensor_test.cc
+++ b/test/tensor_test.cc
@@ -17,9 +17,8 @@ limitations under the License.
 #include <string>
 #include <thread>
 
-#include "arrow/status.h"
-#include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "basic/ds/tensor.h"
 #include "client/client.h"

--- a/test/version_test.cc
+++ b/test/version_test.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <thread>
 
 #include "arrow/api.h"
+#include "arrow/io/api.h"
 
 #include "client/client.h"
 #include "common/util/logging.h"

--- a/test/version_test.cc
+++ b/test/version_test.cc
@@ -17,9 +17,7 @@ limitations under the License.
 #include <string>
 #include <thread>
 
-#include "arrow/status.h"
-#include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/api.h"
 
 #include "client/client.h"
 #include "common/util/logging.h"


### PR DESCRIPTION
What do these changes do?
-------------------------

Arrow: simplify the include statements and keeps things in different translation unit consistent.

Related issue number
--------------------

N/A
