### PR TITLE
Use send() rather than write() to avoid the SIGPIPE signal.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 compile_commands.json
 cmake-build-debug
 
+# core dump
+core
+
 # for python packaging
 /dist/
 *.egg-info/
@@ -42,3 +45,5 @@ default.etcd/
 # Rust build
 /**/target/
 
+# Java JVM crash logs
+hs_err_pid*.log

--- a/src/client/io.cc
+++ b/src/client/io.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include "client/io.h"
 
 #include <fcntl.h>
+#include <sys/socket.h>
 #include <unistd.h>
 #include <iostream>
 
@@ -136,7 +137,8 @@ Status send_bytes(int fd, const void* data, size_t length) {
   size_t offset = 0;
   const char* ptr = static_cast<const char*>(data);
   while (bytes_left > 0) {
-    nbytes = write(fd, ptr + offset, bytes_left);
+    // Release: avoid SIGPIPE in any cases as it is hard to catch and diagnose.
+    nbytes = send(fd, ptr + offset, bytes_left, MSG_NOSIGNAL);
     if (nbytes < 0) {
       if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
         continue;

--- a/src/server/async/socket_server.cc
+++ b/src/server/async/socket_server.cc
@@ -1033,7 +1033,6 @@ bool SocketConnection::doDebug(const json& root) {
 bool SocketConnection::doNewSession(const json& root) {
   auto self(shared_from_this());
   std::string bulk_store_type;
-  json result;
   TRY_READ_REQUEST(ReadNewSessionRequest, root, bulk_store_type);
   VINEYARD_CHECK_OK(server_ptr_->GetRunner()->CreateNewSession(
       bulk_store_type,


### PR DESCRIPTION
What do these changes do?
-------------------------

Fixes the CI failure in https://github.com/v6d-io/v6d/runs/5888312753?check_suite_focus=true


