### PR TITLE
Update wheels to different paths based on python version

### DIFF
--- a/.github/workflows/build-vineyardd-and-wheels-linux.yaml
+++ b/.github/workflows/build-vineyardd-and-wheels-linux.yaml
@@ -172,5 +172,5 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: ${{ github.event_name == 'workflow_dispatch' && github.repository == 'v6d-io/v6d' }}
         with:
-          name: vineyard-linux-wheels
+          name: vineyard-linux-wheels-${{ matrix.python }}
           path: fixed_wheels/*.whl

--- a/.github/workflows/build-vineyardd-and-wheels-macos.yaml
+++ b/.github/workflows/build-vineyardd-and-wheels-macos.yaml
@@ -196,7 +196,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-10.15]
-        python: [3.7, 3.8, 3.9, 3.10]
+        python: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2
@@ -383,5 +383,5 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: ${{ github.event_name == 'workflow_dispatch' && github.repository == 'v6d-io/v6d' }}
         with:
-          name: vineyard-macosx-wheels
+          name: vineyard-macosx-wheels-${{ matrix.python }}
           path: fixed_wheels/*.whl


### PR DESCRIPTION
What do these changes do?
-------------------------

Upload different Python versions to different zips otherwise the artifacts is unusable.

Related issue number
--------------------

N/A

