### PR TITLE
Instructions for deploying airflow on Kubernetes with vineyard as backend

### DIFF
--- a/python/vineyard/contrib/airflow/etcd.yaml
+++ b/python/vineyard/contrib/airflow/etcd.yaml
@@ -1,0 +1,52 @@
+# referred from https://github.com/etcd-io/etcd/blob/master/hack/kubernetes-deploy/etcd.yml
+
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: etcd
+    etcd_node: etcd0
+  name: etcd0
+spec:
+  containers:
+  - command:
+    - /usr/local/bin/etcd
+    - --name
+    - etcd0
+    - --initial-advertise-peer-urls
+    - http://etcd0:2380
+    - --listen-peer-urls
+    - http://0.0.0.0:2380
+    - --listen-client-urls
+    - http://0.0.0.0:2379
+    - --advertise-client-urls
+    - http://etcd0:2379
+    - --initial-cluster
+    - etcd0=http://etcd0:2380
+    - --initial-cluster-state
+    - new
+    image: quay.io/coreos/etcd:v3.4.16
+    name: etcd0
+    ports:
+    - containerPort: 2379
+      name: client
+      protocol: TCP
+    - containerPort: 2380
+      name: server
+      protocol: TCP
+  restartPolicy: Always
+
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: etcd-for-vineyard
+spec:
+  ports:
+  - name: etcd-for-vineyard-port
+    port: 2379
+    protocol: TCP
+    targetPort: 2379
+  selector:
+    app: etcd

--- a/python/vineyard/contrib/airflow/values.yaml
+++ b/python/vineyard/contrib/airflow/values.yaml
@@ -1,0 +1,193 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+---
+
+# Airflow executor
+# One of: LocalExecutor, LocalKubernetesExecutor, CeleryExecutor, KubernetesExecutor, CeleryKubernetesExecutor
+executor: "CeleryExecutor"
+
+# Environment variables for all airflow containers
+env:
+- name: "VINEYARD_IPC_SOCKET"
+  value: "/var/run/vineyard/vineyard.sock"
+- name: "AIRFLOW__VINEYARD__IPC_SOCKET"
+  value: "/var/run/vineyard/vineyard.sock"
+
+# Airflow scheduler settings
+scheduler:
+  replicas: 1
+
+  # Command to use when running the Airflow scheduler (templated).
+  command: ~
+  # Args to use when running the Airflow scheduler (templated).
+  args:
+    - "bash"
+    - "-c"
+    - |
+      export AIRFLOW__CORE__XCOM_BACKEND=vineyard.contrib.airflow.xcom.VineyardXCom; \
+      python3 -m pip install vineyard vineyard-migrate airflow-provider-vineyard; \
+      exec airflow scheduler
+
+  # Launch additional containers into scheduler.
+  extraContainers:
+    - name: vineyard
+      image: libvineyard/vineyardd:v0.4.1
+      command:
+      - /bin/bash
+      - "-c"
+      - |
+        /usr/local/bin/vineyardd \
+          --size 4Gi \
+          --etcd_endpoint http://etcd-for-vineyard:2379 \
+          --etcd_prefix airflow-my-airflow-release \
+          --rpc_socket_port 9600 \
+          --socket /var/run/vineyard.sock
+      securityContext:
+        runAsUser: 0
+      env:
+        - name: MY_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: MY_HOST_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+      livenessProbe:
+        tcpSocket:
+          port: 9600
+        periodSeconds: 60
+      readinessProbe:
+        exec:
+          command:
+          - ls
+          - /var/run/vineyard.sock
+      volumeMounts:
+        - name: vineyard-socket
+          mountPath: /var/run
+        - name: shm
+          mountPath: /dev/shm
+
+  # Mount additional volumes into scheduler.
+  extraVolumeMounts:
+    - name: vineyard-socket
+      mountPath: /var/run/vineyard
+    - name: shm
+      mountPath: /dev/shm
+
+  extraVolumes:
+    - name: vineyard-socket
+      emptyDir: {}
+    - name: shm
+      emptyDir:
+        medium: Memory
+
+# Airflow Worker Config
+workers:
+  # Number of airflow celery workers in StatefulSet
+  replicas: 1
+
+  # Command to use when running Airflow workers (templated).
+  command: ~
+  # Args to use when running Airflow workers (templated).
+  args:
+    - "bash"
+    - "-c"
+    # The format below is necessary to get `helm lint` happy
+    - |-
+      export AIRFLOW__CORE__XCOM_BACKEND=vineyard.contrib.airflow.xcom.VineyardXCom; \
+      python3 -m pip install vineyard vineyard-migrate airflow-provider-vineyard; \
+      exec \
+      airflow {{ semverCompare ">=2.0.0" .Values.airflowVersion | ternary "celery worker" "worker" }}
+
+  extraContainers:
+    - name: vineyard
+      image: libvineyard/vineyardd:v0.4.1
+      command:
+      - /bin/bash
+      - "-c"
+      - |
+        id; \
+        /usr/local/bin/vineyardd \
+          --size 4Gi \
+          --etcd_endpoint http://etcd-for-vineyard:2379 \
+          --etcd_prefix airflow-my-airflow-release \
+          --rpc_socket_port 9600 \
+          --socket /var/run/vineyard.sock
+      securityContext:
+        runAsUser: 0
+      env:
+        - name: MY_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: MY_HOST_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+      livenessProbe:
+        tcpSocket:
+          port: 9600
+        periodSeconds: 60
+      readinessProbe:
+        exec:
+          command:
+          - ls
+          - /var/run/vineyard.sock
+      volumeMounts:
+        - name: vineyard-socket
+          mountPath: /var/run
+        - name: shm
+          mountPath: /dev/shm
+
+  # Mount additional volumes into worker.
+  extraVolumeMounts:
+    - name: vineyard-socket
+      mountPath: /var/run/vineyard
+    - name: shm
+      mountPath: /dev/shm
+
+  extraVolumes:
+    - name: vineyard-socket
+      emptyDir: {}
+    - name: shm
+      emptyDir:
+        medium: Memory

--- a/setup_airflow.py
+++ b/setup_airflow.py
@@ -74,6 +74,9 @@ setup(
     long_description_content_type='text/markdown',
     url='https://v6d.io',
     package_dir={'vineyard.contrib.airflow': 'python/vineyard/contrib/airflow'},
+    package_data={
+        'vineyard.contrib.airflow': ['*.yaml', '*.README'],
+    },
     packages=find_airflow_packages('python'),
     cmdclass={'bdist_wheel': bdist_wheel_plat, "install": install_plat},
     zip_safe=False,


### PR DESCRIPTION
What do these changes do?
-------------------------

- Add a reference `values.yaml` for helm deployment
- Add instructions about how to deploy airlfow on kubernetes with vineyard as the XCom backend.

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #720 

