### PR TITLE
Restrict the version of click to `<8.1`.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -89,8 +89,8 @@ jobs:
           sudo pip3 install --no-binary pyarrow pyarrow==3.0.0
 
           # install python packages for codegen, and io adaptors
-          sudo pip3 install -U Pygments>=2.4.1
-          sudo pip3 install -U libclang parsec sphinx sphinx_rtd_theme docutils==0.16 breathe nbsphinx gcovr pytest hdfs3 numpy>=0.18.5
+          sudo pip3 install -U "Pygments>=2.4.1"
+          sudo pip3 install -U libclang parsec sphinx sphinx_rtd_theme docutils==0.16 breathe nbsphinx gcovr pytest hdfs3 "numpy>=0.18.5"
 
           # install linters
           sudo pip3 install black isort flake8

--- a/setup_dask.py
+++ b/setup_dask.py
@@ -85,7 +85,7 @@ setup(
     packages=find_dask_packages('python'),
     cmdclass={'bdist_wheel': bdist_wheel_plat, "install": install_plat},
     zip_safe=False,
-    install_requires=['vineyard', 'dask[complete]'],
+    install_requires=['vineyard', 'dask[complete]', 'click<8.1'],
     platform=['POSIX', 'MacOS'],
     license="Apache License 2.0",
     classifiers=[


### PR DESCRIPTION

What do these changes do?
-------------------------

Fixes current CI failures of dask cases.

