### PR TITLE
[Compatibility] Add external bulk store for diverse ObjectID type.

### DIFF
--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -90,7 +90,7 @@ Status Client::Open(std::string const& ipc_socket) {
   {
     std::lock_guard<std::recursive_mutex> guard(client_mutex_);
     std::string message_out;
-    WriteNewSessionRequest(message_out);
+    WriteNewSessionRequest(message_out, "Normal");
     RETURN_ON_ERROR(doWrite(message_out));
     json message_in;
     RETURN_ON_ERROR(doRead(message_in));
@@ -501,6 +501,96 @@ Status Client::DropBuffer(const ObjectID id, const int fd) {
   json message_in;
   RETURN_ON_ERROR(doRead(message_in));
   RETURN_ON_ERROR(ReadDropBufferReply(message_in));
+  return Status::OK();
+}
+
+ExternalClient::~ExternalClient() {}
+
+Status ExternalClient::Open(std::string const& ipc_socket) {
+  RETURN_ON_ASSERT(!this->connected_,
+                   "The client has already been connected to vineyard server");
+  std::string socket_path;
+  VINEYARD_CHECK_OK(Connect(ipc_socket));
+
+  {
+    std::lock_guard<std::recursive_mutex> guard(client_mutex_);
+    std::string message_out;
+    WriteNewSessionRequest(message_out, "External");
+    RETURN_ON_ERROR(doWrite(message_out));
+    json message_in;
+    RETURN_ON_ERROR(doRead(message_in));
+    RETURN_ON_ERROR(ReadNewSessionReply(message_in, socket_path));
+  }
+
+  Disconnect();
+  VINEYARD_CHECK_OK(Connect(socket_path));
+  return Status::OK();
+}
+
+Status ExternalClient::CreateBlob(ExternalID external_id, size_t size,
+                                  size_t external_size,
+                                  std::unique_ptr<BlobWriter>& blob) {
+  ENSURE_CONNECTED(this);
+  ObjectID object_id = InvalidObjectID();
+  ExternalPayload external_payload;
+  std::shared_ptr<arrow::MutableBuffer> buffer = nullptr;
+
+  std::string message_out;
+  WriteCreateBufferByExternalRequest(external_id, size, external_size,
+                                     message_out);
+  RETURN_ON_ERROR(doWrite(message_out));
+
+  json message_in;
+  RETURN_ON_ERROR(doRead(message_in));
+  RETURN_ON_ERROR(
+      ReadCreateBufferByExternalReply(message_in, object_id, external_payload));
+
+  RETURN_ON_ASSERT(static_cast<size_t>(external_payload.data_size) == size);
+  uint8_t *shared = nullptr, *dist = nullptr;
+  if (external_payload.data_size > 0) {
+    RETURN_ON_ERROR(this->shm_->Mmap(external_payload.store_fd,
+                                     external_payload.map_size, false, true,
+                                     &shared));
+    dist = shared + external_payload.data_offset;
+  }
+  buffer =
+      std::make_shared<arrow::MutableBuffer>(dist, external_payload.data_size);
+
+  auto payload = external_payload.ToNormalPayload();
+  blob.reset(new BlobWriter(object_id, payload, buffer));
+  return Status::OK();
+}
+
+Status ExternalClient::GetBlobs(
+    const std::set<ExternalID>& external_ids,
+    std::map<ExternalID, ExternalPayload>& external_payloads,
+    std::map<ExternalID, std::shared_ptr<arrow::Buffer>>& buffers) {
+  if (external_ids.empty()) {
+    return Status::OK();
+  }
+  ENSURE_CONNECTED(this);
+
+  std::string message_out;
+  WriteGetBuffersByExternalRequest(external_ids, message_out);
+  RETURN_ON_ERROR(doWrite(message_out));
+
+  json message_in;
+  RETURN_ON_ERROR(doRead(message_in));
+  std::vector<ExternalPayload> _payloads;
+
+  RETURN_ON_ERROR(ReadGetBuffersByExternalReply(message_in, _payloads));
+  for (auto const& item : _payloads) {
+    std::shared_ptr<arrow::Buffer> buffer = nullptr;
+    uint8_t *shared = nullptr, *dist = nullptr;
+    if (item.data_size > 0) {
+      VINEYARD_CHECK_OK(
+          this->shm_->Mmap(item.store_fd, item.map_size, true, true, &shared));
+      dist = shared + item.data_offset;
+    }
+    buffer = std::make_shared<arrow::Buffer>(dist, item.data_size);
+    buffers.emplace(item.external_id, buffer);
+    external_payloads.emplace(item.external_id, item);
+  }
   return Status::OK();
 }
 

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -32,6 +32,7 @@ limitations under the License.
 #include "client/utils.h"
 #include "common/memory/fling.h"
 #include "common/util/boost.h"
+#include "common/util/logging.h"
 #include "common/util/protocols.h"
 
 namespace vineyard {

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -417,6 +417,7 @@ class Client : public ClientBase {
 };
 
 class ExternalClient : public Client {
+ public:
   ExternalClient() : Client() {}
 
   ~ExternalClient() override;

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -109,7 +109,7 @@ class Client : public ClientBase {
  public:
   Client();
 
-  virtual ~Client() override;
+  ~Client() override;
 
   /**
    * @brief Connect to vineyard using the UNIX domain socket file specified by
@@ -419,7 +419,7 @@ class Client : public ClientBase {
 class ExternalClient : public Client {
   ExternalClient() : Client() {}
 
-  virtual ~ExternalClient() override;
+  ~ExternalClient() override;
 
   /**
    * @brief Create a new anonymous session in vineyardd and connect to it .

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -109,7 +109,7 @@ class Client : public ClientBase {
  public:
   Client();
 
-  ~Client() override;
+  virtual ~Client() override;
 
   /**
    * @brief Connect to vineyard using the UNIX domain socket file specified by
@@ -408,12 +408,50 @@ class Client : public ClientBase {
    */
   Status DropBuffer(const ObjectID id, const int fd);
 
- private:
+ protected:
   std::shared_ptr<detail::SharedMemoryManager> shm_;
 
  private:
   friend class Blob;
   friend class BlobWriter;
+};
+
+class ExternalClient : public Client {
+  ExternalClient() : Client() {}
+
+  virtual ~ExternalClient() override;
+
+  /**
+   * @brief Create a new anonymous session in vineyardd and connect to it .
+   *
+   * @param ipc_socket Location of the UNIX domain socket.
+   *
+   * @return Status that indicates whether the connection of has succeeded.
+   */
+  Status Open(std::string const& ipc_socket);
+
+  /**
+   * @brief Create a blob in vineyard server. When creating a blob, vineyard
+   * server's bulk allocator will prepare a block of memory of the requested
+   * size, the map the memory to client's process to share the allocated memory.
+   *
+   * @param external_id The id of external data.
+   * @param size The size of requested blob.
+   * @param external_size The size of external data.
+   * @param blob The result mutable blob will be set in `blob`.
+   *
+   * @return Status that indicates whether the create action has succeeded.
+   */
+  Status CreateBlob(ExternalID external_id, size_t size, size_t external_size,
+                    std::unique_ptr<BlobWriter>& blob);
+
+  /**
+   * Used only for integration.
+   */
+  Status GetBlobs(
+      const std::set<ExternalID>& external_ids,
+      std::map<ExternalID, ExternalPayload>& external_payloads,
+      std::map<ExternalID, std::shared_ptr<arrow::Buffer>>& buffers);
 };
 
 }  // namespace vineyard

--- a/src/client/ds/blob.h
+++ b/src/client/ds/blob.h
@@ -36,6 +36,7 @@ namespace vineyard {
 class BlobWriter;
 class BufferSet;
 class Client;
+class ExternalClient;
 class ObjectMeta;
 
 /**
@@ -134,6 +135,7 @@ class Blob : public Registered<Blob> {
   std::shared_ptr<arrow::Buffer> buffer_ = nullptr;
 
   friend class Client;
+  friend class ExternalClient;
   friend class RPCClient;
   friend class BlobWriter;
   friend class BufferSet;
@@ -239,6 +241,7 @@ class BlobWriter : public ObjectBuilder {
   std::unordered_map<std::string, std::string> metadata_;
 
   friend class Client;
+  friend class ExternalClient;
   friend class RPCClient;
 };
 

--- a/src/client/ds/i_object.h
+++ b/src/client/ds/i_object.h
@@ -176,6 +176,7 @@ class Object : public ObjectBase, public std::enable_shared_from_this<Object> {
 
   friend class ClientBase;
   friend class Client;
+  friend class ExternalClient;
   friend class RPCClient;
   friend class ObjectMeta;
 };

--- a/src/client/ds/object_meta.h
+++ b/src/client/ds/object_meta.h
@@ -552,6 +552,7 @@ class ObjectMeta {
 
   friend class ClientBase;
   friend class Client;
+  friend class ExternalClient;
   friend class RPCClient;
 
   friend class Blob;

--- a/src/common/memory/payload.cc
+++ b/src/common/memory/payload.cc
@@ -53,7 +53,8 @@ json ExternalPayload::ToJSON() const {
 }
 
 void ExternalPayload::ToJSON(json& tree) const {
-  tree["external_id"] = object_id;
+  tree["external_id"] = external_id;
+  tree["object_id"] = object_id;
   tree["external_size"] = external_size;
   tree["store_fd"] = store_fd;
   tree["data_offset"] = data_offset;
@@ -62,7 +63,8 @@ void ExternalPayload::ToJSON(json& tree) const {
 }
 
 void ExternalPayload::FromJSON(const json& tree) {
-  external_id = tree["external_id"].get<ObjectID>();
+  external_id = tree["external_id"].get<ExternalID>();
+  object_id = tree["object_id"].get<ObjectID>();
   external_size = tree["external_size"].get<int64_t>();
   store_fd = tree["store_fd"].get<int>();
   data_offset = tree["data_offset"].get<ptrdiff_t>();

--- a/src/common/memory/payload.cc
+++ b/src/common/memory/payload.cc
@@ -46,4 +46,35 @@ Payload Payload::FromJSON1(const json& tree) {
   return payload;
 }
 
+json ExternalPayload::ToJSON() const {
+  json payload;
+  this->ToJSON(payload);
+  return payload;
+}
+
+void ExternalPayload::ToJSON(json& tree) const {
+  tree["external_id"] = object_id;
+  tree["external_size"] = external_size;
+  tree["store_fd"] = store_fd;
+  tree["data_offset"] = data_offset;
+  tree["data_size"] = data_size;
+  tree["map_size"] = map_size;
+}
+
+void ExternalPayload::FromJSON(const json& tree) {
+  external_id = tree["external_id"].get<ObjectID>();
+  external_size = tree["external_size"].get<int64_t>();
+  store_fd = tree["store_fd"].get<int>();
+  data_offset = tree["data_offset"].get<ptrdiff_t>();
+  data_size = tree["data_size"].get<int64_t>();
+  map_size = tree["map_size"].get<int64_t>();
+  pointer = nullptr;
+}
+
+ExternalPayload ExternalPayload::FromJSON1(const json& tree) {
+  ExternalPayload external_payload;
+  external_payload.FromJSON(tree);
+  return external_payload;
+}
+
 }  // namespace vineyard

--- a/src/common/util/base64.cc
+++ b/src/common/util/base64.cc
@@ -39,7 +39,6 @@ std::string base64_encode(const std::string& buffer) {
   size_t bufLen = buffer.size();
   std::string ret;
   int i = 0;
-  int j = 0;
   unsigned char char_array_3[3];
   unsigned char char_array_4[4];
 
@@ -60,7 +59,7 @@ std::string base64_encode(const std::string& buffer) {
   }
 
   if (i) {
-    for (j = i; j < 3; j++)
+    for (int j = i; j < 3; j++)
       char_array_3[j] = '\0';
 
     char_array_4[0] = (char_array_3[0] & 0xfc) >> 2;
@@ -70,7 +69,7 @@ std::string base64_encode(const std::string& buffer) {
         ((char_array_3[1] & 0x0f) << 2) + ((char_array_3[2] & 0xc0) >> 6);
     char_array_4[3] = char_array_3[2] & 0x3f;
 
-    for (j = 0; (j < i + 1); j++)
+    for (int j = 0; (j < i + 1); j++)
       ret += base64_chars[char_array_4[j]];
 
     while ((i++ < 3))

--- a/src/common/util/base64.cc
+++ b/src/common/util/base64.cc
@@ -1,0 +1,131 @@
+/** Copyright 2020-2021 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <iostream>
+
+#include "common/util/base64.h"
+
+/* std::vector<unsigned char> myData;
+ * ...
+ * std::string encodedData = base64_encode(&myData[0], myData.size());
+ * std::vector<unsigned char> decodedData = base64_decode(encodedData);
+ */
+namespace vineyard {
+
+static const char _base64_chars[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "abcdefghijklmnopqrstuvwxyz"
+    "0123456789+/";
+
+static inline bool is_base64(unsigned char c) {
+  return (isalnum(c) || (c == '+') || (c == '/'));
+}
+
+std::string base64_encode(const std::string& buffer) {
+  const unsigned char* buf = reinterpret_cast<const unsigned char*>(&buffer[0]);
+  std::string base64_chars(_base64_chars);
+  size_t bufLen = buffer.size();
+  std::string ret;
+  int i = 0;
+  int j = 0;
+  unsigned char char_array_3[3];
+  unsigned char char_array_4[4];
+
+  while (bufLen--) {
+    char_array_3[i++] = *(buf++);
+    if (i == 3) {
+      char_array_4[0] = (char_array_3[0] & 0xfc) >> 2;
+      char_array_4[1] =
+          ((char_array_3[0] & 0x03) << 4) + ((char_array_3[1] & 0xf0) >> 4);
+      char_array_4[2] =
+          ((char_array_3[1] & 0x0f) << 2) + ((char_array_3[2] & 0xc0) >> 6);
+      char_array_4[3] = char_array_3[2] & 0x3f;
+
+      for (i = 0; (i < 4); i++)
+        ret += base64_chars[char_array_4[i]];
+      i = 0;
+    }
+  }
+
+  if (i) {
+    for (j = i; j < 3; j++)
+      char_array_3[j] = '\0';
+
+    char_array_4[0] = (char_array_3[0] & 0xfc) >> 2;
+    char_array_4[1] =
+        ((char_array_3[0] & 0x03) << 4) + ((char_array_3[1] & 0xf0) >> 4);
+    char_array_4[2] =
+        ((char_array_3[1] & 0x0f) << 2) + ((char_array_3[2] & 0xc0) >> 6);
+    char_array_4[3] = char_array_3[2] & 0x3f;
+
+    for (j = 0; (j < i + 1); j++)
+      ret += base64_chars[char_array_4[j]];
+
+    while ((i++ < 3))
+      ret += '=';
+  }
+
+  return ret;
+}
+
+std::string base64_decode(const std::string& encoded_string) {
+  auto in_len = encoded_string.size();
+  std::string base64_chars(_base64_chars);
+  int i = 0;
+  int j = 0;
+  int in_ = 0;
+  unsigned char char_array_4[4], char_array_3[3];
+  std::vector<unsigned char> ret;
+
+  while (in_len-- && (encoded_string[in_] != '=') &&
+         is_base64(encoded_string[in_])) {
+    char_array_4[i++] = encoded_string[in_];
+    in_++;
+    if (i == 4) {
+      for (i = 0; i < 4; i++)
+        char_array_4[i] = base64_chars.find(char_array_4[i]);
+
+      char_array_3[0] =
+          (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
+      char_array_3[1] =
+          ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
+      char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
+
+      for (i = 0; (i < 3); i++)
+        ret.push_back(char_array_3[i]);
+      i = 0;
+    }
+  }
+
+  if (i) {
+    for (j = i; j < 4; j++)
+      char_array_4[j] = 0;
+
+    for (j = 0; j < 4; j++)
+      char_array_4[j] = base64_chars.find(char_array_4[j]);
+
+    char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
+    char_array_3[1] =
+        ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
+    char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
+
+    for (j = 0; (j < i - 1); j++)
+      ret.push_back(char_array_3[j]);
+  }
+
+  return std::string(ret.begin(), ret.end());
+}
+
+}  // namespace vineyard

--- a/src/common/util/base64.cc
+++ b/src/common/util/base64.cc
@@ -84,7 +84,6 @@ std::string base64_decode(const std::string& encoded_string) {
   auto in_len = encoded_string.size();
   std::string base64_chars(_base64_chars);
   int i = 0;
-  int j = 0;
   int in_ = 0;
   unsigned char char_array_4[4], char_array_3[3];
   std::vector<unsigned char> ret;
@@ -110,10 +109,10 @@ std::string base64_decode(const std::string& encoded_string) {
   }
 
   if (i) {
-    for (j = i; j < 4; j++)
+    for (int j = i; j < 4; j++)
       char_array_4[j] = 0;
 
-    for (j = 0; j < 4; j++)
+    for (int j = 0; j < 4; j++)
       char_array_4[j] = base64_chars.find(char_array_4[j]);
 
     char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
@@ -121,7 +120,7 @@ std::string base64_decode(const std::string& encoded_string) {
         ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
     char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
 
-    for (j = 0; (j < i - 1); j++)
+    for (int j = 0; (j < i - 1); j++)
       ret.push_back(char_array_3[j]);
   }
 

--- a/src/common/util/base64.h
+++ b/src/common/util/base64.h
@@ -1,0 +1,27 @@
+/** Copyright 2020-2021 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef SRC_COMMON_UTIL_BASE64_H_
+#define SRC_COMMON_UTIL_BASE64_H_
+
+#include <string>
+#include <vector>
+
+namespace vineyard {
+
+std::string base64_encode(const std::string& buffer);
+std::string base64_decode(const std::string& buffer);
+}  // namespace vineyard
+#endif  // SRC_COMMON_UTIL_BASE64_H_

--- a/src/common/util/protocols.cc
+++ b/src/common/util/protocols.cc
@@ -116,6 +116,10 @@ CommandType ParseCommandType(const std::string& str_type) {
     return CommandType::DeleteSessionRequest;
   } else if (str_type == "delete_session_reply") {
     return CommandType::DeleteSessionReply;
+  } else if (str_type == "create_buffer_by_external_request") {
+    return CommandType::CreateBufferByExternalRequest;
+  } else if (str_type == "get_buffers_by_external_request") {
+    return CommandType::GetBuffersByExternalRequest;
   } else {
     return CommandType::NullCommand;
   }
@@ -1159,13 +1163,14 @@ void WriteDeleteSessionReply(std::string& msg) {
 }
 
 void WriteCreateBufferByExternalRequest(ExternalID const external_id,
+                                        size_t const size,
                                         size_t const external_size,
-                                        size_t const size, std::string& msg) {
+                                        std::string& msg) {
   json root;
-  root["type"] = "create_buffer_request_by_external_request";
-  root["size"] = size;
-  root["external_size"] = external_size;
+  root["type"] = "create_buffer_by_external_request";
   root["external_id"] = external_id;
+  root["external_size"] = external_size;
+  root["size"] = size;
 
   encode_msg(root, msg);
 }
@@ -1173,9 +1178,9 @@ void WriteCreateBufferByExternalRequest(ExternalID const external_id,
 Status ReadCreateBufferByExternalRequest(json const& root,
                                          ExternalID& external_id, size_t& size,
                                          size_t& external_size) {
-  RETURN_ON_ASSERT(root["type"] == "create_buffer_request_by_external_request");
-  size = root["size"].get<size_t>();
+  RETURN_ON_ASSERT(root["type"] == "create_buffer_by_external_request");
   external_id = root["external_id"].get<ExternalID>();
+  size = root["size"].get<size_t>();
   external_size = root["external_size"].get<size_t>();
 
   return Status::OK();

--- a/src/common/util/protocols.cc
+++ b/src/common/util/protocols.cc
@@ -1119,10 +1119,18 @@ Status ReadDebugReply(const json& root, json& result) {
   return Status::OK();
 }
 
-void WriteNewSessionRequest(std::string& msg) {
+void WriteNewSessionRequest(std::string& msg,
+                            std::string const& bulk_store_name) {
   json root;
   root["type"] = "new_session_request";
+  root["bulk_store_name"] = bulk_store_name;
   encode_msg(root, msg);
+}
+
+Status ReadNewSessionRequest(json const& root, std::string& bulk_store_name) {
+  RETURN_ON_ASSERT(root["type"] == "new_session_request");
+  bulk_store_name = root["bulk_store_name"].get_ref<std::string const&>();
+  return Status::OK();
 }
 
 void WriteNewSessionReply(std::string& msg, std::string const& socket_path) {
@@ -1148,6 +1156,101 @@ void WriteDeleteSessionReply(std::string& msg) {
   json root;
   root["type"] = "delete_session_reply";
   encode_msg(root, msg);
+}
+
+void WriteCreateBufferByExternalRequest(ExternalID const external_id,
+                                        size_t const external_size,
+                                        size_t const size, std::string& msg) {
+  json root;
+  root["type"] = "create_buffer_request_by_external_request";
+  root["size"] = size;
+  root["external_size"] = external_size;
+  root["external_id"] = external_id;
+
+  encode_msg(root, msg);
+}
+
+Status ReadCreateBufferByExternalRequest(json const& root,
+                                         ExternalID& external_id, size_t& size,
+                                         size_t& external_size) {
+  RETURN_ON_ASSERT(root["type"] == "create_buffer_request_by_external_request");
+  size = root["size"].get<size_t>();
+  external_id = root["external_id"].get<ExternalID>();
+  external_size = root["external_size"].get<size_t>();
+
+  return Status::OK();
+}
+
+void WriteCreateBufferByExternalReply(
+    ObjectID const object_id,
+    const std::shared_ptr<ExternalPayload>& external_object, std::string& msg) {
+  json root;
+  root["type"] = "create_buffer_by_external_reply";
+  root["id"] = object_id;
+  json tree;
+  external_object->ToJSON(tree);
+  root["created"] = tree;
+
+  encode_msg(root, msg);
+}
+
+Status ReadCreateBufferByExternalReply(json const& root, ObjectID& object_id,
+                                       ExternalPayload& external_object) {
+  CHECK_IPC_ERROR(root, "create_buffer_by_external_reply");
+  json tree = root["created"];
+  object_id = root["id"].get<ObjectID>();
+  external_object.FromJSON(tree);
+  return Status::OK();
+}
+
+void WriteGetBuffersByExternalRequest(std::set<ExternalID> const& external_ids,
+                                      std::string& msg) {
+  json root;
+  root["type"] = "get_buffers_by_external_request";
+  int idx = 0;
+  for (auto const& eid : external_ids) {
+    root[std::to_string(idx++)] = eid;
+  }
+  root["num"] = external_ids.size();
+
+  encode_msg(root, msg);
+}
+
+Status ReadGetBuffersByExternalRequest(const json& root,
+                                       std::vector<ExternalID>& external_ids) {
+  RETURN_ON_ASSERT(root["type"] == "get_buffers_by_external_request");
+  size_t num = root["num"].get<size_t>();
+  for (size_t i = 0; i < num; ++i) {
+    external_ids.push_back(root[std::to_string(i)].get<ExternalID>());
+  }
+  return Status::OK();
+}
+
+void WriteGetBuffersByExternalReply(
+    std::vector<std::shared_ptr<ExternalPayload>> const external_objects,
+    std::string& msg) {
+  json root;
+  root["type"] = "get_buffers_by_external_reply";
+  for (size_t i = 0; i < external_objects.size(); ++i) {
+    json tree;
+    external_objects[i]->ToJSON(tree);
+    root[std::to_string(i)] = tree;
+  }
+  root["num"] = external_objects.size();
+
+  encode_msg(root, msg);
+}
+
+Status ReadGetBuffersByExternalReply(
+    json const& root, std::vector<ExternalPayload>& external_objects) {
+  CHECK_IPC_ERROR(root, "get_buffers_by_external_reply");
+  for (size_t i = 0; i < root["num"]; ++i) {
+    json tree = root[std::to_string(i)];
+    ExternalPayload external_object;
+    external_object.FromJSON(tree);
+    external_objects.emplace_back(external_object);
+  }
+  return Status::OK();
 }
 
 }  // namespace vineyard

--- a/src/common/util/protocols.cc
+++ b/src/common/util/protocols.cc
@@ -1227,7 +1227,7 @@ Status ReadGetBuffersByExternalRequest(const json& root,
 }
 
 void WriteGetBuffersByExternalReply(
-    std::vector<std::shared_ptr<ExternalPayload>> const external_objects,
+    std::vector<std::shared_ptr<ExternalPayload>> const& external_objects,
     std::string& msg) {
   json root;
   root["type"] = "get_buffers_by_external_reply";

--- a/src/common/util/protocols.h
+++ b/src/common/util/protocols.h
@@ -73,6 +73,10 @@ enum class CommandType {
   NewSessionReply = 39,
   DeleteSessionRequest = 40,
   DeleteSessionReply = 41,
+  CreateBufferByExternalRequest = 42,
+  CreateBufferByExternalReply = 43,
+  GetBuffersByExternalRequest = 44,
+  GetBuffersByExternalReply = 45,
 };
 
 CommandType ParseCommandType(const std::string& str_type);
@@ -376,7 +380,10 @@ void WriteDebugReply(const json& result, std::string& msg);
 
 Status ReadDebugReply(const json& root, json& result);
 
-void WriteNewSessionRequest(std::string& msg);
+void WriteNewSessionRequest(std::string& msg,
+                            std::string const& bulk_store_name);
+
+Status ReadNewSessionRequest(json const& root, std::string& bulk_store_name);
 
 void WriteNewSessionReply(std::string& msg, std::string const& socket_path);
 
@@ -385,6 +392,35 @@ Status ReadNewSessionReply(json const& root, std::string& socket_path);
 void WriteDeleteSessionRequest(std::string& msg);
 
 void WriteDeleteSessionReply(std::string& msg);
+
+void WriteCreateBufferByExternalRequest(ExternalID const external_id,
+                                        size_t const size,
+                                        size_t const external_size,
+                                        std::string& msg);
+
+Status ReadCreateBufferByExternalRequest(json const& root,
+                                         ExternalID& external_id, size_t& size,
+                                         size_t& external_size);
+
+void WriteCreateBufferByExternalReply(
+    ObjectID const object_id,
+    const std::shared_ptr<ExternalPayload>& external_object, std::string& msg);
+
+Status ReadCreateBufferByExternalReply(json const& root, ObjectID& object_id,
+                                       ExternalPayload& external_object);
+
+void WriteGetBuffersByExternalRequest(std::set<ExternalID> const& external_ids,
+                                      std::string& msg);
+
+Status ReadGetBuffersByExternalRequest(json const& root,
+                                       std::vector<ExternalID>& external_ids);
+
+void WriteGetBuffersByExternalReply(
+    std::vector<std::shared_ptr<ExternalPayload>> const external_objects,
+    std::string& msg);
+
+Status ReadGetBuffersByExternalReply(
+    json const& root, std::vector<ExternalPayload>& external_objects);
 
 }  // namespace vineyard
 

--- a/src/common/util/protocols.h
+++ b/src/common/util/protocols.h
@@ -416,7 +416,7 @@ Status ReadGetBuffersByExternalRequest(json const& root,
                                        std::vector<ExternalID>& external_ids);
 
 void WriteGetBuffersByExternalReply(
-    std::vector<std::shared_ptr<ExternalPayload>> const external_objects,
+    std::vector<std::shared_ptr<ExternalPayload>> const& external_objects,
     std::string& msg);
 
 Status ReadGetBuffersByExternalReply(

--- a/src/common/util/uuid.cc
+++ b/src/common/util/uuid.cc
@@ -37,7 +37,7 @@ const std::string SignatureToString(const Signature id) {
   return std::string(buffer);
 }
 
-const std::string SessionIDToString(const SessionId id) {
+const std::string SessionIDToString(const SessionID id) {
   thread_local char buffer[18] = {'\0'};
   std::snprintf(buffer, sizeof(buffer), "S%016" PRIx64, id);
   return std::string(buffer);

--- a/src/common/util/uuid.h
+++ b/src/common/util/uuid.h
@@ -25,6 +25,8 @@ limitations under the License.
 #include <limits>
 #include <string>
 
+#include "common/util/base64.h"
+
 namespace vineyard {
 
 /**
@@ -123,7 +125,7 @@ inline bool IsBlob(ObjectID id) { return id & 0x8000000000000000UL; }
 const std::string ObjectIDToString(const ObjectID id);
 
 inline std::string const ExternalIDToString(ExternalID const external_id) {
-  return std::string(external_id);
+  return base64_decode(std::string(external_id));
 }
 
 inline ObjectID ObjectIDFromString(const std::string& s) {
@@ -136,10 +138,12 @@ inline ObjectID ObjectIDFromString(const char* s) {
 
 // TODO base64 encoding
 inline ExternalID ExternalIDFromString(std::string const& s) {
-  return ExternalID(s);
+  return ExternalID(base64_encode(s));
 }
 
-inline ExternalID ExternalIDFromString(const char* s) { return ExternalID(s); }
+inline ExternalID ExternalIDFromString(const char* s) {
+  return ExternalID(base64_encode(s));
+}
 
 constexpr inline SessionID RootSessionID() { return 0x0000000000000000UL; }
 

--- a/src/common/util/uuid.h
+++ b/src/common/util/uuid.h
@@ -48,28 +48,50 @@ using Signature = uint64_t;
 using InstanceID = uint64_t;
 
 /**
- * @brief SessionId is an opaque type for vineyard's Session. The
- * underlying type of SessionId is a 64-bit unsigned integer.
+ * @brief SessionID is an opaque type for vineyard's Session. The
+ * underlying type of SessionID is a 64-bit unsigned integer.
  */
-using SessionId = int64_t;
+using SessionID = int64_t;
+
+/**
+ * @brief ExternalID is an opaque type for vineyard's ExternalPayload. The
+ * underlying type of ExternalID is base64 string for compatibility.
+ */
+using ExternalID = std::string;
+
+template <typename T, typename F>
+auto static_if(std::true_type, T t, F f) {
+  return t;
+}
+
+template <typename T, typename F>
+auto static_if(std::false_type, T t, F f) {
+  return f;
+}
+
+template <bool B, typename T, typename F>
+auto static_if(T t, F f) {
+  return static_if(std::integral_constant<bool, B>{}, t, f);
+}
+
+template <bool B, typename T>
+auto static_if(T t) {
+  return static_if(std::integral_constant<bool, B>{}, t, [](auto&&...) {});
+}
+
 // blob id: 1 + memory address (in vineyardd)
 // non-blob id: 0 + random (rdstc)
-
 inline void* GetBlobAddr(ObjectID const id) {
   return (id & 0x8000000000000000UL)
              ? reinterpret_cast<void*>(id & 0x7FFFFFFFFFFFFFFFUL)
              : nullptr;
 }
 
-inline ObjectID GenerateBlobID(const void* ptr) {
-  return 0x8000000000000000UL | reinterpret_cast<uint64_t>(ptr);
-}
-
 inline ObjectID GenerateBlobID(const uintptr_t ptr) {
   return 0x8000000000000000UL | static_cast<uint64_t>(ptr);
 }
 
-inline SessionId GenerateSessionId() {
+inline SessionID GenerateSessionID() {
 #if defined(__x86_64__)
   return 0x7FFFFFFFFFFFFFFFUL & static_cast<uint64_t>(__rdtsc());
 #else
@@ -77,8 +99,6 @@ inline SessionId GenerateSessionId() {
          static_cast<uint64_t>(rand());  // NOLINT(runtime/threadsafe_fn)
 #endif
 }
-
-constexpr inline ObjectID EmptyBlobID() { return 0x8000000000000000UL; }
 
 inline ObjectID GenerateObjectID() {
 #if defined(__x86_64__)
@@ -102,6 +122,10 @@ inline bool IsBlob(ObjectID id) { return id & 0x8000000000000000UL; }
 
 const std::string ObjectIDToString(const ObjectID id);
 
+inline std::string const ExternalIDToString(ExternalID const external_id) {
+  return std::string(external_id);
+}
+
 inline ObjectID ObjectIDFromString(const std::string& s) {
   return strtoull(s.c_str() + 1, nullptr, 16);
 }
@@ -110,15 +134,22 @@ inline ObjectID ObjectIDFromString(const char* s) {
   return strtoull(s + 1, nullptr, 16);
 }
 
-constexpr inline SessionId RootSessionID() { return 0x0000000000000000UL; }
+// TODO base64 encoding
+inline ExternalID ExternalIDFromString(std::string const& s) {
+  return ExternalID(s);
+}
 
-const std::string SessionIDToString(const SessionId id);
+inline ExternalID ExternalIDFromString(const char* s) { return ExternalID(s); }
 
-inline SessionId SessionIDFromString(const std::string& s) {
+constexpr inline SessionID RootSessionID() { return 0x0000000000000000UL; }
+
+const std::string SessionIDToString(const SessionID id);
+
+inline SessionID SessionIDFromString(const std::string& s) {
   return strtoull(s.c_str() + 1, nullptr, 16);
 }
 
-inline SessionId SessionIDFromString(const char* s) {
+inline SessionID SessionIDFromString(const char* s) {
   return strtoull(s + 1, nullptr, 16);
 }
 
@@ -161,6 +192,38 @@ inline ObjectID InvalidSignature() {
 
 inline InstanceID UnspecifiedInstanceID() {
   return std::numeric_limits<InstanceID>::max();
+}
+
+template <typename ID = ObjectID>
+inline ID GenerateBlobID(uintptr_t ptr) {
+  uint64_t ans = 0x8000000000000000UL | reinterpret_cast<uint64_t>(ptr);
+  return static_if<std::is_same<ID, ObjectID>{}>(
+      [&]() { return ObjectID(ans); },
+      [&]() {
+        return ExternalIDFromString(ObjectIDToString(ObjectID(ans)));
+      })();
+}
+
+template <typename ID = ObjectID>
+inline ID GenerateBlobID(const void* ptr) {
+  uint64_t ans = 0x8000000000000000UL | reinterpret_cast<uint64_t>(ptr);
+  return static_if<std::is_same<ID, ObjectID>{}>(
+      [&]() { return ObjectID(ans); },
+      [&]() {
+        return ExternalIDFromString(ObjectIDToString(ObjectID(ans)));
+      })();
+}
+
+template <typename ID = ObjectID>
+ID EmptyBlobID() {
+  return GenerateBlobID<ID>(0x8000000000000000UL);
+}
+
+template <typename ID>
+std::string IDToString(ID id) {
+  return static_if<std::is_same<ID, ObjectID>{}>(
+      [](ObjectID& id) { return ObjectIDToString(id); },
+      [](ExternalID& id) { return ExternalIDToString(id); })(id);
 }
 
 }  // namespace vineyard

--- a/src/server/async/socket_server.h
+++ b/src/server/async/socket_server.h
@@ -56,79 +56,83 @@ class SocketConnection : public std::enable_shared_from_this<SocketConnection> {
   bool Stop();
 
  protected:
-  bool doRegister(const json& root);
+  bool doRegister(json const& root);
 
-  bool doGetBuffers(const json& root);
+  bool doGetBuffers(json const& root);
 
   /**
    * @brief doGetRemoteBuffers differs from doGetRemoteBuffers, that the
    * content of blob is in the response body, rather than via memory sharing.
    */
-  bool doGetRemoteBuffers(const json& root);
+  bool doGetRemoteBuffers(json const& root);
 
-  bool doCreateBuffer(const json& root);
+  bool doCreateBuffer(json const& root);
 
   /**
    * @brief doCreateBuffer differs from doCreateRemoteBuffer, that the content
    * of blob is in the request body, rather than via memory sharing.
    */
-  bool doCreateRemoteBuffer(const json& root);
+  bool doCreateRemoteBuffer(json const& root);
 
-  bool doDropBuffer(const json& root);
+  bool doDropBuffer(json const& root);
 
-  bool doGetData(const json& root);
+  bool doGetData(json const& root);
 
-  bool doListData(const json& root);
+  bool doListData(json const& root);
 
-  bool doCreateData(const json& root);
+  bool doCreateData(json const& root);
 
-  bool doPersist(const json& root);
+  bool doPersist(json const& root);
 
-  bool doIfPersist(const json& root);
+  bool doIfPersist(json const& root);
 
-  bool doExists(const json& root);
+  bool doExists(json const& root);
 
-  bool doShallowCopy(const json& root);
+  bool doShallowCopy(json const& root);
 
-  bool doDeepCopy(const json& root);
+  bool doDeepCopy(json const& root);
 
-  bool doDelData(const json& root);
+  bool doDelData(json const& root);
 
-  bool doCreateStream(const json& root);
+  bool doCreateStream(json const& root);
 
-  bool doOpenStream(const json& root);
+  bool doOpenStream(json const& root);
 
-  bool doGetNextStreamChunk(const json& root);
+  bool doGetNextStreamChunk(json const& root);
 
-  bool doPushNextStreamChunk(const json& root);
+  bool doPushNextStreamChunk(json const& root);
 
-  bool doPullNextStreamChunk(const json& root);
+  bool doPullNextStreamChunk(json const& root);
 
-  bool doStopStream(const json& root);
+  bool doStopStream(json const& root);
 
-  bool doPutName(const json& root);
+  bool doPutName(json const& root);
 
-  bool doGetName(const json& root);
+  bool doGetName(json const& root);
 
-  bool doDropName(const json& root);
+  bool doDropName(json const& root);
 
-  bool doMigrateObject(const json& root);
+  bool doMigrateObject(json const& root);
 
-  bool doClusterMeta(const json& root);
+  bool doClusterMeta(json const& root);
 
-  bool doInstanceStatus(const json& root);
+  bool doInstanceStatus(json const& root);
 
-  bool doMakeArena(const json& root);
+  bool doMakeArena(json const& root);
 
-  bool doFinalizeArena(const json& root);
+  bool doFinalizeArena(json const& root);
 
-  bool doClear(const json& root);
+  bool doClear(json const& root);
 
-  bool doDebug(const json& root);
+  bool doDebug(json const& root);
 
-  bool doNewSession(const json& root);
+  bool doNewSession(json const& root);
 
-  bool doDeleteSession(const json& root);
+  bool doDeleteSession(json const& root);
+
+  bool doCreateBufferByExternal(json const& root);
+
+  bool doGetBuffersByExternal(json const& root);
 
  private:
   int nativeHandle() { return socket_.native_handle(); }

--- a/src/server/memory/memory.cc
+++ b/src/server/memory/memory.cc
@@ -125,10 +125,12 @@ static void recycle_arena(const uintptr_t base, const size_t size,
 }
 }  // namespace memory
 
-std::set<ObjectID> BulkStore::Arena::spans{};
+template<typename ID>
+std::set<ID> BulkStore<ID>::Arena::spans{};
 
-BulkStore::~BulkStore() {
-  std::vector<ObjectID> object_ids;
+template<typename ID>
+BulkStore<ID>::~BulkStore() {
+  std::vector<ID> object_ids;
   object_ids.reserve(objects_.size());
   for (auto iter = objects_.begin(); iter != objects_.end(); iter++) {
     object_ids.emplace_back(iter->first);
@@ -138,7 +140,8 @@ BulkStore::~BulkStore() {
   }
 }
 
-Status BulkStore::PreAllocate(const size_t size) {
+template<typename ID>
+Status BulkStore<ID>::PreAllocate(const size_t size) {
   BulkAllocator::SetFootprintLimit(size);
   void* pointer = BulkAllocator::Init(size);
 
@@ -148,7 +151,7 @@ Status BulkStore::PreAllocate(const size_t size) {
   }
 
   // insert a special marker for obtaining the whole shared memory range
-  ObjectID object_id = GenerateBlobID(
+  ID object_id = GenerateBlobID(
       reinterpret_cast<void*>(std::numeric_limits<uintptr_t>::max()));
   int fd = -1;
   int64_t map_size = 0;
@@ -162,7 +165,8 @@ Status BulkStore::PreAllocate(const size_t size) {
 }
 
 // Allocate memory
-uint8_t* BulkStore::AllocateMemory(size_t size, int* fd, int64_t* map_size,
+template<typename ID>
+uint8_t* BulkStore<ID>::AllocateMemory(size_t size, int* fd, int64_t* map_size,
                                    ptrdiff_t* offset) {
   // Try to evict objects until there is enough space.
   uint8_t* pointer = nullptr;
@@ -174,7 +178,8 @@ uint8_t* BulkStore::AllocateMemory(size_t size, int* fd, int64_t* map_size,
   return pointer;
 }
 
-Status BulkStore::Create(const size_t data_size, ObjectID& object_id,
+template<typename ID>
+Status BulkStore<ID>::Create(const size_t data_size, ID& object_id,
                          std::shared_ptr<Payload>& object) {
   if (data_size == 0) {
     object_id = EmptyBlobID();
@@ -193,33 +198,35 @@ Status BulkStore::Create(const size_t data_size, ObjectID& object_id,
   object = std::make_shared<Payload>(object_id, data_size, pointer, fd,
                                      map_size, offset);
   objects_.emplace(object_id, object);
-  DVLOG(10) << "after allocate: " << ObjectIDToString(object_id) << ": "
+  DVLOG(10) << "after allocate: " << IDToString(object_id) << ": "
             << Footprint() << "(" << FootprintLimit() << ")";
   return Status::OK();
 }
 
-Status BulkStore::Get(const ObjectID id, std::shared_ptr<Payload>& object) {
+template<typename ID>
+Status BulkStore<ID>::Get(const ID id, std::shared_ptr<Payload>& object) {
   if (id == EmptyBlobID()) {
     object = Payload::MakeEmpty();
     return Status::OK();
   } else {
-    object_map_t::const_accessor accessor;
+    typename object_map_t::const_accessor accessor;
     if (objects_.find(accessor, id)) {
       object = accessor->second;
       return Status::OK();
     } else {
-      return Status::ObjectNotExists("get: id = " + ObjectIDToString(id));
+      return Status::ObjectNotExists("get: id = " + IDToString(id));
     }
   }
 }
 
-Status BulkStore::Get(const std::vector<ObjectID>& ids,
+template<typename ID>
+Status BulkStore<ID>::Get(const std::vector<ID>& ids,
                       std::vector<std::shared_ptr<Payload>>& objects) {
   for (auto object_id : ids) {
     if (object_id == EmptyBlobID()) {
       objects.push_back(Payload::MakeEmpty());
     } else {
-      object_map_t::const_accessor accessor;
+      typename object_map_t::const_accessor accessor;
       if (objects_.find(accessor, object_id)) {
         objects.push_back(accessor->second);
       }
@@ -228,23 +235,24 @@ Status BulkStore::Get(const std::vector<ObjectID>& ids,
   return Status::OK();
 }
 
-Status BulkStore::Delete(const ObjectID& object_id) {
-  // see also: BulkStore::PreAllocate().
+template<typename ID>
+Status BulkStore<ID>::Delete(const ID& object_id) {
+  // see also: BulkStore<ID>::PreAllocate().
   if (object_id == EmptyBlobID() ||
       object_id == GenerateBlobID(reinterpret_cast<void*>(
                        std::numeric_limits<uintptr_t>::max()))) {
     return Status::OK();
   }
-  object_map_t::const_accessor accessor;
+  typename object_map_t::const_accessor accessor;
   if (!objects_.find(accessor, object_id)) {
     return Status::ObjectNotExists("delete: id = " +
-                                   ObjectIDToString(object_id));
+                                   IDToString(object_id));
   }
   auto& object = accessor->second;
   if (object->arena_fd == -1) {
     auto buff_size = object->data_size;
     BulkAllocator::Free(object->pointer, buff_size);
-    DVLOG(10) << "after free: " << ObjectIDToString(object_id) << ": "
+    DVLOG(10) << "after free: " << IDToString(object_id) << ": "
               << Footprint() << "(" << FootprintLimit() << ")";
   } else {
     static size_t page_size = memory::system_page_size();
@@ -256,7 +264,7 @@ Status BulkStore::Delete(const ObjectID& object_id) {
       auto iter = Arena::spans.find(object_id);
       if (iter != Arena::spans.begin()) {
         auto iter_prev = std::prev(iter);
-        object_map_t::const_accessor accessor;
+        typename object_map_t::const_accessor accessor;
         if (!objects_.find(accessor, *iter_prev)) {
           return Status::Invalid(
               "Internal state error: previous blob not found");
@@ -269,7 +277,7 @@ Status BulkStore::Delete(const ObjectID& object_id) {
       }
       auto iter_next = std::next(iter);
       if (iter_next != Arena::spans.end()) {
-        object_map_t::const_accessor accessor;
+        typename object_map_t::const_accessor accessor;
         if (!objects_.find(accessor, *iter_next)) {
           return Status::Invalid("Internal state error: next blob not found");
         }
@@ -290,18 +298,22 @@ Status BulkStore::Delete(const ObjectID& object_id) {
   return Status::OK();
 }
 
-bool BulkStore::Exists(const ObjectID& object_id) {
-  object_map_t::const_accessor accessor;
+template<typename ID>
+bool BulkStore<ID>::Exists(const ID& object_id) {
+  typename object_map_t::const_accessor accessor;
   return objects_.find(accessor, object_id);
 }
 
-size_t BulkStore::Footprint() const { return BulkAllocator::Allocated(); }
+template<typename ID>
+size_t BulkStore<ID>::Footprint() const { return BulkAllocator::Allocated(); }
 
-size_t BulkStore::FootprintLimit() const {
+template<typename ID>
+size_t BulkStore<ID>::FootprintLimit() const {
   return BulkAllocator::GetFootprintLimit();
 }
 
-Status BulkStore::MakeArena(size_t const size, int& fd, uintptr_t& base) {
+template<typename ID>
+Status BulkStore<ID>::MakeArena(size_t const size, int& fd, uintptr_t& base) {
   fd = memory::create_buffer(size);
   if (fd == -1) {
     return Status::NotEnoughMemory("Failed to allocate a new arena");
@@ -314,7 +326,8 @@ Status BulkStore::MakeArena(size_t const size, int& fd, uintptr_t& base) {
   return Status::OK();
 }
 
-Status BulkStore::FinalizeArena(const int fd,
+template<typename ID>
+Status BulkStore<ID>::FinalizeArena(const int fd,
                                 std::vector<size_t> const& offsets,
                                 std::vector<size_t> const& sizes) {
   VLOG(2) << "finalizing arena (fd) " << fd << "...";
@@ -334,7 +347,7 @@ Status BulkStore::FinalizeArena(const int fd,
             << " of size " << sizes[idx];
     // make them available for blob pool
     uintptr_t pointer = mmap_base + offsets[idx];
-    ObjectID object_id = GenerateBlobID(pointer);
+    ID object_id = GenerateBlobID(pointer);
     objects_.emplace(object_id, std::make_shared<Payload>(
                                     object_id, sizes[idx],
                                     reinterpret_cast<uint8_t*>(pointer), fd,

--- a/src/server/memory/memory.h
+++ b/src/server/memory/memory.h
@@ -41,30 +41,31 @@
 
 namespace vineyard {
 
+template<typename ID>
 class BulkStore {
  public:
   using object_map_t =
-      tbb::concurrent_hash_map<ObjectID, std::shared_ptr<Payload>>;
+      tbb::concurrent_hash_map<ID, std::shared_ptr<Payload>>;
 
   ~BulkStore();
 
   Status PreAllocate(const size_t size);
 
-  Status Create(const size_t size, ObjectID& object_id,
+  Status Create(const size_t size, ID& object_id,
                 std::shared_ptr<Payload>& object);
 
-  Status Get(const ObjectID id, std::shared_ptr<Payload>& object);
+  Status Get(const ID id, std::shared_ptr<Payload>& object);
 
   /**
    * This methods only return available objects, and doesn't fail when object
    * does not exists.
    */
-  Status Get(const std::vector<ObjectID>& ids,
+  Status Get(const std::vector<ID>& ids,
              std::vector<std::shared_ptr<Payload>>& objects);
 
-  Status Delete(const ObjectID& object_id);
+  Status Delete(const ID& object_id);
 
-  bool Exists(const ObjectID& object_id);
+  bool Exists(const ID& object_id);
 
   object_map_t const& List() const { return objects_; }
 
@@ -83,7 +84,7 @@ class BulkStore {
     int fd;
     size_t size;
     uintptr_t base;
-    static std::set<ObjectID> spans;
+    static std::set<ID> spans;
   };
 
   std::unordered_map<int /* fd */, Arena> arenas_;

--- a/src/server/server/vineyard_runner.h
+++ b/src/server/server/vineyard_runner.h
@@ -39,7 +39,7 @@ limitations under the License.
 namespace vineyard {
 
 namespace asio = boost::asio;
-using session_map_t = tbb::concurrent_hash_map<SessionId, vs_ptr_t>;
+using session_map_t = tbb::concurrent_hash_map<SessionID, vs_ptr_t>;
 
 class VineyardServer;
 
@@ -49,10 +49,11 @@ class VineyardRunner : public std::enable_shared_from_this<VineyardRunner> {
   Status Serve();
   Status Finalize();
   Status GetRootSession(vs_ptr_t& vs_ptr);
-  Status CreateNewSession(std::string& ipc_socket);
-  Status Delete(SessionId const& sid);
-  Status Get(SessionId const& sid, vs_ptr_t& session);
-  bool Exists(SessionId const& sid);
+  Status CreateNewSession(std::string& ipc_socket,
+                          std::string const& bulk_store_name);
+  Status Delete(SessionID const& sid);
+  Status Get(SessionID const& sid, vs_ptr_t& session);
+  bool Exists(SessionID const& sid);
   void Stop();
   bool Running() const;
 

--- a/src/server/server/vineyard_server.h
+++ b/src/server/server/vineyard_server.h
@@ -73,18 +73,18 @@ class DeferredReq {
  */
 class VineyardServer : public std::enable_shared_from_this<VineyardServer> {
  public:
-  explicit VineyardServer(const json& spec, const SessionId& session_id,
+  explicit VineyardServer(const json& spec, const SessionID& session_id,
                           std::shared_ptr<VineyardRunner> runner,
                           asio::io_context& context,
                           asio::io_context& meta_context);
-  Status Serve();
+  Status Serve(std::string bulk_store_name);
   Status Finalize();
   inline const json& GetSpec() { return spec_; }
   inline const std::string GetDeployment() {
     return spec_["deployment"].get_ref<std::string const&>();
   }
 
-  inline SessionId GetSessionId() const { return session_id_; }
+  inline SessionID GetSessionID() const { return session_id_; }
 #if BOOST_VERSION >= 106600
   inline asio::io_context& GetContext() { return context_; }
   inline asio::io_context& GetMetaContext() { return meta_context_; }
@@ -93,6 +93,9 @@ class VineyardServer : public std::enable_shared_from_this<VineyardServer> {
   inline asio::io_service& GetMetaContext() { return meta_context_; }
 #endif
   inline std::shared_ptr<BulkStore> GetBulkStore() { return bulk_store_; }
+  inline std::shared_ptr<ExternalBulkStore> GetExternalBulkStore() {
+    return external_bulk_store_;
+  }
   inline std::shared_ptr<StreamStore> GetStreamStore() { return stream_store_; }
   inline std::shared_ptr<VineyardRunner> GetRunner() { return runner_; }
 
@@ -191,7 +194,7 @@ class VineyardServer : public std::enable_shared_from_this<VineyardServer> {
 
  private:
   json spec_;
-  SessionId session_id_;
+  SessionID session_id_;
 
 #if BOOST_VERSION >= 106600
   asio::io_context& context_;
@@ -208,6 +211,7 @@ class VineyardServer : public std::enable_shared_from_this<VineyardServer> {
   std::list<DeferredReq> deferred_;
 
   std::shared_ptr<BulkStore> bulk_store_;
+  std::shared_ptr<ExternalBulkStore> external_bulk_store_;
   std::shared_ptr<StreamStore> stream_store_;
   std::shared_ptr<VineyardRunner> runner_;
 

--- a/src/server/services/etcd_meta_service.h
+++ b/src/server/services/etcd_meta_service.h
@@ -138,7 +138,7 @@ class EtcdMetaService : public IMetaService {
       : IMetaService(server_ptr),
         etcd_spec_(server_ptr_->GetSpec()["metastore_spec"]),
         prefix_(etcd_spec_["etcd_prefix"].get<std::string>() + "/" +
-                SessionIDToString(server_ptr->GetSessionId())) {
+                SessionIDToString(server_ptr->GetSessionID())) {
     this->handled_rev_.store(0);
   }
 

--- a/test/external_test.cc
+++ b/test/external_test.cc
@@ -1,0 +1,117 @@
+/** Copyright 2020-2021 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <map>
+#include <memory>
+#include <random>
+#include <string>
+#include <thread>
+
+#include "arrow/api.h"
+#include "arrow/io/api.h"
+
+#include "basic/ds/tensor.h"
+#include "client/client.h"
+#include "client/ds/object_meta.h"
+#include "common/util/logging.h"
+
+using namespace vineyard;  // NOLINT(build/namespaces)
+
+int main(int argc, char** argv) {
+  if (argc < 2) {
+    printf("usage ./external_test.cc <ipc_socket>");
+    return 1;
+  }
+
+  std::string ipc_socket = std::string(argv[1]);
+
+  auto randStr = [](size_t length) {
+    std::string templ =
+        "1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ`~!@"
+        "#$%^&*()_+-=?<>,.;':";
+    std::string buffer;
+    std::random_device rd;
+    std::default_random_engine random(rd());
+    for (size_t i = 0; i < length; ++i) {
+      auto idx = random() % templ.size();
+      buffer += templ[idx];
+    }
+    return buffer;
+  };
+
+  auto generated_test_data = [&](std::map<std::string, std::string>& db,
+                                 size_t test_size) {
+    for (size_t i = 0; i < test_size; ++i) {
+      db.insert(std::make_pair(randStr(10), randStr(50)));
+    }
+  };
+
+  auto create_external_object = [](ExternalClient& client,
+                                   std::string const& oid,
+                                   std::string const& data) {
+    ExternalID eid = ExternalIDFromString(oid);
+    std::unique_ptr<vineyard::BlobWriter> blob;
+    VINEYARD_CHECK_OK(client.CreateBlob(eid, data.size(), 0, blob));
+    auto buffer = reinterpret_cast<uint8_t*>(blob->data());
+    memcpy(buffer, data.c_str(), data.size());
+    return eid;
+  };
+
+  auto get_external_objects = [](ExternalClient& client,
+                                 std::vector<ExternalID>& eids) {
+    std::vector<std::string> results;
+    std::map<ExternalID, ExternalPayload> payloads;
+    std::map<ExternalID, std::shared_ptr<arrow::Buffer>> buffers;
+    VINEYARD_CHECK_OK(client.GetBlobs(
+        std::set<ExternalID>(eids.begin(), eids.end()), payloads, buffers));
+    for (size_t i = 0; i < eids.size(); ++i) {
+      std::shared_ptr<arrow::Buffer> buff = buffers.find(eids[i])->second;
+      ExternalPayload payload = payloads.find(eids[i])->second;
+      char* data = reinterpret_cast<char*>(const_cast<uint8_t*>(buff->data()));
+      results.emplace_back(std::string(data, buff->size()));
+    }
+    return results;
+  };
+
+  auto check_results = [&](std::vector<ExternalID>& eids,
+                           std::vector<std::string> results,
+                           std::map<std::string, std::string> answer) {
+    CHECK_EQ(eids.size(), results.size());
+    for (size_t i = 0; i < eids.size(); ++i) {
+      auto search = answer.find(ExternalIDToString(eids[i]));
+      CHECK(search != answer.end());
+      CHECK(search->second == results[i]);
+    }
+  };
+
+  {
+    std::map<std::string, std::string> answer;
+    generated_test_data(answer, 64);
+
+    ExternalClient client;
+    VINEYARD_CHECK_OK(client.Open(ipc_socket));
+
+    std::vector<std::string> eids;
+    for (auto it = answer.begin(); it != answer.end(); ++it) {
+      eids.emplace_back(create_external_object(client, it->first, it->second));
+    }
+
+    auto results = get_external_objects(client, eids);
+
+    check_results(eids, results, answer);
+
+    client.CloseSession();
+  }
+}

--- a/test/runner.py
+++ b/test/runner.py
@@ -313,6 +313,7 @@ def run_single_vineyardd_tests():
         run_test('typename_test')
         run_test('version_test')
         run_test('session_test')
+        run_test('external_test')
 
         run_invalid_client_test('127.0.0.1', rpc_socket_port)
 

--- a/test/session_test.cc
+++ b/test/session_test.cc
@@ -89,7 +89,7 @@ int main(int argc, char** argv) {
   }
 
   {  // test session deletion
-    std::vector<Client> clients(1024);
+    std::vector<Client> clients(8);
     VINEYARD_CHECK_OK(clients[0].Open(ipc_socket));
     auto session_socket_path = clients[0].IPCSocket();
     for (size_t i = 1; i < clients.size(); ++i) {


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------
Provide a new ExternalBulkStore to support the plasma client.
- Add `ExternalBulkStore` to store a external object
- Add `ExternalClient` to send external object related request.
- Add `ExternalID`, `ExternalPayload`
- Add base64 encoder/decoder.
- Add protocols to process the ExternalBlob get/create.

**Use case:**

```c++
...
ExternalClient client;
client.Open(ipc_sokect);
client.CreateBlob(ExternalIDFromString("string_object_id"), size, external_size, blob);
...
```

<!-- Please give a short brief about these changes. -->


Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

closes #664
