### PR TITLE
[bugfix] Control visibility for unsealed blob.

### DIFF
--- a/modules/graph/utils/table_shuffler_beta.h
+++ b/modules/graph/utils/table_shuffler_beta.h
@@ -37,26 +37,6 @@ limitations under the License.
 #include "basic/ds/arrow_utils.h"
 #include "graph/utils/error.h"
 
-namespace grape {
-
-inline InArchive& operator<<(InArchive& in_archive,
-                             const arrow::util::string_view& val) {
-  in_archive << val.length();
-  in_archive.AddBytes(val.data(), val.length());
-  return in_archive;
-}
-
-inline OutArchive& operator>>(OutArchive& out_archive,
-                              arrow::util::string_view& val) {
-  size_t length;
-  out_archive >> length;
-  const char* ptr = static_cast<const char*>(out_archive.GetBytes(length));
-  val = arrow::util::string_view(ptr, length);
-  return out_archive;
-}
-
-}  // namespace grape
-
 namespace vineyard {
 
 namespace beta {

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -529,12 +529,15 @@ Status Client::Seal(ObjectID const& object_id) {
 
   json message_in;
   RETURN_ON_ERROR(doRead(message_in));
+  RETURN_ON_ERROR(ReadSealReply(message_in));
   return Status::OK();
 }
 
 ExternalClient::~ExternalClient() {}
 
 Status ExternalClient::Seal(ExternalID const& external_id) {
+  VINEYARD_CHECK_OK(check_fd(this->vineyard_conn_));
+
   ENSURE_CONNECTED(this);
   std::string message_out;
   WriteExternalSealRequest(external_id, message_out);
@@ -542,6 +545,7 @@ Status ExternalClient::Seal(ExternalID const& external_id) {
 
   json message_in;
   RETURN_ON_ERROR(doRead(message_in));
+  RETURN_ON_ERROR(ReadSealReply(message_in));
   return Status::OK();
 }
 
@@ -583,6 +587,7 @@ Status ExternalClient::CreateBlob(ExternalID external_id, size_t size,
       std::make_shared<arrow::MutableBuffer>(dist, external_payload.data_size);
 
   auto payload = external_payload.ToNormalPayload();
+  object_id = payload.object_id;
   blob.reset(new BlobWriter(object_id, payload, buffer));
   return Status::OK();
 }

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -521,7 +521,29 @@ Status Client::DropBuffer(const ObjectID id, const int fd) {
   return Status::OK();
 }
 
+Status Client::Seal(ObjectID const& object_id) {
+  ENSURE_CONNECTED(this);
+  std::string message_out;
+  WriteSealRequest(object_id, message_out);
+  RETURN_ON_ERROR(doWrite(message_out));
+
+  json message_in;
+  RETURN_ON_ERROR(doRead(message_in));
+  return Status::OK();
+}
+
 ExternalClient::~ExternalClient() {}
+
+Status ExternalClient::Seal(ExternalID const& external_id) {
+  ENSURE_CONNECTED(this);
+  std::string message_out;
+  WriteExternalSealRequest(external_id, message_out);
+  RETURN_ON_ERROR(doWrite(message_out));
+
+  json message_in;
+  RETURN_ON_ERROR(doRead(message_in));
+  return Status::OK();
+}
 
 Status ExternalClient::Open(std::string const& ipc_socket) {
   return Client::Open(ipc_socket, /*bulk_store_type=*/"External");

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -536,8 +536,6 @@ Status Client::Seal(ObjectID const& object_id) {
 ExternalClient::~ExternalClient() {}
 
 Status ExternalClient::Seal(ExternalID const& external_id) {
-  VINEYARD_CHECK_OK(check_fd(this->vineyard_conn_));
-
   ENSURE_CONNECTED(this);
   std::string message_out;
   WriteExternalSealRequest(external_id, message_out);

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -431,6 +431,8 @@ class Client : public ClientBase {
   Status Open(std::string const& ipc_socket,
               std::string const& bulk_store_type);
 
+  Status Seal(ObjectID const& object_id);
+
  protected:
   std::shared_ptr<detail::SharedMemoryManager> shm_;
 
@@ -486,6 +488,9 @@ class ExternalClient : public Client {
       const std::set<ExternalID>& external_ids,
       std::map<ExternalID, ExternalPayload>& external_payloads,
       std::map<ExternalID, std::shared_ptr<arrow::Buffer>>& buffers);
+
+ protected:
+  Status Seal(ExternalID const& object_id);
 };
 
 }  // namespace vineyard

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -489,7 +489,6 @@ class ExternalClient : public Client {
       std::map<ExternalID, ExternalPayload>& external_payloads,
       std::map<ExternalID, std::shared_ptr<arrow::Buffer>>& buffers);
 
- protected:
   Status Seal(ExternalID const& object_id);
 };
 

--- a/src/client/ds/blob.cc
+++ b/src/client/ds/blob.cc
@@ -223,6 +223,7 @@ std::shared_ptr<Object> BlobWriter::_Seal(Client& client) {
   VINEYARD_CHECK_OK(blob->meta_.buffer_set_->EmplaceBuffer(object_id_));
   VINEYARD_CHECK_OK(blob->meta_.buffer_set_->EmplaceBuffer(object_id_, buffer));
 
+  VINEYARD_CHECK_OK(client.Seal(object_id_));
   // assoicate extra key-value metadata
   for (auto const& kv : metadata_) {
     blob->meta_.AddKeyValue(kv.first, kv.second);

--- a/src/client/io.cc
+++ b/src/client/io.cc
@@ -15,6 +15,9 @@ limitations under the License.
 
 #include "client/io.h"
 
+#include "fcntl.h"
+#include "unistd.h"
+
 #include <iostream>
 
 namespace vineyard {
@@ -189,4 +192,15 @@ Status recv_message(int fd, std::string& msg) {
   return Status::OK();
 }
 
+Status check_fd(int fd) {
+  int r = fcntl(fd, F_GETFL);
+  if (r == -1) {
+    return Status::Invalid("fd error.");
+  } else if (r & O_RDONLY) {
+    return Status::Invalid("fd is read-only.");
+  } else if (r & O_WRONLY) {
+    return Status::Invalid("fd is write-only.");
+  }
+  return Status::OK();
+}
 }  // namespace vineyard

--- a/src/client/io.cc
+++ b/src/client/io.cc
@@ -15,9 +15,8 @@ limitations under the License.
 
 #include "client/io.h"
 
-#include "fcntl.h"
-#include "unistd.h"
-
+#include <fcntl.h>
+#include <unistd.h>
 #include <iostream>
 
 namespace vineyard {

--- a/src/client/io.h
+++ b/src/client/io.h
@@ -47,6 +47,8 @@ Status recv_bytes(int fd, void* data, size_t length);
 
 Status recv_message(int fd, std::string& msg);
 
+Status check_fd(int fd);
+
 }  // namespace vineyard
 
 #endif  // SRC_CLIENT_IO_H_

--- a/src/common/memory/payload.h
+++ b/src/common/memory/payload.h
@@ -30,8 +30,8 @@ struct Payload {
   ptrdiff_t data_offset;
   int64_t data_size;
   int64_t map_size;
-  int64_t is_sealed;
   uint8_t* pointer;
+  bool is_sealed;
 
   Payload()
       : object_id(EmptyBlobID()),
@@ -40,8 +40,8 @@ struct Payload {
         data_offset(0),
         data_size(0),
         map_size(0),
-        is_sealed(0),
-        pointer(nullptr) {}
+        pointer(nullptr),
+        is_sealed(0) {}
 
   Payload(ObjectID object_id, int64_t size, uint8_t* ptr, int fd, int64_t msize,
           ptrdiff_t offset)
@@ -51,8 +51,8 @@ struct Payload {
         data_offset(offset),
         data_size(size),
         map_size(msize),
-        is_sealed(0),
-        pointer(ptr){}
+        pointer(ptr),
+        is_sealed(0) {}
 
   Payload(ObjectID object_id, int64_t size, uint8_t* ptr, int fd, int arena_fd,
           int64_t msize, ptrdiff_t offset)
@@ -62,8 +62,8 @@ struct Payload {
         data_offset(offset),
         data_size(size),
         map_size(msize),
-        is_sealed(0),
-        pointer(ptr){}
+        pointer(ptr),
+        is_sealed(0) {}
 
   static std::shared_ptr<Payload> MakeEmpty() {
     static std::shared_ptr<Payload> payload = std::make_shared<Payload>();
@@ -76,7 +76,7 @@ struct Payload {
             (data_size == other.data_size));
   }
 
-  inline void MarkAsSealed() { is_sealed = 1; }
+  inline void MarkAsSealed() { is_sealed = true; }
 
   inline bool IsSealed() { return is_sealed; }
 

--- a/src/common/memory/payload.h
+++ b/src/common/memory/payload.h
@@ -30,8 +30,8 @@ struct Payload {
   ptrdiff_t data_offset;
   int64_t data_size;
   int64_t map_size;
+  int64_t is_sealed;
   uint8_t* pointer;
-  bool is_sealed;
 
   Payload()
       : object_id(EmptyBlobID()),
@@ -40,8 +40,8 @@ struct Payload {
         data_offset(0),
         data_size(0),
         map_size(0),
-        pointer(nullptr),
-        is_sealed(false) {}
+        is_sealed(0),
+        pointer(nullptr) {}
 
   Payload(ObjectID object_id, int64_t size, uint8_t* ptr, int fd, int64_t msize,
           ptrdiff_t offset)
@@ -51,8 +51,8 @@ struct Payload {
         data_offset(offset),
         data_size(size),
         map_size(msize),
-        pointer(ptr),
-        is_sealed(false) {}
+        is_sealed(0),
+        pointer(ptr){}
 
   Payload(ObjectID object_id, int64_t size, uint8_t* ptr, int fd, int arena_fd,
           int64_t msize, ptrdiff_t offset)
@@ -62,8 +62,8 @@ struct Payload {
         data_offset(offset),
         data_size(size),
         map_size(msize),
-        pointer(ptr),
-        is_sealed(false) {}
+        is_sealed(0),
+        pointer(ptr){}
 
   static std::shared_ptr<Payload> MakeEmpty() {
     static std::shared_ptr<Payload> payload = std::make_shared<Payload>();
@@ -76,7 +76,7 @@ struct Payload {
             (data_size == other.data_size));
   }
 
-  inline void MarkAsSealed() { is_sealed = true; }
+  inline void MarkAsSealed() { is_sealed = 1; }
 
   inline bool IsSealed() { return is_sealed; }
 
@@ -132,7 +132,7 @@ struct ExternalPayload : public Payload {
             (data_size == other.data_size));
   }
 
-  Payload ToNormalPayload() {
+  Payload ToNormalPayload() const {
     return Payload(object_id, data_size, pointer, store_fd, arena_fd, map_size,
                    data_offset);
   }

--- a/src/common/memory/payload.h
+++ b/src/common/memory/payload.h
@@ -31,6 +31,7 @@ struct Payload {
   int64_t data_size;
   int64_t map_size;
   uint8_t* pointer;
+  bool is_sealed;
 
   Payload()
       : object_id(EmptyBlobID()),
@@ -39,7 +40,8 @@ struct Payload {
         data_offset(0),
         data_size(0),
         map_size(0),
-        pointer(nullptr) {}
+        pointer(nullptr),
+        is_sealed(false) {}
 
   Payload(ObjectID object_id, int64_t size, uint8_t* ptr, int fd, int64_t msize,
           ptrdiff_t offset)
@@ -49,7 +51,8 @@ struct Payload {
         data_offset(offset),
         data_size(size),
         map_size(msize),
-        pointer(ptr) {}
+        pointer(ptr),
+        is_sealed(false) {}
 
   Payload(ObjectID object_id, int64_t size, uint8_t* ptr, int fd, int arena_fd,
           int64_t msize, ptrdiff_t offset)
@@ -59,7 +62,8 @@ struct Payload {
         data_offset(offset),
         data_size(size),
         map_size(msize),
-        pointer(ptr) {}
+        pointer(ptr),
+        is_sealed(false) {}
 
   static std::shared_ptr<Payload> MakeEmpty() {
     static std::shared_ptr<Payload> payload = std::make_shared<Payload>();
@@ -71,6 +75,10 @@ struct Payload {
             (data_offset == other.data_offset) &&
             (data_size == other.data_size));
   }
+
+  inline void MarkAsSealed() { is_sealed = true; }
+
+  inline bool IsSealed() { return is_sealed; }
 
   json ToJSON() const;
 
@@ -84,65 +92,31 @@ struct Payload {
   static Payload FromJSON1(const json& tree);
 };
 
-struct ExternalPayload {
+struct ExternalPayload : public Payload {
   ExternalID external_id;
-  ObjectID object_id;
   int64_t external_size;
-  int store_fd;
-  int arena_fd;
-  ptrdiff_t data_offset;
-  int64_t data_size;
-  int64_t map_size;
-  uint8_t* pointer;
 
-  ExternalPayload()
-      : external_id(),
-        object_id(EmptyBlobID()),
-        external_size(0),
-        store_fd(-1),
-        arena_fd(-1),
-        data_offset(0),
-        data_size(0),
-        map_size(0),
-        pointer(nullptr) {}
+  ExternalPayload() : Payload(), external_id(), external_size(0) {}
 
   ExternalPayload(ExternalID external_id, ObjectID object_id,
                   int64_t external_size, int64_t size, uint8_t* ptr, int fd,
                   int64_t msize, ptrdiff_t offset)
-      : external_id(external_id),
-        object_id(object_id),
-        external_size(external_size),
-        store_fd(fd),
-        arena_fd(-1),
-        data_offset(offset),
-        data_size(size),
-        map_size(msize),
-        pointer(ptr) {}
+      : Payload(object_id, size, ptr, fd, msize, offset),
+        external_id(external_id),
+        external_size(external_size) {}
 
   ExternalPayload(ExternalID external_id, ObjectID object_id,
                   int64_t external_size, int64_t size, uint8_t* ptr, int fd,
                   int arena_fd, int64_t msize, ptrdiff_t offset)
-      : external_id(external_id),
-        object_id(object_id),
-        external_size(external_size),
-        store_fd(fd),
-        arena_fd(arena_fd),
-        data_offset(offset),
-        data_size(size),
-        map_size(msize),
-        pointer(ptr) {}
+      : Payload(object_id, size, ptr, fd, arena_fd, msize, offset),
+        external_id(external_id),
+        external_size(external_size) {}
 
   ExternalPayload(ExternalID external_id, int64_t size, uint8_t* ptr, int fd,
                   int64_t msize, ptrdiff_t offset)
-      : external_id(external_id),
-        object_id(EmptyBlobID()),
-        external_size(0),
-        store_fd(fd),
-        arena_fd(-1),
-        data_offset(offset),
-        data_size(size),
-        map_size(msize),
-        pointer(ptr) {}
+      : Payload(EmptyBlobID(), size, ptr, fd, msize, offset),
+        external_id(external_id),
+        external_size(0) {}
 
   static std::shared_ptr<ExternalPayload> MakeEmpty() {
     static std::shared_ptr<ExternalPayload> payload =
@@ -153,6 +127,8 @@ struct ExternalPayload {
   bool operator==(const ExternalPayload& other) const {
     return ((object_id == other.object_id) && (store_fd == other.store_fd) &&
             (data_offset == other.data_offset) &&
+            (external_size == other.external_size) &&
+            (external_id == other.external_id) &&
             (data_size == other.data_size));
   }
 

--- a/src/common/util/protocols.cc
+++ b/src/common/util/protocols.cc
@@ -121,6 +121,10 @@ CommandType ParseCommandType(const std::string& str_type) {
     return CommandType::CreateBufferByExternalRequest;
   } else if (str_type == "get_buffers_by_external_request") {
     return CommandType::GetBuffersByExternalRequest;
+  } else if (str_type == "seal_request") {
+    return CommandType::SealRequest;
+  } else if (str_type == "external_seal_request") {
+    return CommandType::ExternalSealRequest;
   } else {
     return CommandType::NullCommand;
   }
@@ -1265,4 +1269,37 @@ Status ReadGetBuffersByExternalReply(
   return Status::OK();
 }
 
+void WriteSealRequest(ObjectID const& object_id, std::string& msg) {
+  json root;
+  root["type"] = "seal_request";
+  root["object_id"] = object_id;
+  encode_msg(root, msg);
+}
+
+Status ReadSealRequest(json const& root, ObjectID& object_id) {
+  CHECK_IPC_ERROR(root, "seal_request");
+  object_id = root["object_id"].get<ObjectID>();
+  return Status::OK();
+}
+
+void WriteExternalSealRequest(ExternalID const& external_id, std::string& msg) {
+  json root;
+  root["type"] = "external_seal_request";
+  root["external_id"] = external_id;
+  encode_msg(root, msg);
+}
+
+Status ReadExternalSealRequest(json const& root, ExternalID& external_id) {
+  CHECK_IPC_ERROR(root, "external_seal_request");
+  external_id = root["external_id"].get<ExternalID>();
+  return Status::OK();
+}
+
+void WriteSealReply(std::string& msg) {
+  json root;
+  root["type"] = "seal_reply";
+  encode_msg(root, msg);
+}
+
 }  // namespace vineyard
+   //

--- a/src/common/util/protocols.cc
+++ b/src/common/util/protocols.cc
@@ -1277,7 +1277,7 @@ void WriteSealRequest(ObjectID const& object_id, std::string& msg) {
 }
 
 Status ReadSealRequest(json const& root, ObjectID& object_id) {
-  CHECK_IPC_ERROR(root, "seal_request");
+  RETURN_ON_ASSERT(root["type"] == "seal_request");
   object_id = root["object_id"].get<ObjectID>();
   return Status::OK();
 }
@@ -1290,7 +1290,7 @@ void WriteExternalSealRequest(ExternalID const& external_id, std::string& msg) {
 }
 
 Status ReadExternalSealRequest(json const& root, ExternalID& external_id) {
-  CHECK_IPC_ERROR(root, "external_seal_request");
+  RETURN_ON_ASSERT(root["type"] == "external_seal_request");
   external_id = root["external_id"].get<ExternalID>();
   return Status::OK();
 }
@@ -1301,5 +1301,9 @@ void WriteSealReply(std::string& msg) {
   encode_msg(root, msg);
 }
 
+Status ReadSealReply(json const& root) {
+  RETURN_ON_ASSERT(root["type"] == "seal_reply");
+  return Status::OK();
+}
+
 }  // namespace vineyard
-   //

--- a/src/common/util/protocols.h
+++ b/src/common/util/protocols.h
@@ -79,6 +79,7 @@ enum class CommandType {
   GetBuffersByExternalReply = 45,
   SealRequest = 46,
   ExternalSealRequest = 47,
+  SealReply = 48,
 };
 
 CommandType ParseCommandType(const std::string& str_type);
@@ -436,6 +437,8 @@ void WriteExternalSealRequest(ExternalID const& external_id,
 Status ReadExternalSealRequest(json const& root, ExternalID& external_id);
 
 void WriteSealReply(std::string& msg);
+
+Status ReadSealReply(json const& root);
 
 }  // namespace vineyard
 

--- a/src/common/util/protocols.h
+++ b/src/common/util/protocols.h
@@ -77,6 +77,8 @@ enum class CommandType {
   CreateBufferByExternalReply = 43,
   GetBuffersByExternalRequest = 44,
   GetBuffersByExternalReply = 45,
+  SealRequest = 46,
+  ExternalSealRequest = 47,
 };
 
 CommandType ParseCommandType(const std::string& str_type);
@@ -423,6 +425,17 @@ void WriteGetBuffersByExternalReply(
 
 Status ReadGetBuffersByExternalReply(
     json const& root, std::vector<ExternalPayload>& external_objects);
+
+void WriteSealRequest(ObjectID const& object_id, std::string& message_out);
+
+Status ReadSealRequest(json const& root, ObjectID& object_id);
+
+void WriteExternalSealRequest(ExternalID const& external_id,
+                              std::string& message_out);
+
+Status ReadExternalSealRequest(json const& root, ExternalID& external_id);
+
+void WriteSealReply(std::string& msg);
 
 }  // namespace vineyard
 

--- a/src/common/util/status.h
+++ b/src/common/util/status.h
@@ -345,6 +345,12 @@ class VINEYARD_MUST_USE_TYPE Status {
     return Status(StatusCode::kObjectNotSealed, "");
   }
 
+  /// Return an error when user are trying to maniplate the object but the
+  /// object hasn't been sealed yet.
+  static Status ObjectNotSealed(std::string const& message) {
+    return Status(StatusCode::kObjectNotSealed, message);
+  }
+
   /// Return an error when user are trying to perform unsupported operations
   /// on blob objects.
   static Status ObjectIsBlob(std::string const& message = "") {

--- a/src/server/async/socket_server.cc
+++ b/src/server/async/socket_server.cc
@@ -716,7 +716,7 @@ bool SocketConnection::doGetNextStreamChunk(const json& root) {
         if (status.ok()) {
           std::shared_ptr<Payload> object;
           RETURN_ON_ERROR(
-              self->server_ptr_->GetBulkStore()->Get(chunk, object));
+              self->server_ptr_->GetBulkStore()->GetUnchecked(chunk, object));
           WriteGetNextStreamChunkReply(object, message_out);
           int store_fd = object->store_fd;
           int data_size = object->data_size;

--- a/src/server/async/socket_server.cc
+++ b/src/server/async/socket_server.cc
@@ -1109,7 +1109,6 @@ bool SocketConnection::doGetBuffersByExternal(json const& root) {
 }
 
 bool SocketConnection::doSealBlob(json const& root) {
-  LOG(INFO) << "Normal";
   auto self(shared_from_this());
   ObjectID id;
   TRY_READ_REQUEST(ReadSealRequest, root, id);
@@ -1117,18 +1116,18 @@ bool SocketConnection::doSealBlob(json const& root) {
   std::string message_out;
   WriteSealReply(message_out);
   this->doWrite(message_out);
-  return true;
+  return false;
 }
 
 bool SocketConnection::doSealExternalBlob(json const& root) {
   auto self(shared_from_this());
   ExternalID id;
   TRY_READ_REQUEST(ReadExternalSealRequest, root, id);
-  //RESPONSE_ON_ERROR(server_ptr_->GetExternalBulkStore()->Seal(id));
+  RESPONSE_ON_ERROR(server_ptr_->GetExternalBulkStore()->Seal(id));
   std::string message_out;
   WriteSealReply(message_out);
   this->doWrite(message_out);
-  return true;
+  return false;
 }
 
 void SocketConnection::doWrite(const std::string& buf) {

--- a/src/server/async/socket_server.cc
+++ b/src/server/async/socket_server.cc
@@ -1109,6 +1109,7 @@ bool SocketConnection::doGetBuffersByExternal(json const& root) {
 }
 
 bool SocketConnection::doSealBlob(json const& root) {
+  LOG(INFO) << "Normal";
   auto self(shared_from_this());
   ObjectID id;
   TRY_READ_REQUEST(ReadSealRequest, root, id);
@@ -1123,7 +1124,7 @@ bool SocketConnection::doSealExternalBlob(json const& root) {
   auto self(shared_from_this());
   ExternalID id;
   TRY_READ_REQUEST(ReadExternalSealRequest, root, id);
-  RESPONSE_ON_ERROR(server_ptr_->GetExternalBulkStore()->Seal(id));
+  //RESPONSE_ON_ERROR(server_ptr_->GetExternalBulkStore()->Seal(id));
   std::string message_out;
   WriteSealReply(message_out);
   this->doWrite(message_out);

--- a/src/server/async/socket_server.h
+++ b/src/server/async/socket_server.h
@@ -135,6 +135,10 @@ class SocketConnection : public std::enable_shared_from_this<SocketConnection> {
 
   bool doGetBuffersByExternal(json const& root);
 
+  bool doSealBlob(json const& root);
+
+  bool doSealExternalBlob(json const& root);
+
  private:
   int nativeHandle() { return socket_.native_handle(); }
 

--- a/src/server/memory/memory.cc
+++ b/src/server/memory/memory.cc
@@ -183,10 +183,30 @@ Status BulkStoreBase<ID, P>::Get(ID const& id, std::shared_ptr<P>& object) {
         object = accessor->second;
         return Status::OK();
       } else {
-        return Status::ObjectNotSealed();
+        return Status::ObjectNotSealed("Failed to get blob with id " +
+                                       IDToString<ID>(id));
       }
     } else {
-      return Status::ObjectNotExists("get: id = " + IDToString<ID>(id));
+      return Status::ObjectNotExists("Failed to get blob with id " +
+                                     IDToString<ID>(id));
+    }
+  }
+}
+
+template <typename ID, typename P>
+Status BulkStoreBase<ID, P>::GetUnchecked(ID const& id,
+                                          std::shared_ptr<P>& object) {
+  if (id == EmptyBlobID<ID>()) {
+    object = P::MakeEmpty();
+    return Status::OK();
+  } else {
+    typename object_map_t::const_accessor accessor;
+    if (objects_.find(accessor, id)) {
+      object = accessor->second;
+      return Status::OK();
+    } else {
+      return Status::ObjectNotExists("Failed to get blob with id " +
+                                     IDToString<ID>(id));
     }
   }
 }

--- a/src/server/memory/memory.cc
+++ b/src/server/memory/memory.cc
@@ -179,8 +179,8 @@ Status BulkStoreBase<ID, P>::Get(ID const& id, std::shared_ptr<P>& object) {
   } else {
     typename object_map_t::const_accessor accessor;
     if (objects_.find(accessor, id)) {
-      object = accessor->second;
-      if (object->IsSealed()) {
+      if (accessor->second->IsSealed()) {
+        object = accessor->second;
         return Status::OK();
       } else {
         return Status::ObjectNotSealed();

--- a/src/server/memory/memory.h
+++ b/src/server/memory/memory.h
@@ -50,6 +50,8 @@ class BulkStoreBase {
 
   Status Get(ID const& id, std::shared_ptr<P>& object);
 
+  Status GetUnchecked(ID const& id, std::shared_ptr<P>& object);
+
   /**
    * This methods only return available objects, and doesn't fail when object
    * does not exists.

--- a/src/server/memory/memory.h
+++ b/src/server/memory/memory.h
@@ -48,29 +48,31 @@ class BulkStoreBase {
 
   ~BulkStoreBase();
 
-  Status Get(const ID id, std::shared_ptr<P>& object);
+  Status Get(ID const& id, std::shared_ptr<P>& object);
 
   /**
    * This methods only return available objects, and doesn't fail when object
    * does not exists.
    */
-  Status Get(const std::vector<ID>& ids,
+  Status Get(std::vector<ID> const& ids,
              std::vector<std::shared_ptr<P>>& objects);
 
-  Status Delete(const ID& object_id);
+  Status Delete(ID const& object_id);
 
-  bool Exists(const ID& object_id);
+  bool Exists(ID const& object_id);
+
+  Status Seal(ID const& object_id);
 
   object_map_t const& List() const { return objects_; }
 
   size_t Footprint() const;
   size_t FootprintLimit() const;
 
-  Status MakeArena(const size_t size, int& fd, uintptr_t& base);
+  Status MakeArena(size_t const size, int& fd, uintptr_t& base);
 
-  Status PreAllocate(const size_t size);
+  Status PreAllocate(size_t const size);
 
-  Status FinalizeArena(const int fd, std::vector<size_t> const& offsets,
+  Status FinalizeArena(int const fd, std::vector<size_t> const& offsets,
                        std::vector<size_t> const& sizes);
 
  protected:

--- a/src/server/memory/stream_store.cc
+++ b/src/server/memory/stream_store.cc
@@ -78,6 +78,7 @@ Status StreamStore::Get(ObjectID const stream_id, size_t const size,
 
   // seal current chunk
   if (stream->current_writing_) {
+    VINEYARD_DISCARD(store_->Seal(stream->current_writing_.get()));
     stream->ready_chunks_.push(stream->current_writing_.get());
     stream->current_writing_ = boost::none;
   }
@@ -236,6 +237,7 @@ Status StreamStore::Stop(ObjectID const stream_id, bool failed) {
   }
   // seal current writing chunk
   if (stream->current_writing_) {
+    VINEYARD_DISCARD(store_->Seal(stream->current_writing_.get()));
     stream->ready_chunks_.push(stream->current_writing_.get());
     stream->current_writing_ = boost::none;
   }

--- a/test/external_test.cc
+++ b/test/external_test.cc
@@ -64,8 +64,8 @@ int main(int argc, char** argv) {
     ExternalID eid = ExternalIDFromString(oid);
     std::unique_ptr<vineyard::BlobWriter> blob;
     VINEYARD_CHECK_OK(client.CreateBlob(eid, data.size(), 0, blob));
-    // auto buffer = reinterpret_cast<uint8_t*>(blob->data());
-    // memcpy(buffer, data.c_str(), data.size());
+    auto buffer = reinterpret_cast<uint8_t*>(blob->data());
+    memcpy(buffer, data.c_str(), data.size());
     if (do_seal) {
       VINEYARD_CHECK_OK(client.Seal(eid));
     }
@@ -143,7 +143,7 @@ int main(int argc, char** argv) {
               << client.IPCSocket();
     create_external_object(client, "hetao", "the_gaint_head", false);
     std::vector<ExternalID> eids = {ExternalIDFromString("hetao")};
-    get_external_objects(client, eids, false);
+    get_external_objects(client, eids, true);
     client.CloseSession();
   }
 

--- a/test/external_test.cc
+++ b/test/external_test.cc
@@ -60,27 +60,40 @@ int main(int argc, char** argv) {
 
   auto create_external_object = [](ExternalClient& client,
                                    std::string const& oid,
-                                   std::string const& data) {
+                                   std::string const& data, bool do_seal) {
     ExternalID eid = ExternalIDFromString(oid);
     std::unique_ptr<vineyard::BlobWriter> blob;
     VINEYARD_CHECK_OK(client.CreateBlob(eid, data.size(), 0, blob));
-    auto buffer = reinterpret_cast<uint8_t*>(blob->data());
-    memcpy(buffer, data.c_str(), data.size());
+    // auto buffer = reinterpret_cast<uint8_t*>(blob->data());
+    // memcpy(buffer, data.c_str(), data.size());
+    if (do_seal) {
+      VINEYARD_CHECK_OK(client.Seal(eid));
+    }
     return eid;
   };
 
   auto get_external_objects = [](ExternalClient& client,
-                                 std::vector<ExternalID>& eids) {
+                                 std::vector<ExternalID>& eids,
+                                 bool check_seal) {
     std::vector<std::string> results;
     std::map<ExternalID, ExternalPayload> payloads;
     std::map<ExternalID, std::shared_ptr<arrow::Buffer>> buffers;
-    VINEYARD_CHECK_OK(client.GetBlobs(
-        std::set<ExternalID>(eids.begin(), eids.end()), payloads, buffers));
+    auto status = client.GetBlobs(
+        std::set<ExternalID>(eids.begin(), eids.end()), payloads, buffers);
+    if (!check_seal) {
+      VINEYARD_CHECK_OK(status);
+    } else {
+      LOG(INFO) << "status should be not sealed: " << status.ToString()
+                << std::endl;
+      CHECK(status.IsObjectNotSealed());
+      return results;
+    }
     for (size_t i = 0; i < eids.size(); ++i) {
       std::shared_ptr<arrow::Buffer> buff = buffers.find(eids[i])->second;
       ExternalPayload payload = payloads.find(eids[i])->second;
       char* data = reinterpret_cast<char*>(const_cast<uint8_t*>(buff->data()));
       results.emplace_back(std::string(data, buff->size()));
+      VINEYARD_CHECK_OK(client.Seal(eids[i]));
     }
     return results;
   };
@@ -97,25 +110,40 @@ int main(int argc, char** argv) {
   };
 
   {  // test create/get
+    ExternalClient client;
+    VINEYARD_CHECK_OK(client.Open(ipc_socket));
+
+    LOG(INFO) << "Connected to IPCServer(ExternalBulkStore): "
+              << client.IPCSocket();
+
     std::map<std::string, std::string> answer;
     size_t test_data_size = 64;
     generated_test_data(answer, test_data_size);
     LOG(INFO) << "Generated test data " << test_data_size;
 
-    ExternalClient client;
-    VINEYARD_CHECK_OK(client.Open(ipc_socket));
-
     std::vector<std::string> eids;
     for (auto it = answer.begin(); it != answer.end(); ++it) {
-      eids.emplace_back(create_external_object(client, it->first, it->second));
+      eids.emplace_back(
+          create_external_object(client, it->first, it->second, true));
     }
     LOG(INFO) << "Finish all the get request... ";
 
-    auto results = get_external_objects(client, eids);
+    auto results = get_external_objects(client, eids, false);
 
     check_results(eids, results, answer);
     LOG(INFO) << "Passed external create/get test...";
 
+    client.CloseSession();
+  }
+
+  {  // test visibility
+    ExternalClient client;
+    VINEYARD_CHECK_OK(client.Open(ipc_socket));
+    LOG(INFO) << "Connected to IPCServer(ExternalBulkStore): "
+              << client.IPCSocket();
+    create_external_object(client, "hetao", "the_gaint_head", false);
+    std::vector<ExternalID> eids = {ExternalIDFromString("hetao")};
+    get_external_objects(client, eids, false);
     client.CloseSession();
   }
 


### PR DESCRIPTION

What do these changes do?
-------------------------

Add `is_sealed` flag for each blob. Before users call `client.Seal(object_id)` explicitly, they can not get the blob.
