### PR TITLE
Validate the fd set between client and server

### DIFF
--- a/src/client/client.h
+++ b/src/client/client.h
@@ -93,6 +93,12 @@ class SharedMemoryManager {
   Status Mmap(int fd, int64_t map_size, uint8_t* pointer, bool readonly,
               bool realign, uint8_t** ptr);
 
+  // compute if the given fd requireds a recv_fd and mmap
+  int PreMmap(int fd);
+
+  // compute the set of fds that needs to `recv` from the server
+  void PreMmap(int fd, std::vector<int>& fds, std::set<int>& dedup);
+
   bool Exists(const uintptr_t target);
 
   bool Exists(const void* target);

--- a/src/common/util/protocols.h
+++ b/src/common/util/protocols.h
@@ -199,9 +199,10 @@ Status ReadCreateBufferRequest(const json& root, size_t& size);
 
 void WriteCreateBufferReply(const ObjectID id,
                             const std::shared_ptr<Payload>& object,
-                            std::string& msg);
+                            const int fd_to_send, std::string& msg);
 
-Status ReadCreateBufferReply(const json& root, ObjectID& id, Payload& object);
+Status ReadCreateBufferReply(const json& root, ObjectID& id, Payload& object,
+                             int& fd_sent);
 
 void WriteCreateRemoteBufferRequest(const size_t size, std::string& msg);
 
@@ -212,9 +213,10 @@ void WriteGetBuffersRequest(const std::set<ObjectID>& ids, std::string& msg);
 Status ReadGetBuffersRequest(const json& root, std::vector<ObjectID>& ids);
 
 void WriteGetBuffersReply(const std::vector<std::shared_ptr<Payload>>& objects,
-                          std::string& msg);
+                          const std::vector<int>& fd_to_send, std::string& msg);
 
-Status ReadGetBuffersReply(const json& root, std::vector<Payload>& objects);
+Status ReadGetBuffersReply(const json& root, std::vector<Payload>& objects,
+                           std::vector<int>& fd_sent);
 
 void WriteGetRemoteBuffersRequest(const std::unordered_set<ObjectID>& ids,
                                   std::string& msg);
@@ -294,10 +296,11 @@ void WriteGetNextStreamChunkRequest(const ObjectID stream_id, const size_t size,
 Status ReadGetNextStreamChunkRequest(const json& root, ObjectID& stream_id,
                                      size_t& size);
 
-void WriteGetNextStreamChunkReply(std::shared_ptr<Payload>& object,
-                                  std::string& msg);
+void WriteGetNextStreamChunkReply(std::shared_ptr<Payload> const& object,
+                                  int fd_to_send, std::string& msg);
 
-Status ReadGetNextStreamChunkReply(const json& root, Payload& object);
+Status ReadGetNextStreamChunkReply(const json& root, Payload& object,
+                                   int& fd_sent);
 
 void WritePushNextStreamChunkRequest(const ObjectID stream_id,
                                      const ObjectID chunk, std::string& msg);
@@ -412,10 +415,12 @@ Status ReadCreateBufferByPlasmaRequest(json const& root, PlasmaID& plasma_id,
 
 void WriteCreateBufferByPlasmaReply(
     ObjectID const object_id,
-    const std::shared_ptr<PlasmaPayload>& plasma_object, std::string& msg);
+    const std::shared_ptr<PlasmaPayload>& plasma_object, int fd_to_send,
+    std::string& msg);
 
 Status ReadCreateBufferByPlasmaReply(json const& root, ObjectID& object_id,
-                                     PlasmaPayload& plasma_object);
+                                     PlasmaPayload& plasma_object,
+                                     int& fd_sent);
 
 void WriteGetBuffersByPlasmaRequest(std::set<PlasmaID> const& plasma_ids,
                                     std::string& msg);

--- a/test/array_two_clients_test.cc
+++ b/test/array_two_clients_test.cc
@@ -1,0 +1,78 @@
+/** Copyright 2020-2021 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "arrow/api.h"
+#include "arrow/io/api.h"
+
+#include "basic/ds/array.h"
+#include "client/client.h"
+#include "client/ds/object_meta.h"
+#include "common/util/logging.h"
+
+using namespace vineyard;  // NOLINT(build/namespaces)
+
+int main(int argc, char** argv) {
+  if (argc < 2) {
+    printf("usage ./array_two_clients_test <ipc_socket>");
+    return 1;
+  }
+  std::string ipc_socket = std::string(argv[1]);
+
+  Client client;
+  VINEYARD_CHECK_OK(client.Connect(ipc_socket));
+  LOG(INFO) << "Connected to IPCServer: " << ipc_socket;
+
+  std::vector<double> double_array = {1.0, 7.0, 3.0, 4.0, 2.0};
+  ArrayBuilder<double> builder(client, double_array);
+  auto sealed_double_array =
+      std::dynamic_pointer_cast<Array<double>>(builder.Seal(client));
+
+  ObjectID id = sealed_double_array->id();
+  LOG(INFO) << "successfully sealed, " << ObjectIDToString(id) << " ...";
+
+  CHECK(!sealed_double_array->IsPersist());
+  CHECK(sealed_double_array->IsLocal());
+
+  VINEYARD_CHECK_OK(sealed_double_array->Persist(client));
+  LOG(INFO) << "successfully persisted...";
+
+  CHECK(sealed_double_array->IsPersist());
+  CHECK(sealed_double_array->IsLocal());
+
+  // re-establish the client
+  client.Disconnect();
+  VINEYARD_CHECK_OK(client.Connect(ipc_socket));
+
+  auto vy_double_array =
+      std::dynamic_pointer_cast<Array<double>>(client.GetObject(id));
+  LOG(INFO) << "successfully obtained...";
+
+  CHECK_EQ(sealed_double_array->size(), double_array.size());
+  CHECK_EQ(vy_double_array->size(), double_array.size());
+  for (size_t i = 0; i < double_array.size(); ++i) {
+    CHECK_EQ((*sealed_double_array)[i], double_array[i]);
+    CHECK_EQ((*vy_double_array)[i], double_array[i]);
+  }
+
+  LOG(INFO) << "Passed double array tests under two clients...";
+
+  client.Disconnect();
+
+  return 0;
+}

--- a/test/runner.py
+++ b/test/runner.py
@@ -299,6 +299,7 @@ def run_single_vineyardd_tests(tests):
         default_ipc_socket=VINEYARD_CI_IPC_SOCKET,
     ) as (_, rpc_socket_port):
         run_test(tests, 'array_test')
+        run_test(tests, 'array_two_clients_test')
         # FIXME: cannot be safely dtor after #350 and #354.
         # run_test('allocator_test')
         run_test(tests, 'arrow_data_structure_test')


### PR DESCRIPTION

What do these changes do?
-------------------------

This pull request adds a validation pass to verify the consistence of fds between client and server, before issuing the `recv_fd` calls.

This pull request prevents the client being blocked by `recv_fd` when there's actually no fd sent from the server.

Related issue number
--------------------

Fixes #748

