### PR TITLE
add a dep when compile on macos

### DIFF
--- a/docs/notes/install.rst
+++ b/docs/notes/install.rst
@@ -84,7 +84,7 @@ Vineyard has been tests on MacOS as well, the dependencies can be installed usin
 
 .. code:: shell
 
-    brew install apache-arrow boost gflags glog grpc protobuf mpich openssl zlib
+    brew install apache-arrow boost gflags glog grpc protobuf mpich openssl zlib autoconf
 
 Install from source
 -------------------


### PR DESCRIPTION
Signed-off-by: waruto210 <wmc314@outlook.com>

<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
add a dependency when compile on macOS

<!-- Please give a short brief about these changes. -->
add a dependency when compile on macOS


<!-- Are there any issues opened that will be resolved by merging this change? -->

no issue

