### PR TITLE
Correctly find vineyard package on Debian with multiarch support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,9 @@ else()
     set(HAVE_FLAG_STD_CXX14 TRUE)
 endif()
 
+set(CMAKE_INSTALL_DIR lib/cmake/vineyard CACHE STRING
+    "The subdirectory where CMake package config files should be installed")
+
 macro(find_apache_arrow)
     # workaround for: https://issues.apache.org/jira/browse/ARROW-11836
     if(NOT BUILD_VINEYARD_PYPI_PACKAGES)
@@ -790,11 +793,11 @@ install(FILES "${PROJECT_BINARY_DIR}/vineyard-config.cmake"
               "${PROJECT_SOURCE_DIR}/cmake/GenerateVineyard.cmake"
               "${PROJECT_SOURCE_DIR}/cmake/GenerateVineyardJava.cmake"
               "${PROJECT_SOURCE_DIR}/cmake/DetermineImplicitIncludes.cmake"
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/vineyard
+              DESTINATION ${CMAKE_INSTALL_DIR}
 )
 install(EXPORT vineyard-targets
         FILE vineyard-targets.cmake
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/vineyard
+        DESTINATION ${CMAKE_INSTALL_DIR}
 )
 
 # build docs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,9 +168,6 @@ else()
     set(HAVE_FLAG_STD_CXX14 TRUE)
 endif()
 
-set(CMAKE_INSTALL_DIR lib/cmake/vineyard CACHE STRING
-    "The subdirectory where CMake package config files should be installed")
-
 macro(find_apache_arrow)
     # workaround for: https://issues.apache.org/jira/browse/ARROW-11836
     if(NOT BUILD_VINEYARD_PYPI_PACKAGES)
@@ -793,11 +790,11 @@ install(FILES "${PROJECT_BINARY_DIR}/vineyard-config.cmake"
               "${PROJECT_SOURCE_DIR}/cmake/GenerateVineyard.cmake"
               "${PROJECT_SOURCE_DIR}/cmake/GenerateVineyardJava.cmake"
               "${PROJECT_SOURCE_DIR}/cmake/DetermineImplicitIncludes.cmake"
-              DESTINATION ${CMAKE_INSTALL_DIR}
+              DESTINATION lib/cmake/vineyard
 )
 install(EXPORT vineyard-targets
         FILE vineyard-targets.cmake
-        DESTINATION ${CMAKE_INSTALL_DIR}
+        DESTINATION lib/cmake/vineyard
 )
 
 # build docs


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

Fixes CI failed on [GraphScope](https://github.com/alibaba/GraphScope/runs/6083691703?check_suite_focus=true)

Follow [CMAKE Doc](https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html)

> LIBDIR: object code libraries (lib or lib64) 
                 On Debian, this may be lib/multiarch-tuple when CMAKE_INSTALL_PREFIX is /usr

I'm not sure whether has a better way to fix it. Welcome any comments.


<!-- Please give a short brief about these changes. -->


Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

