### PR TITLE
Fixes the compute of iv/ov num

### DIFF
--- a/modules/graph/fragment/arrow_fragment.h
+++ b/modules/graph/fragment/arrow_fragment.h
@@ -120,24 +120,18 @@ class BasicArrowFragmentBuilder
       tg.AddTask(fn, std::ref(client));
     }
 
-    std::atomic<size_t> ie_num, oe_num;
-    ie_num.store(0);
-    oe_num.store(0);
-
     for (label_id_t i = 0; i < this->vertex_label_num_; ++i) {
       for (label_id_t j = 0; j < this->edge_label_num_; ++j) {
-        auto fn = [this, i, j, &ie_num, &oe_num](Client& client) {
+        auto fn = [this, i, j](Client& client) {
           if (this->directed_) {
             vineyard::FixedSizeBinaryArrayBuilder ie_builder(client,
                                                              ie_lists_[i][j]);
             this->set_ie_lists_(i, j, ie_builder.Seal(client));
-            ie_num.fetch_add(ie_lists_[i][j]->length());
           }
           {
             vineyard::FixedSizeBinaryArrayBuilder oe_builder(client,
                                                              oe_lists_[i][j]);
             this->set_oe_lists_(i, j, oe_builder.Seal(client));
-            oe_num.fetch_add(oe_lists_[i][j]->length());
           }
           if (this->directed_) {
             vineyard::NumericArrayBuilder<int64_t> ieo(client,
@@ -157,8 +151,6 @@ class BasicArrowFragmentBuilder
 
     tg.TakeResults();
 
-    this->set_ienum_(ie_num.load());
-    this->set_oenum_(oe_num.load());
     this->set_vm_ptr_(vm_ptr_);
 
     this->set_oid_type(type_name<oid_t>());

--- a/modules/graph/fragment/arrow_fragment.vineyard-mod
+++ b/modules/graph/fragment/arrow_fragment.vineyard-mod
@@ -176,6 +176,18 @@ class [[vineyard]] ArrowFragment
 
     // init pointers for arrays and tables
     initPointers();
+
+    // init edge numbers
+    oenum_ = 0;
+    ienum_ = 0;
+    for (label_id_t i = 0; i < vertex_label_num_; i++) {
+      for (auto& v : InnerVertices(i)) {
+        for (label_id_t j = 0; j < edge_label_num_; j++) {
+          oenum_ += GetLocalOutDegree(v, j);
+          ienum_ += GetLocalInDegree(v, j);
+        }
+      }
+    }
   }
 
   fid_t fid() const { return fid_; }
@@ -999,20 +1011,15 @@ class [[vineyard]] ArrowFragment
     }
 
     // Extra ie_list, oe_list, ie_offset_list, oe_offset_list
-    std::atomic<size_t> ie_num, oe_num;
-    ie_num.store(builder.ienum_);
-    oe_num.store(builder.oenum_);
-
     for (label_id_t i = 0; i < total_vertex_label_num; ++i) {
       for (label_id_t j = 0; j < total_edge_label_num; ++j) {
-        auto fn = [this, &builder, i, j, &ie_num, &oe_num, &ie_lists, &oe_lists,
+        auto fn = [this, &builder, i, j, &ie_lists, &oe_lists,
                    &ie_offsets_lists, &oe_offsets_lists](Client& client) {
           if (directed_) {
             if (!(i < vertex_label_num_ && j < edge_label_num_)) {
               vineyard::FixedSizeBinaryArrayBuilder ie_builder(client,
                                                                ie_lists[i][j]);
               builder.set_ie_lists_(i, j, ie_builder.Seal(client));
-              ie_num.fetch_add(ie_lists[i][j]->length());
             }
             vineyard::NumericArrayBuilder<int64_t> ieo_builder(
                 client, ie_offsets_lists[i][j]);
@@ -1022,7 +1029,6 @@ class [[vineyard]] ArrowFragment
             vineyard::FixedSizeBinaryArrayBuilder oe_builder(client,
                                                              oe_lists[i][j]);
             builder.set_oe_lists_(i, j, oe_builder.Seal(client));
-            oe_num.fetch_add(oe_lists[i][j]->length());
           }
           vineyard::NumericArrayBuilder<int64_t> oeo_builder(
               client, oe_offsets_lists[i][j]);
@@ -1036,8 +1042,6 @@ class [[vineyard]] ArrowFragment
     // wait all
     tg.TakeResults();
 
-    builder.set_ienum_(ie_num.load());
-    builder.set_oenum_(oe_num.load());
     builder.set_vm_ptr_(vm_ptr);
 
     return builder.Seal(client)->id();
@@ -1443,20 +1447,15 @@ class [[vineyard]] ArrowFragment
     }
 
     // Extra ie_list, oe_list, ie_offset_list, oe_offset_list
-    std::atomic<size_t> ie_num, oe_num;
-    ie_num.store(builder.ienum_);
-    oe_num.store(builder.oenum_);
-
     for (label_id_t i = 0; i < vertex_label_num_; ++i) {
       for (label_id_t j = 0; j < extra_edge_label_num; ++j) {
-        auto fn = [this, &builder, i, j, &ie_num, &oe_num, &ie_lists, &oe_lists,
+        auto fn = [this, &builder, i, j, &ie_lists, &oe_lists,
                    &ie_offsets_lists, &oe_offsets_lists](Client& client) {
           label_id_t edge_label_id = edge_label_num_ + j;
           if (directed_) {
             vineyard::FixedSizeBinaryArrayBuilder ie_builder(client,
                                                              ie_lists[i][j]);
             builder.set_ie_lists_(i, edge_label_id, ie_builder.Seal(client));
-            ie_num.fetch_add(ie_lists[i][j]->length());
 
             vineyard::NumericArrayBuilder<int64_t> ieo_builder(
                 client, ie_offsets_lists[i][j]);
@@ -1466,7 +1465,6 @@ class [[vineyard]] ArrowFragment
           vineyard::FixedSizeBinaryArrayBuilder oe_builder(client,
                                                            oe_lists[i][j]);
           builder.set_oe_lists_(i, edge_label_id, oe_builder.Seal(client));
-          oe_num.fetch_add(oe_lists[i][j]->length());
 
           vineyard::NumericArrayBuilder<int64_t> oeo_builder(
               client, oe_offsets_lists[i][j]);
@@ -1498,9 +1496,6 @@ class [[vineyard]] ArrowFragment
       }
     }
     tg.TakeResults();
-
-    builder.set_ienum_(ie_num.load());
-    builder.set_oenum_(oe_num.load());
 
     return builder.Seal(client)->id();
   }
@@ -1684,9 +1679,6 @@ class [[vineyard]] ArrowFragment
     }
 
     if (directed_) {
-      std::atomic<size_t> oe_num;
-      oe_num.store(0);
-
       bool is_multigraph = is_multigraph_;
       directedCSR2Undirected(oe_lists, oe_offsets_lists, concurrency,
                              is_multigraph);
@@ -1696,14 +1688,12 @@ class [[vineyard]] ArrowFragment
           vineyard::FixedSizeBinaryArrayBuilder oe_builder(client,
                                                            oe_lists[i][j]);
           builder.set_oe_lists_(i, j, oe_builder.Seal(client));
-          oe_num.fetch_add(oe_lists[i][j]->length());
 
           vineyard::NumericArrayBuilder<int64_t> oeo_builder(
               client, oe_offsets_lists[i][j]);
           builder.set_oe_offsets_lists_(i, j, oeo_builder.Seal(client));
         }
       }
-      builder.set_oenum_(oe_num.load());
       builder.set_is_multigraph_(is_multigraph);
     }
 
@@ -1903,7 +1893,7 @@ class [[vineyard]] ArrowFragment
   [[shared]] bool is_multigraph_;
   [[shared]] property_graph_types::LABEL_ID_TYPE vertex_label_num_;
   [[shared]] property_graph_types::LABEL_ID_TYPE edge_label_num_;
-  [[shared]] size_t oenum_, ienum_;
+  size_t oenum_, ienum_;  // FIXME: should be pre-computable
 
   [[shared]] String oid_type, vid_type;
 

--- a/modules/graph/test/arrow_fragment_test.cc
+++ b/modules/graph/test/arrow_fragment_test.cc
@@ -55,6 +55,11 @@ void WriteOut(vineyard::Client& client, const grape::CommSpec& comm_spec,
     auto mg_schema = vineyard::MaxGraphSchema(schema);
     mg_schema.DumpToFile("/tmp/" + std::to_string(fragment_group_id) + ".json");
 
+    LOG(INFO) << "graph total node number: " << frag->GetTotalNodesNum();
+    LOG(INFO) << "fragment edge number: " << frag->GetEdgeNum();
+    LOG(INFO) << "fragment in edge number: " << frag->GetInEdgeNum();
+    LOG(INFO) << "fragment out edge number: " << frag->GetOutEdgeNum();
+
     LOG(INFO) << "[worker-" << comm_spec.worker_id()
               << "] loaded graph to vineyard: " << ObjectIDToString(frag_id)
               << " ...";


### PR DESCRIPTION

What do these changes do?
-------------------------

The `{ie,oe}_lists` includes edges for outer vertices as well.

This pull revert the changes in #698 and fallback to the costly solution before #698 to make it correct.

I have left a `FIXME` to make sure it be optimized later.

