### PR TITLE
Drop arrow 0.17.x check.

### DIFF
--- a/.github/workflows/build-compatibility.yml
+++ b/.github/workflows/build-compatibility.yml
@@ -26,12 +26,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, macos-10.15]
-        arrow: [none, 0.17.1-1, 1.0.1-1, 2.0.0-1, 3.0.0-1]
+        arrow: [none, 1.0.1-1, 2.0.0-1, 3.0.0-1]
         exclude:
           - os: ubuntu-18.04
             arrow: none
-          - os: macos-10.15
-            arrow: 0.17.1-1
           - os: macos-10.15
             arrow: 1.0.1-1
           - os: macos-10.15


### PR DESCRIPTION
Fixes the failures on CI.