### PR TITLE
Reinterpret cast to `uintptr_t`, rather than static cast to int type.

### DIFF
--- a/src/common/util/uuid.h
+++ b/src/common/util/uuid.h
@@ -90,7 +90,7 @@ inline void* GetBlobAddr(ObjectID const id) {
 }
 
 inline ObjectID GenerateBlobID(const uintptr_t ptr) {
-  return 0x8000000000000000UL | static_cast<uint64_t>(ptr);
+  return 0x8000000000000000UL | reinterpret_cast<uintptr_t>(ptr);
 }
 
 inline SessionID GenerateSessionID() {
@@ -200,7 +200,7 @@ inline InstanceID UnspecifiedInstanceID() {
 
 template <typename ID = ObjectID>
 inline ID GenerateBlobID(uintptr_t ptr) {
-  uint64_t ans = 0x8000000000000000UL | reinterpret_cast<uint64_t>(ptr);
+  uint64_t ans = 0x8000000000000000UL | reinterpret_cast<uintptr_t>(ptr);
   return static_if<std::is_same<ID, ObjectID>{}>(
       [&]() { return ObjectID(ans); },
       [&]() {


### PR DESCRIPTION
What do these changes do?
-------------------------

The original code doesn't work on MacOS with clang 13.

N/A

