### PR TITLE
Remove write msg mutex for SocketConnection.

### DIFF
--- a/src/server/async/socket_server.cc
+++ b/src/server/async/socket_server.cc
@@ -1212,8 +1212,7 @@ void SocketConnection::doWrite(const std::string& buf) {
   memcpy(ptr, &length, sizeof(size_t));
   ptr += sizeof(size_t);
   memcpy(ptr, buf.data(), length);
-  write_msgs_.push_back(std::move(to_send));
-  doAsyncWrite();
+  doAsyncWrite(std::move(to_send));
 }
 
 void SocketConnection::doWrite(const std::string& buf, callback_t<> callback) {
@@ -1224,13 +1223,11 @@ void SocketConnection::doWrite(const std::string& buf, callback_t<> callback) {
   memcpy(ptr, &length, sizeof(size_t));
   ptr += sizeof(size_t);
   memcpy(ptr, buf.data(), length);
-  write_msgs_.push_back(std::move(to_send));
-  doAsyncWrite(callback);
+  doAsyncWrite(std::move(to_send), callback);
 }
 
 void SocketConnection::doWrite(std::string&& buf) {
-  write_msgs_.push_back(std::move(buf));
-  doAsyncWrite();
+  doAsyncWrite(std::move(buf));
 }
 
 void SocketConnection::doStop() {
@@ -1240,49 +1237,32 @@ void SocketConnection::doStop() {
   }
 }
 
-void SocketConnection::doAsyncWrite() {
-  std::shared_ptr<std::string> payload = nullptr;
-  if (!write_msgs_.empty()) {
-    payload.reset(new std::string());
-    payload->swap(write_msgs_.front());
-    write_msgs_.pop_front();
-  }
-  if (payload == nullptr) {
-    return;
-  }
+void SocketConnection::doAsyncWrite(std::string&& buf) {
+  std::shared_ptr<std::string> payload =
+      std::make_shared<std::string>(std::move(buf));
   auto self(shared_from_this());
   asio::async_write(
       socket_, boost::asio::buffer(payload->data(), payload->length()),
       [this, self, payload](boost::system::error_code ec, std::size_t) {
-        if (!ec) {
-          doAsyncWrite();
-        } else {
+        if (ec) {
           doStop();
         }
       });
 }
 
-void SocketConnection::doAsyncWrite(callback_t<> callback) {
-  std::shared_ptr<std::string> payload = nullptr;
-  if (!write_msgs_.empty()) {
-    payload.reset(new std::string());
-    payload->swap(write_msgs_.front());
-    write_msgs_.pop_front();
-  }
-  if (payload == nullptr) {
-    auto status = callback(Status::OK());
-    if (!status.ok()) {
-      doStop();
-    }
-    return;
-  }
+void SocketConnection::doAsyncWrite(std::string&& buf, callback_t<> callback) {
+  std::shared_ptr<std::string> payload =
+      std::make_shared<std::string>(std::move(buf));
   auto self(shared_from_this());
   asio::async_write(socket_,
                     boost::asio::buffer(payload->data(), payload->length()),
                     [this, self, payload, callback](
                         boost::system::error_code ec, std::size_t) {
                       if (!ec) {
-                        doAsyncWrite(callback);
+                        auto status = callback(Status::OK());
+                        if (!status.ok()) {
+                          doStop();
+                        }
                       } else {
                         doStop();
                       }

--- a/src/server/async/socket_server.h
+++ b/src/server/async/socket_server.h
@@ -202,9 +202,9 @@ class SocketConnection : public std::enable_shared_from_this<SocketConnection> {
    */
   void doStop();
 
-  void doAsyncWrite();
+  void doAsyncWrite(std::string&& buf);
 
-  void doAsyncWrite(callback_t<> callback);
+  void doAsyncWrite(std::string&& buf, callback_t<> callback);
 
   void sendBufferHelper(std::vector<std::shared_ptr<Payload>> const objects,
                         size_t index, boost::system::error_code const ec,
@@ -217,7 +217,6 @@ class SocketConnection : public std::enable_shared_from_this<SocketConnection> {
   std::atomic_bool running_;
 
   asio::streambuf buf_;
-  socket_message_queue_t write_msgs_;
 
   std::unordered_set<int> used_fds_;
   // the associated reader of the stream

--- a/src/server/async/socket_server.h
+++ b/src/server/async/socket_server.h
@@ -218,7 +218,6 @@ class SocketConnection : public std::enable_shared_from_this<SocketConnection> {
 
   asio::streambuf buf_;
   socket_message_queue_t write_msgs_;
-  std::recursive_mutex write_msgs_mutex_;  // protect the write_msgs
 
   std::unordered_set<int> used_fds_;
   // the associated reader of the stream


### PR DESCRIPTION
Only one thread can access the `write_msgs_`, thus we do not need the lock.