### PR TITLE
Support session in Vineyard.

### DIFF
--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -81,6 +81,38 @@ Status Client::Connect(const std::string& ipc_socket) {
   return Status::OK();
 }
 
+Status Client::Open(std::string const& ipc_socket) {
+  RETURN_ON_ASSERT(!Connected(),
+                   "The client has already been connected to vineyard server");
+  std::string socket_path;
+  VINEYARD_CHECK_OK(Connect(ipc_socket));
+
+  {
+    std::lock_guard<std::recursive_mutex> guard(client_mutex_);
+    std::string message_out;
+    WriteNewSessionRequest(message_out);
+    RETURN_ON_ERROR(doWrite(message_out));
+    json message_in;
+    RETURN_ON_ERROR(doRead(message_in));
+    RETURN_ON_ERROR(ReadNewSessionReply(message_in, socket_path));
+  }
+
+  Disconnect();
+  VINEYARD_CHECK_OK(Connect(socket_path));
+  return Status::OK();
+}
+
+void Client::CloseSession() {
+  // TODO: send a request to vineyardd to tear down the session
+  {
+    std::lock_guard<std::recursive_mutex> guard(client_mutex_);
+    std::string message_out;
+    WriteDeleteSessionRequest(message_out);
+    VINEYARD_SUPPRESS(doWrite(message_out));
+  }
+  Disconnect();
+}
+
 Status Client::Fork(Client& client) {
   RETURN_ON_ASSERT(!client.Connected(),
                    "The client has already been connected to vineyard server");

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -82,7 +82,7 @@ Status Client::Connect(const std::string& ipc_socket) {
 }
 
 Status Client::Open(std::string const& ipc_socket) {
-  RETURN_ON_ASSERT(!Connected(),
+  RETURN_ON_ASSERT(!this->connected_,
                    "The client has already been connected to vineyard server");
   std::string socket_path;
   VINEYARD_CHECK_OK(Connect(ipc_socket));
@@ -100,17 +100,6 @@ Status Client::Open(std::string const& ipc_socket) {
   Disconnect();
   VINEYARD_CHECK_OK(Connect(socket_path));
   return Status::OK();
-}
-
-void Client::CloseSession() {
-  // TODO: send a request to vineyardd to tear down the session
-  {
-    std::lock_guard<std::recursive_mutex> guard(client_mutex_);
-    std::string message_out;
-    WriteDeleteSessionRequest(message_out);
-    VINEYARD_SUPPRESS(doWrite(message_out));
-  }
-  Disconnect();
 }
 
 Status Client::Fork(Client& client) {

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -120,6 +120,29 @@ class Client : public ClientBase {
   Status Connect();
 
   /**
+   * @brief Create a new session in vineyardd.
+   *
+   * @param session_name the name of the session.
+   *
+   * @return Status that indicates whether the creation of has succeeded.
+   */
+  Status NewSession(std::string const& session_name, std::string& ipc_socket);
+
+  /**
+   * @brief Create a new anonymous session in vineyardd and connect to it .
+   *
+   * @param ipc_socket Location of the UNIX domain socket.
+   *
+   * @return Status that indicates whether the connection of has succeeded.
+   */
+  Status Open(std::string const& ipc_socket);
+
+  /**
+   * @brief Close the session that the client is connecting to.
+   */
+  void CloseSession();
+
+  /**
    * @brief Connect to vineyardd using the given UNIX domain socket
    * `ipc_socket`.
    *
@@ -274,11 +297,13 @@ class Client : public ClientBase {
    */
   template <typename T>
   Status GetObject(const ObjectID id, std::shared_ptr<T>& object) {
-    object = std::dynamic_pointer_cast<T>(GetObject(id));
-    if (object == nullptr) {
+    std::shared_ptr<Object> _object;
+    RETURN_ON_ERROR(GetObject(id, _object));
+    if (_object == nullptr) {
       return Status::ObjectNotExists("object not exists: " +
                                      ObjectIDToString(id));
     } else {
+      object = std::dynamic_pointer_cast<T>(_object);
       return Status::OK();
     }
   }

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -120,13 +120,14 @@ class Client : public ClientBase {
   Status Connect();
 
   /**
-   * @brief Create a new session in vineyardd.
+   * @brief Connect to vineyardd using the given UNIX domain socket
+   * `ipc_socket`.
    *
-   * @param session_name the name of the session.
+   * @param ipc_socket Location of the UNIX domain socket.
    *
-   * @return Status that indicates whether the creation of has succeeded.
+   * @return Status that indicates whether the connect has succeeded.
    */
-  Status NewSession(std::string const& session_name, std::string& ipc_socket);
+  Status Connect(const std::string& ipc_socket);
 
   /**
    * @brief Create a new anonymous session in vineyardd and connect to it .
@@ -136,21 +137,6 @@ class Client : public ClientBase {
    * @return Status that indicates whether the connection of has succeeded.
    */
   Status Open(std::string const& ipc_socket);
-
-  /**
-   * @brief Close the session that the client is connecting to.
-   */
-  void CloseSession();
-
-  /**
-   * @brief Connect to vineyardd using the given UNIX domain socket
-   * `ipc_socket`.
-   *
-   * @param ipc_socket Location of the UNIX domain socket.
-   *
-   * @return Status that indicates whether the connect has succeeded.
-   */
-  Status Connect(const std::string& ipc_socket);
 
   /**
    * @brief Create a new client using self UNIX domain socket.

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -285,11 +285,11 @@ class Client : public ClientBase {
   Status GetObject(const ObjectID id, std::shared_ptr<T>& object) {
     std::shared_ptr<Object> _object;
     RETURN_ON_ERROR(GetObject(id, _object));
-    if (_object == nullptr) {
+    object = std::dynamic_pointer_cast<T>(_object);
+    if (object == nullptr) {
       return Status::ObjectNotExists("object not exists: " +
                                      ObjectIDToString(id));
     } else {
-      object = std::dynamic_pointer_cast<T>(_object);
       return Status::OK();
     }
   }

--- a/src/client/client_base.cc
+++ b/src/client/client_base.cc
@@ -444,6 +444,20 @@ void ClientBase::Disconnect() {
   connected_ = false;
 }
 
+void ClientBase::CloseSession() {
+  std::lock_guard<std::recursive_mutex> guard(client_mutex_);
+  if (!Connected()) {
+    return;
+  }
+  std::string message_out;
+  WriteDeleteSessionRequest(message_out);
+  VINEYARD_SUPPRESS(doWrite(message_out));
+  json message_in;
+  VINEYARD_SUPPRESS(doRead(message_in));
+  close(vineyard_conn_);
+  connected_ = false;
+}
+
 Status ClientBase::doWrite(const std::string& message_out) {
   auto status = send_message(vineyard_conn_, message_out);
   if (!status.ok()) {

--- a/src/client/client_base.h
+++ b/src/client/client_base.h
@@ -415,6 +415,20 @@ class ClientBase {
   void Disconnect();
 
   /**
+   * @brief Create a new anonymous session in vineyardd and connect to it .
+   *
+   * @param ipc_socket Location of the UNIX domain socket.
+   *
+   * @return Status that indicates whether the connection of has succeeded.
+   */
+  Status Open(std::string const& ipc_socket);
+
+  /**
+   * @brief Close the session that the client is connecting to.
+   */
+  void CloseSession();
+
+  /**
    * @brief Get the UNIX domain socket location of the connected vineyardd
    * server.
    *

--- a/src/common/util/protocols.cc
+++ b/src/common/util/protocols.cc
@@ -108,6 +108,12 @@ CommandType ParseCommandType(const std::string& str_type) {
     return CommandType::ClearRequest;
   } else if (str_type == "debug_command") {
     return CommandType::DebugCommand;
+  } else if (str_type == "new_session_request") {
+    return CommandType::NewSessionRequest;
+  } else if (str_type == "new_session_reply") {
+    return CommandType::NewSessionReply;
+  } else if (str_type == "delete_session_request") {
+    return CommandType::DeleteSessionRequest;
   } else {
     return CommandType::NullCommand;
   }
@@ -1111,4 +1117,28 @@ Status ReadDebugReply(const json& root, json& result) {
   return Status::OK();
 }
 
+void WriteNewSessionRequest(std::string& msg) {
+  json root;
+  root["type"] = "new_session_request";
+  encode_msg(root, msg);
+}
+
+void WriteNewSessionReply(std::string& msg, std::string const& socket_path) {
+  json root;
+  root["type"] = "new_session_reply";
+  root["socket_path"] = socket_path;
+  encode_msg(root, msg);
+}
+
+Status ReadNewSessionReply(const json& root, std::string& socket_path) {
+  CHECK_IPC_ERROR(root, "new_session_reply");
+  socket_path = root["socket_path"].get_ref<std::string const&>();
+  return Status::OK();
+}
+
+void WriteDeleteSessionRequest(std::string& msg) {
+  json root;
+  root["type"] = "delete_session_request";
+  encode_msg(root, msg);
+}
 }  // namespace vineyard

--- a/src/common/util/protocols.cc
+++ b/src/common/util/protocols.cc
@@ -114,6 +114,8 @@ CommandType ParseCommandType(const std::string& str_type) {
     return CommandType::NewSessionReply;
   } else if (str_type == "delete_session_request") {
     return CommandType::DeleteSessionRequest;
+  } else if (str_type == "delete_session_reply") {
+    return CommandType::DeleteSessionReply;
   } else {
     return CommandType::NullCommand;
   }
@@ -1141,4 +1143,11 @@ void WriteDeleteSessionRequest(std::string& msg) {
   root["type"] = "delete_session_request";
   encode_msg(root, msg);
 }
+
+void WriteDeleteSessionReply(std::string& msg) {
+  json root;
+  root["type"] = "delete_session_reply";
+  encode_msg(root, msg);
+}
+
 }  // namespace vineyard

--- a/src/common/util/protocols.h
+++ b/src/common/util/protocols.h
@@ -72,6 +72,7 @@ enum class CommandType {
   NewSessionRequest = 38,
   NewSessionReply = 39,
   DeleteSessionRequest = 40,
+  DeleteSessionReply = 41,
 };
 
 CommandType ParseCommandType(const std::string& str_type);
@@ -382,6 +383,8 @@ void WriteNewSessionReply(std::string& msg, std::string const& socket_path);
 Status ReadNewSessionReply(json const& root, std::string& socket_path);
 
 void WriteDeleteSessionRequest(std::string& msg);
+
+void WriteDeleteSessionReply(std::string& msg);
 
 }  // namespace vineyard
 

--- a/src/common/util/protocols.h
+++ b/src/common/util/protocols.h
@@ -69,6 +69,9 @@ enum class CommandType {
   DeepCopyRequest = 35,
   ClearRequest = 36,
   PushNextStreamChunkRequest = 37,
+  NewSessionRequest = 38,
+  NewSessionReply = 39,
+  DeleteSessionRequest = 40,
 };
 
 CommandType ParseCommandType(const std::string& str_type);
@@ -371,6 +374,14 @@ Status ReadDebugRequest(const json& root, json& debug);
 void WriteDebugReply(const json& result, std::string& msg);
 
 Status ReadDebugReply(const json& root, json& result);
+
+void WriteNewSessionRequest(std::string& msg);
+
+void WriteNewSessionReply(std::string& msg, std::string const& socket_path);
+
+Status ReadNewSessionReply(json const& root, std::string& socket_path);
+
+void WriteDeleteSessionRequest(std::string& msg);
 
 }  // namespace vineyard
 

--- a/src/common/util/uuid.cc
+++ b/src/common/util/uuid.cc
@@ -37,4 +37,10 @@ const std::string SignatureToString(const Signature id) {
   return std::string(buffer);
 }
 
+const std::string SessionIDToString(const SessionId id) {
+  thread_local char buffer[18] = {'\0'};
+  std::snprintf(buffer, sizeof(buffer), "S%016" PRIx64, id);
+  return std::string(buffer);
+}
+
 }  // namespace vineyard

--- a/src/common/util/uuid.h
+++ b/src/common/util/uuid.h
@@ -42,11 +42,16 @@ using ObjectID = uint64_t;
 using Signature = uint64_t;
 
 /**
- * @brief InstanceID is an opaque type for vineyard's instance ID id. The
- * underlying type of ObjectID is a 64-bit unsigned integer.
+ * @brief InstanceID is an opaque type for vineyard's instance. The
+ * underlying type of Instance is a 64-bit unsigned integer.
  */
 using InstanceID = uint64_t;
 
+/**
+ * @brief SessionId is an opaque type for vineyard's Session. The
+ * underlying type of SessionId is a 64-bit unsigned integer.
+ */
+using SessionId = int64_t;
 // blob id: 1 + memory address (in vineyardd)
 // non-blob id: 0 + random (rdstc)
 
@@ -62,6 +67,15 @@ inline ObjectID GenerateBlobID(const void* ptr) {
 
 inline ObjectID GenerateBlobID(const uintptr_t ptr) {
   return 0x8000000000000000UL | static_cast<uint64_t>(ptr);
+}
+
+inline SessionId GenerateSessionId() {
+#if defined(__x86_64__)
+  return 0x7FFFFFFFFFFFFFFFUL & static_cast<uint64_t>(__rdtsc());
+#else
+  return 0x7FFFFFFFFFFFFFFFUL &
+         static_cast<uint64_t>(rand());  // NOLINT(runtime/threadsafe_fn)
+#endif
 }
 
 constexpr inline ObjectID EmptyBlobID() { return 0x8000000000000000UL; }
@@ -93,6 +107,16 @@ inline ObjectID ObjectIDFromString(const std::string& s) {
 }
 
 inline ObjectID ObjectIDFromString(const char* s) {
+  return strtoull(s + 1, nullptr, 16);
+}
+
+const std::string SessionIDToString(const SessionId id);
+
+inline SessionId SessionIDFromString(const std::string& s) {
+  return strtoull(s.c_str() + 1, nullptr, 16);
+}
+
+inline SessionId SessionIDFromString(const char* s) {
   return strtoull(s + 1, nullptr, 16);
 }
 

--- a/src/common/util/uuid.h
+++ b/src/common/util/uuid.h
@@ -110,6 +110,8 @@ inline ObjectID ObjectIDFromString(const char* s) {
   return strtoull(s + 1, nullptr, 16);
 }
 
+constexpr inline SessionId RootSessionID() { return 0x0000000000000000UL; }
+
 const std::string SessionIDToString(const SessionId id);
 
 inline SessionId SessionIDFromString(const std::string& s) {

--- a/src/server/async/ipc_server.cc
+++ b/src/server/async/ipc_server.cc
@@ -52,6 +52,16 @@ void IPCServer::Start() {
   LOG(INFO) << "Vineyard will listen on " << ipc_spec_["socket"] << " for IPC";
 }
 
+void IPCServer::Close() {
+  SocketServer::Close();
+  boost::system::error_code ec;
+  acceptor_.cancel(ec);
+  if (!ec) {
+    LOG(ERROR) << "Vineyard cannot close session : " << ec.message()
+               << std::endl;
+  }
+}
+
 #if BOOST_VERSION >= 106600
 asio::local::stream_protocol::endpoint IPCServer::getEndpoint(
     asio::io_context& context) {

--- a/src/server/async/ipc_server.cc
+++ b/src/server/async/ipc_server.cc
@@ -110,9 +110,12 @@ void IPCServer::doAccept() {
       connections_.emplace(next_conn_id_, conn);
       ++next_conn_id_;
     }
-    // don't continue when the iocontext being cancelled.
-    if (!stopped_.load()) {
-      doAccept();
+    // don't continue when the iocontext being cancelled or the session is going
+    // to close.
+    if (!ec || ec != boost::system::errc::operation_canceled) {
+      if (!stopped_.load() || !closable_.load()) {
+        doAccept();
+      }
     }
   });
 }

--- a/src/server/async/ipc_server.cc
+++ b/src/server/async/ipc_server.cc
@@ -56,7 +56,7 @@ void IPCServer::Close() {
   SocketServer::Close();
   boost::system::error_code ec;
   acceptor_.cancel(ec);
-  if (!ec) {
+  if (ec) {
     LOG(ERROR) << "Vineyard cannot close session : " << ec.message()
                << std::endl;
   }

--- a/src/server/async/ipc_server.h
+++ b/src/server/async/ipc_server.h
@@ -43,6 +43,8 @@ class IPCServer : public SocketServer {
 
   void Start() override;
 
+  void Close() override;
+
   std::string Socket() {
     return ipc_spec_["socket"].get_ref<std::string const&>();
   }

--- a/src/server/async/rpc_server.cc
+++ b/src/server/async/rpc_server.cc
@@ -79,8 +79,10 @@ void RPCServer::doAccept() {
       ++next_conn_id_;
     }
     // don't continue when the iocontext being cancelled.
-    if (!stopped_.load()) {
-      doAccept();
+    if (!ec || ec != boost::system::errc::operation_canceled) {
+      if (!stopped_.load()) {
+        doAccept();
+      }
     }
   });
 }

--- a/src/server/async/socket_server.cc
+++ b/src/server/async/socket_server.cc
@@ -1015,7 +1015,10 @@ bool SocketConnection::doNewSession(const json& root) {
 }
 
 bool SocketConnection::doDeleteSession(const json& root) {
+  std::string message_out;
+  WriteDeleteSessionReply(message_out);
   socket_server_ptr_->Close();
+  this->doWrite(message_out);
   return true;
 }
 

--- a/src/server/async/socket_server.cc
+++ b/src/server/async/socket_server.cc
@@ -272,6 +272,12 @@ bool SocketConnection::processMessage(const std::string& message_in) {
   case CommandType::ExitRequest: {
     return true;
   }
+  case CommandType::NewSessionRequest: {
+    return doNewSession(root);
+  }
+  case CommandType::DeleteSessionRequest: {
+    return doDeleteSession(root);
+  }
   default: {
     LOG(ERROR) << "Got unexpected command: " << type;
     return false;
@@ -998,6 +1004,21 @@ bool SocketConnection::doDebug(const json& root) {
   return false;
 }
 
+bool SocketConnection::doNewSession(const json& root) {
+  auto self(shared_from_this());
+  std::string message_out, ipc_socket;
+  json result;
+  VINEYARD_CHECK_OK(server_ptr_->GetRunner()->CreateNewSession(ipc_socket));
+  WriteNewSessionReply(message_out, ipc_socket);
+  this->doWrite(message_out);
+  return false;
+}
+
+bool SocketConnection::doDeleteSession(const json& root) {
+  socket_server_ptr_->Close();
+  return true;
+}
+
 void SocketConnection::doWrite(const std::string& buf) {
   std::string to_send;
   size_t length = buf.size();
@@ -1103,6 +1124,7 @@ SocketServer::SocketServer(vs_ptr_t vs_ptr)
 
 void SocketServer::Start() {
   stopped_.store(false);
+  closable_.store(false);
   doAccept();
 }
 
@@ -1124,19 +1146,31 @@ bool SocketServer::ExistsConnection(int conn_id) const {
 }
 
 void SocketServer::RemoveConnection(int conn_id) {
-  std::lock_guard<std::recursive_mutex> scope_lock(this->connections_mutex_);
-  auto conn = connections_.find(conn_id);
-  if (conn != connections_.end()) {
-    connections_.erase(conn);
+  {
+    std::lock_guard<std::recursive_mutex> scope_lock(this->connections_mutex_);
+    auto conn = connections_.find(conn_id);
+    if (conn != connections_.end()) {
+      connections_.erase(conn);
+    }
+
+    if (AliveConnections() == 0 && closable_.load()) {
+      VINEYARD_CHECK_OK(vs_ptr_->GetRunner()->Delete(vs_ptr_->GetSessionId()));
+    }
   }
 }
 
 void SocketServer::CloseConnection(int conn_id) {
-  std::lock_guard<std::recursive_mutex> scope_lock(this->connections_mutex_);
-  auto conn = connections_.find(conn_id);
-  if (conn != connections_.end()) {
-    conn->second->Stop();
-    connections_.erase(conn);
+  {
+    std::lock_guard<std::recursive_mutex> scope_lock(this->connections_mutex_);
+    auto conn = connections_.find(conn_id);
+    if (conn != connections_.end()) {
+      conn->second->Stop();
+      connections_.erase(conn);
+    }
+  }
+
+  if (AliveConnections() == 0 && closable_.load()) {
+    VINEYARD_CHECK_OK(vs_ptr_->GetRunner()->Delete(vs_ptr_->GetSessionId()));
   }
 }
 

--- a/src/server/async/socket_server.h
+++ b/src/server/async/socket_server.h
@@ -204,7 +204,7 @@ class SocketServer {
   /**
    * ready to stop the session.
    */
-  void Close() { closable_.store(true); }
+  virtual void Close() { closable_.store(true); }
 
   /**
    * Check if @conn_id@ exists in the connection pool.

--- a/src/server/async/socket_server.h
+++ b/src/server/async/socket_server.h
@@ -126,6 +126,10 @@ class SocketConnection : public std::enable_shared_from_this<SocketConnection> {
 
   bool doDebug(const json& root);
 
+  bool doNewSession(const json& root);
+
+  bool doDeleteSession(const json& root);
+
  private:
   int nativeHandle() { return socket_.native_handle(); }
 
@@ -198,6 +202,11 @@ class SocketServer {
   void Stop();
 
   /**
+   * ready to stop the session.
+   */
+  void Close() { closable_.store(true); }
+
+  /**
    * Check if @conn_id@ exists in the connection pool.
    */
   bool ExistsConnection(int conn_id) const;
@@ -220,7 +229,8 @@ class SocketServer {
   size_t AliveConnections() const;
 
  protected:
-  std::atomic_bool stopped_;  // if the socket server being stopped.
+  std::atomic_bool stopped_;   // if the socket server being stopped.
+  std::atomic_bool closable_;  // if client want to close the session,
   vs_ptr_t vs_ptr_;
   int next_conn_id_;
   std::unordered_map<int, std::shared_ptr<SocketConnection>> connections_;

--- a/src/server/server/vineyard_runner.cc
+++ b/src/server/server/vineyard_runner.cc
@@ -1,0 +1,165 @@
+/** Copyright 2020-2021 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "server/server/vineyard_runner.h"
+
+#include <iostream>
+#include <memory>
+#include <set>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "boost/bind.hpp"
+
+#include "common/util//logging.h"
+#include "server/server/vineyard_server.h"
+
+namespace vineyard {
+
+VineyardRunner::VineyardRunner(const json& spec)
+    : spec_template_(spec),
+      concurrency_(std::thread::hardware_concurrency()),
+      context_(concurrency_),
+      meta_context_(),
+#if BOOST_VERSION >= 106600
+      guard_(asio::make_work_guard(context_)),
+      meta_guard_(asio::make_work_guard(meta_context_)),
+#else
+      guard_(new boost::asio::io_service::work(context_)),
+      meta_guard_(new boost::asio::io_service::work(context_)),
+#endif
+      root_(0) {
+}
+
+std::shared_ptr<VineyardRunner> VineyardRunner::Get(const json& spec) {
+  return std::shared_ptr<VineyardRunner>(new VineyardRunner(spec));
+}
+
+bool VineyardRunner::Running() const { return !stopped_.load(); }
+
+Status VineyardRunner::Serve() {
+  stopped_.store(false);
+
+  VINEYARD_ASSERT(sessions_.empty(), "Vineyard Runner already started");
+  root_ = GenerateSessionId();
+  auto root_vs = std::make_shared<VineyardServer>(
+      spec_template_, root_, shared_from_this(), context_, meta_context_);
+  sessions_.emplace(root_, root_vs);
+
+  // start a root session
+  VINEYARD_CHECK_OK(root_vs->Serve());
+
+  for (unsigned int idx = 0; idx < concurrency_; ++idx) {
+#if BOOST_VERSION >= 106600
+    workers_.emplace_back(
+        boost::bind(&boost::asio::io_context::run, &context_));
+#else
+    workers_.emplace_back(
+        boost::bind(&boost::asio::io_service::run, &context_));
+#endif
+  }
+
+  meta_context_.run();
+  return Status::OK();
+}
+
+Status VineyardRunner::Finalize() { return Status::OK(); }
+
+Status VineyardRunner::GetRootSession(vs_ptr_t& vs_ptr) {
+  session_map_t::const_accessor accessor;
+  if (!sessions_.find(accessor, root_)) {
+    return Status::Invalid("No root session.");
+  }
+  vs_ptr = accessor->second;
+  return Status::OK();
+}
+
+Status VineyardRunner::CreateNewSession(std::string& ipc_socket) {
+  SessionId session_id = GenerateSessionId();
+  json spec(spec_template_);
+
+  std::string default_ipc_socket =
+      spec["ipc_spec"]["socket"].get<std::string>();
+
+  ipc_socket = default_ipc_socket + "." + SessionIDToString(session_id);
+  spec["ipc_spec"]["socket"] = ipc_socket;
+
+  auto vs_ptr = std::make_shared<VineyardServer>(
+      spec, session_id, shared_from_this(), context_, meta_context_);
+  sessions_.emplace(session_id, vs_ptr);
+  LOG(INFO) << "Vineyard creates a new session with SessionID = "
+            << SessionIDToString(session_id) << std::endl;
+  return vs_ptr->Serve();
+}
+
+Status VineyardRunner::Delete(SessionId const& sid) {
+  session_map_t::const_accessor accessor;
+  if (!sessions_.find(accessor, sid)) {
+    return Status::OK();
+  }
+  accessor->second->Stop();
+  sessions_.erase(accessor);
+  LOG(INFO) << SessionIDToString(sid) << std::endl;
+  return Status::OK();
+}
+
+Status VineyardRunner::Get(SessionId const& sid, vs_ptr_t& session) {
+  session_map_t::const_accessor accessor;
+  if (sessions_.find(accessor, sid)) {
+    session = accessor->second;
+    return Status::OK();
+  } else {
+    return Status::Invalid("Session (sid = " + SessionIDToString(sid) +
+                           ") not exit");
+  }
+}
+
+bool VineyardRunner::Exists(SessionId const& sid) {
+  session_map_t::const_accessor accessor;
+  return sessions_.find(accessor, sid);
+}
+
+void VineyardRunner::Stop() {
+  // Stop creating.
+  if (stopped_.exchange(true)) {
+    return;
+  }
+
+  std::vector<SessionId> session_ids;
+  session_ids.reserve(sessions_.size());
+  for (auto iter = sessions_.begin(); iter != sessions_.end(); iter++) {
+    session_ids.emplace_back(iter->first);
+  }
+  for (auto const& item : session_ids) {
+    VINEYARD_DISCARD(Delete(item));  // trigger item->stop()
+  }
+
+  guard_.reset();
+  meta_guard_.reset();
+
+  // stop the asio context at last
+  context_.stop();
+  meta_context_.stop();
+
+  // wait for the IO context finishes.
+  for (auto& worker : workers_) {
+    if (worker.joinable()) {
+      worker.join();
+    }
+  }
+}
+
+}  // namespace vineyard

--- a/src/server/server/vineyard_runner.cc
+++ b/src/server/server/vineyard_runner.cc
@@ -36,12 +36,12 @@ VineyardRunner::VineyardRunner(const json& spec)
       meta_context_(),
 #if BOOST_VERSION >= 106600
       guard_(asio::make_work_guard(context_)),
-      meta_guard_(asio::make_work_guard(meta_context_)),
+      meta_guard_(asio::make_work_guard(meta_context_))
 #else
       guard_(new boost::asio::io_service::work(context_)),
-      meta_guard_(new boost::asio::io_service::work(context_)),
+      meta_guard_(new boost::asio::io_service::work(context_))
 #endif
-      root_(0) {
+{
 }
 
 std::shared_ptr<VineyardRunner> VineyardRunner::Get(const json& spec) {
@@ -54,10 +54,10 @@ Status VineyardRunner::Serve() {
   stopped_.store(false);
 
   VINEYARD_ASSERT(sessions_.empty(), "Vineyard Runner already started");
-  root_ = GenerateSessionId();
   auto root_vs = std::make_shared<VineyardServer>(
-      spec_template_, root_, shared_from_this(), context_, meta_context_);
-  sessions_.emplace(root_, root_vs);
+      spec_template_, RootSessionID(), shared_from_this(), context_,
+      meta_context_);
+  sessions_.emplace(RootSessionID(), root_vs);
 
   // start a root session
   VINEYARD_CHECK_OK(root_vs->Serve());
@@ -80,7 +80,7 @@ Status VineyardRunner::Finalize() { return Status::OK(); }
 
 Status VineyardRunner::GetRootSession(vs_ptr_t& vs_ptr) {
   session_map_t::const_accessor accessor;
-  if (!sessions_.find(accessor, root_)) {
+  if (!sessions_.find(accessor, RootSessionID())) {
     return Status::Invalid("No root session.");
   }
   vs_ptr = accessor->second;

--- a/src/server/server/vineyard_runner.cc
+++ b/src/server/server/vineyard_runner.cc
@@ -112,7 +112,7 @@ Status VineyardRunner::Delete(SessionId const& sid) {
   }
   accessor->second->Stop();
   sessions_.erase(accessor);
-  LOG(INFO) << SessionIDToString(sid) << std::endl;
+  LOG(INFO) << "Delete session : " << SessionIDToString(sid) << std::endl;
   return Status::OK();
 }
 

--- a/src/server/server/vineyard_runner.h
+++ b/src/server/server/vineyard_runner.h
@@ -75,7 +75,6 @@ class VineyardRunner : public std::enable_shared_from_this<VineyardRunner> {
   std::vector<std::thread> workers_;
 
   session_map_t sessions_;
-  SessionId root_;
   std::atomic_bool stopped_;
 };
 

--- a/src/server/server/vineyard_runner.h
+++ b/src/server/server/vineyard_runner.h
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef SRC_SERVER_SERVER_VINEYARD_SESSION_H_
-#define SRC_SERVER_SERVER_VINEYARD_SESSION_H_
+#ifndef SRC_SERVER_SERVER_VINEYARD_RUNNER_H_
+#define SRC_SERVER_SERVER_VINEYARD_RUNNER_H_
 
 #include <atomic>
 #include <list>
@@ -81,4 +81,4 @@ class VineyardRunner : public std::enable_shared_from_this<VineyardRunner> {
 
 }  // namespace vineyard
 
-#endif  // SRC_SERVER_SERVER_VINEYARD_SESSION_H_
+#endif  // SRC_SERVER_SERVER_VINEYARD_RUNNER_H_

--- a/src/server/server/vineyard_runner.h
+++ b/src/server/server/vineyard_runner.h
@@ -1,0 +1,84 @@
+/** Copyright 2020-2021 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef SRC_SERVER_SERVER_VINEYARD_SESSION_H_
+#define SRC_SERVER_SERVER_VINEYARD_SESSION_H_
+
+#include <atomic>
+#include <list>
+#include <memory>
+#include <set>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "boost/asio.hpp"
+
+#include "common/util/callback.h"
+#include "common/util/json.h"
+#include "common/util/status.h"
+#include "common/util/uuid.h"
+
+#include "server/memory/memory.h"
+#include "server/memory/stream_store.h"
+
+#include "oneapi/tbb/concurrent_hash_map.h"
+
+namespace vineyard {
+
+namespace asio = boost::asio;
+using session_map_t = tbb::concurrent_hash_map<SessionId, vs_ptr_t>;
+
+class VineyardServer;
+
+class VineyardRunner : public std::enable_shared_from_this<VineyardRunner> {
+ public:
+  static std::shared_ptr<VineyardRunner> Get(const json& spec);
+  Status Serve();
+  Status Finalize();
+  Status GetRootSession(vs_ptr_t& vs_ptr);
+  Status CreateNewSession(std::string& ipc_socket);
+  Status Delete(SessionId const& sid);
+  Status Get(SessionId const& sid, vs_ptr_t& session);
+  bool Exists(SessionId const& sid);
+  void Stop();
+  bool Running() const;
+
+ private:
+  explicit VineyardRunner(const json& spec);
+
+  json spec_template_;
+
+  unsigned int concurrency_;
+
+#if BOOST_VERSION >= 106600
+  asio::io_context context_, meta_context_;
+  using ctx_guard = asio::executor_work_guard<asio::io_context::executor_type>;
+#else
+  asio::io_service context_, meta_context_;
+  using ctx_guard = std::unique_ptr<boost::asio::io_service::work>;
+#endif
+
+  ctx_guard guard_, meta_guard_;
+  std::vector<std::thread> workers_;
+
+  session_map_t sessions_;
+  SessionId root_;
+  std::atomic_bool stopped_;
+};
+
+}  // namespace vineyard
+
+#endif  // SRC_SERVER_SERVER_VINEYARD_SESSION_H_

--- a/src/server/services/etcd_meta_service.h
+++ b/src/server/services/etcd_meta_service.h
@@ -137,7 +137,8 @@ class EtcdMetaService : public IMetaService {
   explicit EtcdMetaService(vs_ptr_t& server_ptr)
       : IMetaService(server_ptr),
         etcd_spec_(server_ptr_->GetSpec()["metastore_spec"]),
-        prefix_(etcd_spec_["etcd_prefix"].get_ref<std::string const&>()) {
+        prefix_(etcd_spec_["etcd_prefix"].get<std::string>() + "/" +
+                SessionIDToString(server_ptr->GetSessionId())) {
     this->handled_rev_.store(0);
   }
 

--- a/src/server/services/meta_service.h
+++ b/src/server/services/meta_service.h
@@ -512,8 +512,11 @@ class IMetaService {
         LOG(ERROR) << "heartbeat timer error: " << error << ", "
                    << error.message();
       }
-      // run check, and start the next round in the finish callback.
-      checkInstanceStatus(boost::bind(&IMetaService::startHeartbeat, this, _1));
+      if (!error || error != boost::system::errc::operation_canceled) {
+        // run check, and start the next round in the finish callback.
+        checkInstanceStatus(
+            boost::bind(&IMetaService::startHeartbeat, this, _1));
+      }
     });
     return Status::OK();
   }

--- a/test/runner.py
+++ b/test/runner.py
@@ -312,6 +312,7 @@ def run_single_vineyardd_tests():
         run_test('tuple_test')
         run_test('typename_test')
         run_test('version_test')
+        run_test('session_test')
 
         run_invalid_client_test('127.0.0.1', rpc_socket_port)
 

--- a/test/session_test.cc
+++ b/test/session_test.cc
@@ -78,14 +78,29 @@ int main(int argc, char** argv) {
 
   {  // test session deletion
     Client client1, client2;
+    Client client3;
     auto session_socket_path = client1.IPCSocket();
     VINEYARD_CHECK_OK(client1.Open(ipc_socket));
     VINEYARD_CHECK_OK(client1.Fork(client2));
     client2.CloseSession();
     client1.Disconnect();
-    auto status = client2.Connect(session_socket_path);
+    auto status = client3.Connect(session_socket_path);
     CHECK(status.IsConnectionFailed());
   }
 
+  {  // test session deletion
+    std::vector<Client> clients(1024);
+    VINEYARD_CHECK_OK(clients[0].Open(ipc_socket));
+    auto session_socket_path = clients[0].IPCSocket();
+    for (size_t i = 1; i < clients.size(); ++i) {
+      VINEYARD_CHECK_OK(clients[i].Connect(session_socket_path));
+    }
+    for (size_t i = 0; i < clients.size(); ++i) {
+      clients[i].CloseSession();
+    }
+    Client clientx;
+    auto status = clientx.Connect(session_socket_path);
+    CHECK(status.IsConnectionFailed());
+  }
   return 0;
 }

--- a/test/session_test.cc
+++ b/test/session_test.cc
@@ -25,7 +25,7 @@ limitations under the License.
 #include "client/ds/object_meta.h"
 #include "common/util/logging.h"
 
-using namespace vineyard;
+using namespace vineyard;  // NOLINT(build/namespaces)
 
 int main(int argc, char** argv) {
   if (argc < 2) {

--- a/test/session_test.cc
+++ b/test/session_test.cc
@@ -1,0 +1,91 @@
+/** Copyright 2020-2021 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "arrow/api.h"
+#include "arrow/io/api.h"
+
+#include "basic/ds/tensor.h"
+#include "client/client.h"
+#include "client/ds/object_meta.h"
+#include "common/util/logging.h"
+
+using namespace vineyard;
+
+int main(int argc, char** argv) {
+  if (argc < 2) {
+    printf("usage ./session_test <ipc_socket>");
+    return 1;
+  }
+  std::string ipc_socket = std::string(argv[1]);
+
+  {  // test basic functionality;
+    Client client;
+    VINEYARD_CHECK_OK(client.Open(ipc_socket));
+
+    std::vector<double> double_array = {1.0, 7.0, 3.0, 4.0, 2.0};
+    ArrayBuilder<double> builder(client, double_array);
+    auto sealed_double_array =
+        std::dynamic_pointer_cast<Array<double>>(builder.Seal(client));
+    ObjectID id = sealed_double_array->id();
+    ObjectID copied_id = InvalidObjectID();
+    VINEYARD_CHECK_OK(client.ShallowCopy(id, copied_id));
+    CHECK(copied_id != InvalidObjectID());
+
+    auto arrays = client.GetObjects({id, copied_id});
+    CHECK_EQ(arrays.size(), 2);
+    CHECK_EQ(arrays[0]->id(), id);
+    CHECK_EQ(arrays[1]->id(), copied_id);
+
+    client.Disconnect();
+  }
+
+  {  // test isolation;
+    Client client1, client2;
+    VINEYARD_CHECK_OK(client1.Open(ipc_socket));
+    VINEYARD_CHECK_OK(client2.Open(ipc_socket));
+
+    std::vector<double> double_array = {1.0, 7.0, 3.0, 4.0, 2.0};
+    ArrayBuilder<double> builder1(client1, double_array);
+    auto sealed_double_array =
+        std::dynamic_pointer_cast<Array<double>>(builder1.Seal(client1));
+
+    ObjectID id = sealed_double_array->id();
+
+    std::shared_ptr<Array<double>> array;
+    auto status = client2.GetObject(id, array);
+    CHECK(status.IsObjectNotExists());
+    CHECK(array == nullptr);
+
+    client1.Disconnect();
+    client2.Disconnect();
+  }
+
+  {  // test session deletion
+    Client client1, client2;
+    auto session_socket_path = client1.IPCSocket();
+    VINEYARD_CHECK_OK(client1.Open(ipc_socket));
+    VINEYARD_CHECK_OK(client1.Fork(client2));
+    client2.CloseSession();
+    client1.Disconnect();
+    auto status = client2.Connect(session_socket_path);
+    CHECK(status.IsConnectionFailed());
+  }
+
+  return 0;
+}

--- a/test/session_test.cc
+++ b/test/session_test.cc
@@ -100,7 +100,7 @@ int main(int argc, char** argv) {
     }
     Client clientx;
     auto status = clientx.Connect(session_socket_path);
-    CHECK(status.IsConnectionFailed());
+    CHECK(status.IsConnectionFailed() || status.IsIOError());
   }
   return 0;
 }


### PR DESCRIPTION

What do these changes do?
-------------------------
Provide a new API called `open()`, which will create a separated session. Client in session A can not access the objects in session B. Vineyardd will also create separated socekts.

```
## ls /var/run/
vineyard.sock.S0165a4df7aedb6be  
vineyard.sock.S0165a901b532b7f6
vineyard.sock.S0165a4df7b2a0838  
vineyard.sock.S0165a901b547b944
```

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #issue number

