### PR TITLE
Adapt the parsing in code generator to latest libclang.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,6 @@
 compile_commands.json
 cmake-build-debug
 
-# core dump
-core
-
 # for python packaging
 /dist/
 *.egg-info/

--- a/python/vineyard/core/codegen/parsing.py
+++ b/python/vineyard/core/codegen/parsing.py
@@ -631,6 +631,10 @@ def generate_parsing_flags(
             # strip flags
             flags = strip_flags(list(commands[0].arguments)[1:-1])
 
+            # adapts to libclang v14.0.1
+            if flags and flags[-1] == '--':
+                flags.pop(-1)
+
             # NB: even use compilation database we still needs to include the
             # system includes, since we `-nostdinc{++}`.
             if system_includes:


### PR DESCRIPTION

What do these changes do?
-------------------------

Fixes CI failure in https://github.com/v6d-io/v6d/actions/runs/2214966517


