### PR TITLE
Use a mutex to ensure that the "Start()" won't executed if "Stop()" been called first

### DIFF
--- a/src/server/async/ipc_server.cc
+++ b/src/server/async/ipc_server.cc
@@ -42,6 +42,11 @@ IPCServer::~IPCServer() {
 }
 
 void IPCServer::Start() {
+  std::lock_guard<std::recursive_mutex> stop_lock(mutex_for_stop_);
+  if (stopped_.load()) {
+    return;
+  }
+
   std::string const& ipc_socket =
       ipc_spec_["socket"].get_ref<std::string const&>();
   chmod(ipc_socket.c_str(),

--- a/src/server/async/rpc_server.cc
+++ b/src/server/async/rpc_server.cc
@@ -48,6 +48,11 @@ RPCServer::~RPCServer() {
 }
 
 void RPCServer::Start() {
+  std::lock_guard<std::recursive_mutex> stop_lock(mutex_for_stop_);
+  if (stopped_.load()) {
+    return;
+  }
+
   vs_ptr_->RPCReady();
   SocketServer::Start();
   LOG(INFO) << "Vineyard will listen on 0.0.0.0:"

--- a/src/server/async/socket_server.cc
+++ b/src/server/async/socket_server.cc
@@ -1279,6 +1279,8 @@ void SocketServer::Start() {
 }
 
 void SocketServer::Stop() {
+  std::lock_guard<std::recursive_mutex> stop_lock(mutex_for_stop_);
+
   if (stopped_.exchange(true)) {
     return;
   }

--- a/src/server/async/socket_server.h
+++ b/src/server/async/socket_server.h
@@ -270,7 +270,10 @@ class SocketServer {
   size_t AliveConnections() const;
 
  protected:
-  std::atomic_bool stopped_;   // if the socket server being stopped.
+  std::atomic_bool stopped_;  // if the socket server being stopped.
+  // a mutex that ensure `Start()` and `Stop()` doesn't happen at the same time.
+  std::recursive_mutex mutex_for_stop_;
+
   std::atomic_bool closable_;  // if client want to close the session,
   vs_ptr_t vs_ptr_;
   int next_conn_id_;

--- a/test/runner.py
+++ b/test/runner.py
@@ -90,7 +90,7 @@ def start_etcd():
 def start_vineyardd(
     etcd_endpoints,
     etcd_prefix,
-    size=4 * 1024 * 1024 * 1024,
+    size=3 * 1024 * 1024 * 1024,
     default_ipc_socket=VINEYARD_CI_IPC_SOCKET,
     idx=None,
     **kw,


### PR DESCRIPTION

<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------


The session might be stoped once after initialized.

(The `Start()` method is a callback that are invoked from the meta service, when successfully register to etcd.)

Addresses the CI failure catched in https://github.com/v6d-io/v6d/runs/5879153388?check_suite_focus=true.

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes https://github.com/v6d-io/v6d/runs/5879153388?check_suite_focus=true

