### PR TITLE
Maintain cold blobs in vineyardd.

### DIFF
--- a/python/vineyard/core/codegen/cpp.py
+++ b/python/vineyard/core/codegen/cpp.py
@@ -60,10 +60,10 @@ def codegen_create(class_header, class_name, class_name_elaborated, meth=False):
         function_tpl = create_tpl
 
     return function_tpl.format(
-        class_header=class_header,
-        class_name=class_name,
-        class_name_elaborated=class_name_elaborated,
-    )
+            class_header=class_header,
+            class_name=class_name,
+            class_name_elaborated=class_name_elaborated,
+            )
 
 
 ###############################################################################
@@ -171,8 +171,8 @@ construct_dict_tpl = '''
 
 
 def codegen_construct(
-    class_header, class_name, class_name_elaborated, fields, has_post_ctor, meth=False
-):
+        class_header, class_name, class_name_elaborated, fields, has_post_ctor, meth=False
+        ):
     body = []
     for field in fields:
         spec = parse_codegen_spec_from_type(field)
@@ -207,14 +207,14 @@ def codegen_construct(
             value_type = None
 
         body.append(
-            tpl.format(
-                name=name,
-                element_type=spec.element_type,
-                key_type=key_type,
-                value_type=value_type,
-                deref=spec.deref,
-            )
-        )
+                tpl.format(
+                    name=name,
+                    element_type=spec.element_type,
+                    key_type=key_type,
+                    value_type=value_type,
+                    deref=spec.deref,
+                    )
+                )
 
     if meth:
         function_tpl = construct_meth_tpl
@@ -232,14 +232,14 @@ def codegen_construct(
             post_ctor = ''
 
     code = function_tpl.format(
-        class_header=class_header,
-        class_name=class_name,
-        class_name_elaborated=class_name_elaborated,
-        construct_body=textwrap.indent(
-            ''.join(body), ' ' * function_body_indent
-        ).strip(),
-        post_construct=post_ctor,
-    )
+            class_header=class_header,
+            class_name=class_name,
+            class_name_elaborated=class_name_elaborated,
+            construct_body=textwrap.indent(
+                ''.join(body), ' ' * function_body_indent
+                ).strip(),
+            post_construct=post_ctor,
+            )
     return code
 
 
@@ -298,6 +298,8 @@ class {class_name}BaseBuilder: public ObjectBuilder {{
         this->set_sealed(true);
 
         {post_construct}
+
+        VINEYARD_CHECK_OK(client.PostSeal(__value->meta_));
         return std::static_pointer_cast<Object>(__value);
     }}
 
@@ -332,13 +334,13 @@ def codegen_field_declare(field_name, field_type, spec):
         field_type_elaborated = 'std::set<std::shared_ptr<ObjectBase>>'
     if spec.is_dict:
         field_type_elaborated = (
-            'std::map<{key_type}, std::shared_ptr<ObjectBase>>'.format(
-                key_type='typename %s::key_type' % field_type
-            )
-        )
+                'std::map<{key_type}, std::shared_ptr<ObjectBase>>'.format(
+                    key_type='typename %s::key_type' % field_type
+                    )
+                )
     return field_declare_tpl.format(
-        field_name=field_name, field_type_elaborated=field_type_elaborated
-    )
+            field_name=field_name, field_type_elaborated=field_type_elaborated
+            )
 
 
 field_assign_meta_tpl = '''
@@ -453,12 +455,12 @@ def codegen_field_assign(field_name, field_type, spec):
         element_type = '::element_type'
         element_type_name = 'typename '
     return tpl.format(
-        field_name=field_name,
-        field_type=field_type,
-        deref=spec.deref,
-        element_type=element_type,
-        element_type_name=element_type_name,
-    )
+            field_name=field_name,
+            field_type=field_type,
+            deref=spec.deref,
+            element_type=element_type,
+            element_type_name=element_type_name,
+            )
 
 
 field_setter_meta_tpl = '''
@@ -554,11 +556,11 @@ def codegen_field_setter(field_name, field_type, spec):
         field_key_type = None
         field_value_type = None
     return tpl.format(
-        field_name=field_name,
-        field_type=field_type,
-        field_key_type=field_key_type,
-        field_value_type=field_value_type,
-    )
+            field_name=field_name,
+            field_type=field_type,
+            field_key_type=field_key_type,
+            field_value_type=field_value_type,
+            )
 
 
 get_assign_meta_tpl = '''
@@ -662,13 +664,13 @@ post_construct_in_seal_tpl = '''
 
 
 def codegen_base_builder(
-    class_header,
-    class_name,
-    class_name_elaborated,
-    fields,
-    using_alias_values,
-    has_post_ctor,
-):
+        class_header,
+        class_name,
+        class_name_elaborated,
+        fields,
+        using_alias_values,
+        has_post_ctor,
+        ):
     declarations = []
     assignments = []
     get_and_assigns = []
@@ -703,16 +705,16 @@ def codegen_base_builder(
         post_ctor = ''
 
     code = base_builder_tpl.format(
-        class_header=class_header,
-        class_name=class_name,
-        class_name_elaborated=class_name_elaborated,
-        post_construct=post_ctor,
-        setters=''.join(setters).strip(),
-        assignments=''.join(assignments).strip(),
-        get_and_assign=''.join(get_and_assigns).strip(),
-        using_alias=''.join(using_alias_statements).strip(),
-        fields_declares=''.join(declarations).strip(),
-    )
+            class_header=class_header,
+            class_name=class_name,
+            class_name_elaborated=class_name_elaborated,
+            post_construct=post_ctor,
+            setters=''.join(setters).strip(),
+            assignments=''.join(assignments).strip(),
+            get_and_assign=''.join(get_and_assigns).strip(),
+            using_alias=''.join(using_alias_statements).strip(),
+            fields_declares=''.join(declarations).strip(),
+            )
     return code
 
 
@@ -773,8 +775,8 @@ using {name}StreamBase = vineyard::Stream<{name_elaborated}>;
 
 def codegen_streamable_builder(class_header, name, name_elaborated):
     code = streamable_tpl.format(
-        class_header=class_header, name=name, name_elaborated=name_elaborated
-    )
+            class_header=class_header, name=name, name_elaborated=name_elaborated
+            )
     return code
 
 
@@ -794,42 +796,42 @@ def generate_create_meth(header, name, name_elaborated):
 
 
 def generate_construct(
-    fields, header, name, name_elaborated, has_post_ctor, verbose=False
-):
+        fields, header, name, name_elaborated, has_post_ctor, verbose=False
+        ):
     if verbose:
         print('construct: ', name, [(n.type.spelling, n.spelling) for n in fields])
     return codegen_construct(header, name, name_elaborated, fields, has_post_ctor)
 
 
 def generate_construct_meth(
-    fields, header, name, name_elaborated, has_post_ctor, verbose=False
-):
+        fields, header, name, name_elaborated, has_post_ctor, verbose=False
+        ):
     if verbose:
         print('construct: ', name, [(n.type.spelling, n.spelling) for n in fields])
     return codegen_construct(
-        header, name, name_elaborated, fields, has_post_ctor, meth=True
-    )
+            header, name, name_elaborated, fields, has_post_ctor, meth=True
+            )
 
 
 def generate_base_builder(
-    fields,
-    using_alias_values,
-    header,
-    name,
-    name_elaborated,
-    has_post_ctor,
-    verbose=False,
-):
-    if verbose:
-        print('base_builder: ', name, [(n.type.spelling, n.spelling) for n in fields])
-    return codegen_base_builder(
+        fields,
+        using_alias_values,
         header,
         name,
         name_elaborated,
-        fields,
-        using_alias_values,
         has_post_ctor,
-    )
+        verbose=False,
+        ):
+    if verbose:
+        print('base_builder: ', name, [(n.type.spelling, n.spelling) for n in fields])
+    return codegen_base_builder(
+            header,
+            name,
+            name_elaborated,
+            fields,
+            using_alias_values,
+            has_post_ctor,
+            )
 
 
 def generate_getter_for_distributed(field, verbose=False):
@@ -861,8 +863,8 @@ def codegen(root_directory, content, to_reflect, source, target=None, verbose=Fa
     else:
         macro_guard_base = generated_file_path
     macro_guard = (
-        macro_guard_base.upper().replace('.', '_').replace('/', '_').replace('-', '_')
-    )
+            macro_guard_base.upper().replace('.', '_').replace('/', '_').replace('-', '_')
+            )
 
     with open(generated_file_path, 'w', encoding='utf-8') as fp:
         code_injections = []
@@ -876,14 +878,14 @@ def codegen(root_directory, content, to_reflect, source, target=None, verbose=Fa
 
             # get extend of using A = B
             using_alias_values = [
-                (n, content[t.start.offset : t.end.offset]) for (n, t) in using_alias
-            ]
+                    (n, content[t.start.offset : t.end.offset]) for (n, t) in using_alias
+                    ]
 
             # get extent of type parameters, since default value may involved.
             ts_names = [t for (t, _) in ts]  # without `typename`
             ts_name_values = [
-                content[t.start.offset : t.end.offset] for (_, t) in ts
-            ]  # with `typename`
+                    content[t.start.offset : t.end.offset] for (_, t) in ts
+                    ]  # with `typename`
 
             name_elaborated = generate_template_type(name, ts_names)
 
@@ -892,38 +894,38 @@ def codegen(root_directory, content, to_reflect, source, target=None, verbose=Fa
 
             meth_create = generate_create_meth(header, name, name_elaborated)
             meth_construct = generate_construct_meth(
-                members, header, name, name_elaborated, has_post_ctor, verbose=verbose
-            )
+                    members, header, name, name_elaborated, has_post_ctor, verbose=verbose
+                    )
             inject_blocks = [meth_create, meth_construct]
 
             mb_distributed = find_distributed_field(members)
             if mb_distributed is not None:
                 if kind == 'vineyard(streamable)':
                     raise ValueError(
-                        'A stream cannot be a distributed object: %s' % name
-                    )
+                            'A stream cannot be a distributed object: %s' % name
+                            )
                 inject_blocks.append(
-                    generate_getter_for_distributed(mb_distributed, verbose=verbose)
-                )
+                        generate_getter_for_distributed(mb_distributed, verbose=verbose)
+                        )
 
             to_inject = '%s\n private:\n' % ('\n'.join(inject_blocks))
             code_injections.append((first_member_offset, to_inject))
 
             base_builder = generate_base_builder(
-                members,
-                using_alias_values,
-                header_elaborated,
-                name,
-                name_elaborated,
-                has_post_ctor,
-                verbose=verbose,
-            )
+                    members,
+                    using_alias_values,
+                    header_elaborated,
+                    name,
+                    name_elaborated,
+                    has_post_ctor,
+                    verbose=verbose,
+                    )
             code_blocks.append((namespaces, base_builder))
 
             if kind == 'vineyard(streamable)':
                 streamable = generate_streamable(
-                    header, name, name_elaborated, verbose=verbose
-                )
+                        header, name, name_elaborated, verbose=verbose
+                        )
                 code_blocks.append((namespaces, streamable))
 
         fp.write('#ifndef %s\n' % macro_guard)

--- a/python/vineyard/core/codegen/cpp.py
+++ b/python/vineyard/core/codegen/cpp.py
@@ -60,10 +60,10 @@ def codegen_create(class_header, class_name, class_name_elaborated, meth=False):
         function_tpl = create_tpl
 
     return function_tpl.format(
-            class_header=class_header,
-            class_name=class_name,
-            class_name_elaborated=class_name_elaborated,
-            )
+        class_header=class_header,
+        class_name=class_name,
+        class_name_elaborated=class_name_elaborated,
+    )
 
 
 ###############################################################################
@@ -171,8 +171,8 @@ construct_dict_tpl = '''
 
 
 def codegen_construct(
-        class_header, class_name, class_name_elaborated, fields, has_post_ctor, meth=False
-        ):
+    class_header, class_name, class_name_elaborated, fields, has_post_ctor, meth=False
+):
     body = []
     for field in fields:
         spec = parse_codegen_spec_from_type(field)
@@ -207,14 +207,14 @@ def codegen_construct(
             value_type = None
 
         body.append(
-                tpl.format(
-                    name=name,
-                    element_type=spec.element_type,
-                    key_type=key_type,
-                    value_type=value_type,
-                    deref=spec.deref,
-                    )
-                )
+            tpl.format(
+                name=name,
+                element_type=spec.element_type,
+                key_type=key_type,
+                value_type=value_type,
+                deref=spec.deref,
+            )
+        )
 
     if meth:
         function_tpl = construct_meth_tpl
@@ -232,14 +232,14 @@ def codegen_construct(
             post_ctor = ''
 
     code = function_tpl.format(
-            class_header=class_header,
-            class_name=class_name,
-            class_name_elaborated=class_name_elaborated,
-            construct_body=textwrap.indent(
-                ''.join(body), ' ' * function_body_indent
-                ).strip(),
-            post_construct=post_ctor,
-            )
+        class_header=class_header,
+        class_name=class_name,
+        class_name_elaborated=class_name_elaborated,
+        construct_body=textwrap.indent(
+            ''.join(body), ' ' * function_body_indent
+        ).strip(),
+        post_construct=post_ctor,
+    )
     return code
 
 
@@ -298,8 +298,6 @@ class {class_name}BaseBuilder: public ObjectBuilder {{
         this->set_sealed(true);
 
         {post_construct}
-
-        VINEYARD_CHECK_OK(client.PostSeal(__value->meta_));
         return std::static_pointer_cast<Object>(__value);
     }}
 
@@ -334,13 +332,13 @@ def codegen_field_declare(field_name, field_type, spec):
         field_type_elaborated = 'std::set<std::shared_ptr<ObjectBase>>'
     if spec.is_dict:
         field_type_elaborated = (
-                'std::map<{key_type}, std::shared_ptr<ObjectBase>>'.format(
-                    key_type='typename %s::key_type' % field_type
-                    )
-                )
-    return field_declare_tpl.format(
-            field_name=field_name, field_type_elaborated=field_type_elaborated
+            'std::map<{key_type}, std::shared_ptr<ObjectBase>>'.format(
+                key_type='typename %s::key_type' % field_type
             )
+        )
+    return field_declare_tpl.format(
+        field_name=field_name, field_type_elaborated=field_type_elaborated
+    )
 
 
 field_assign_meta_tpl = '''
@@ -455,12 +453,12 @@ def codegen_field_assign(field_name, field_type, spec):
         element_type = '::element_type'
         element_type_name = 'typename '
     return tpl.format(
-            field_name=field_name,
-            field_type=field_type,
-            deref=spec.deref,
-            element_type=element_type,
-            element_type_name=element_type_name,
-            )
+        field_name=field_name,
+        field_type=field_type,
+        deref=spec.deref,
+        element_type=element_type,
+        element_type_name=element_type_name,
+    )
 
 
 field_setter_meta_tpl = '''
@@ -556,11 +554,11 @@ def codegen_field_setter(field_name, field_type, spec):
         field_key_type = None
         field_value_type = None
     return tpl.format(
-            field_name=field_name,
-            field_type=field_type,
-            field_key_type=field_key_type,
-            field_value_type=field_value_type,
-            )
+        field_name=field_name,
+        field_type=field_type,
+        field_key_type=field_key_type,
+        field_value_type=field_value_type,
+    )
 
 
 get_assign_meta_tpl = '''
@@ -664,13 +662,13 @@ post_construct_in_seal_tpl = '''
 
 
 def codegen_base_builder(
-        class_header,
-        class_name,
-        class_name_elaborated,
-        fields,
-        using_alias_values,
-        has_post_ctor,
-        ):
+    class_header,
+    class_name,
+    class_name_elaborated,
+    fields,
+    using_alias_values,
+    has_post_ctor,
+):
     declarations = []
     assignments = []
     get_and_assigns = []
@@ -705,16 +703,16 @@ def codegen_base_builder(
         post_ctor = ''
 
     code = base_builder_tpl.format(
-            class_header=class_header,
-            class_name=class_name,
-            class_name_elaborated=class_name_elaborated,
-            post_construct=post_ctor,
-            setters=''.join(setters).strip(),
-            assignments=''.join(assignments).strip(),
-            get_and_assign=''.join(get_and_assigns).strip(),
-            using_alias=''.join(using_alias_statements).strip(),
-            fields_declares=''.join(declarations).strip(),
-            )
+        class_header=class_header,
+        class_name=class_name,
+        class_name_elaborated=class_name_elaborated,
+        post_construct=post_ctor,
+        setters=''.join(setters).strip(),
+        assignments=''.join(assignments).strip(),
+        get_and_assign=''.join(get_and_assigns).strip(),
+        using_alias=''.join(using_alias_statements).strip(),
+        fields_declares=''.join(declarations).strip(),
+    )
     return code
 
 
@@ -775,8 +773,8 @@ using {name}StreamBase = vineyard::Stream<{name_elaborated}>;
 
 def codegen_streamable_builder(class_header, name, name_elaborated):
     code = streamable_tpl.format(
-            class_header=class_header, name=name, name_elaborated=name_elaborated
-            )
+        class_header=class_header, name=name, name_elaborated=name_elaborated
+    )
     return code
 
 
@@ -796,42 +794,42 @@ def generate_create_meth(header, name, name_elaborated):
 
 
 def generate_construct(
-        fields, header, name, name_elaborated, has_post_ctor, verbose=False
-        ):
+    fields, header, name, name_elaborated, has_post_ctor, verbose=False
+):
     if verbose:
         print('construct: ', name, [(n.type.spelling, n.spelling) for n in fields])
     return codegen_construct(header, name, name_elaborated, fields, has_post_ctor)
 
 
 def generate_construct_meth(
-        fields, header, name, name_elaborated, has_post_ctor, verbose=False
-        ):
+    fields, header, name, name_elaborated, has_post_ctor, verbose=False
+):
     if verbose:
         print('construct: ', name, [(n.type.spelling, n.spelling) for n in fields])
     return codegen_construct(
-            header, name, name_elaborated, fields, has_post_ctor, meth=True
-            )
+        header, name, name_elaborated, fields, has_post_ctor, meth=True
+    )
 
 
 def generate_base_builder(
-        fields,
-        using_alias_values,
-        header,
-        name,
-        name_elaborated,
-        has_post_ctor,
-        verbose=False,
-        ):
+    fields,
+    using_alias_values,
+    header,
+    name,
+    name_elaborated,
+    has_post_ctor,
+    verbose=False,
+):
     if verbose:
         print('base_builder: ', name, [(n.type.spelling, n.spelling) for n in fields])
     return codegen_base_builder(
-            header,
-            name,
-            name_elaborated,
-            fields,
-            using_alias_values,
-            has_post_ctor,
-            )
+        header,
+        name,
+        name_elaborated,
+        fields,
+        using_alias_values,
+        has_post_ctor,
+    )
 
 
 def generate_getter_for_distributed(field, verbose=False):
@@ -863,8 +861,8 @@ def codegen(root_directory, content, to_reflect, source, target=None, verbose=Fa
     else:
         macro_guard_base = generated_file_path
     macro_guard = (
-            macro_guard_base.upper().replace('.', '_').replace('/', '_').replace('-', '_')
-            )
+        macro_guard_base.upper().replace('.', '_').replace('/', '_').replace('-', '_')
+    )
 
     with open(generated_file_path, 'w', encoding='utf-8') as fp:
         code_injections = []
@@ -878,14 +876,14 @@ def codegen(root_directory, content, to_reflect, source, target=None, verbose=Fa
 
             # get extend of using A = B
             using_alias_values = [
-                    (n, content[t.start.offset : t.end.offset]) for (n, t) in using_alias
-                    ]
+                (n, content[t.start.offset : t.end.offset]) for (n, t) in using_alias
+            ]
 
             # get extent of type parameters, since default value may involved.
             ts_names = [t for (t, _) in ts]  # without `typename`
             ts_name_values = [
-                    content[t.start.offset : t.end.offset] for (_, t) in ts
-                    ]  # with `typename`
+                content[t.start.offset : t.end.offset] for (_, t) in ts
+            ]  # with `typename`
 
             name_elaborated = generate_template_type(name, ts_names)
 
@@ -894,38 +892,38 @@ def codegen(root_directory, content, to_reflect, source, target=None, verbose=Fa
 
             meth_create = generate_create_meth(header, name, name_elaborated)
             meth_construct = generate_construct_meth(
-                    members, header, name, name_elaborated, has_post_ctor, verbose=verbose
-                    )
+                members, header, name, name_elaborated, has_post_ctor, verbose=verbose
+            )
             inject_blocks = [meth_create, meth_construct]
 
             mb_distributed = find_distributed_field(members)
             if mb_distributed is not None:
                 if kind == 'vineyard(streamable)':
                     raise ValueError(
-                            'A stream cannot be a distributed object: %s' % name
-                            )
+                        'A stream cannot be a distributed object: %s' % name
+                    )
                 inject_blocks.append(
-                        generate_getter_for_distributed(mb_distributed, verbose=verbose)
-                        )
+                    generate_getter_for_distributed(mb_distributed, verbose=verbose)
+                )
 
             to_inject = '%s\n private:\n' % ('\n'.join(inject_blocks))
             code_injections.append((first_member_offset, to_inject))
 
             base_builder = generate_base_builder(
-                    members,
-                    using_alias_values,
-                    header_elaborated,
-                    name,
-                    name_elaborated,
-                    has_post_ctor,
-                    verbose=verbose,
-                    )
+                members,
+                using_alias_values,
+                header_elaborated,
+                name,
+                name_elaborated,
+                has_post_ctor,
+                verbose=verbose,
+            )
             code_blocks.append((namespaces, base_builder))
 
             if kind == 'vineyard(streamable)':
                 streamable = generate_streamable(
-                        header, name, name_elaborated, verbose=verbose
-                        )
+                    header, name, name_elaborated, verbose=verbose
+                )
                 code_blocks.append((namespaces, streamable))
 
         fp.write('#ifndef %s\n' % macro_guard)

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -115,6 +115,12 @@ Status Client::Connect() {
       "Environment variable VINEYARD_IPC_SOCKET does't exists");
 }
 
+void Client::Disconnect() {
+  std::lock_guard<std::recursive_mutex> guard(client_mutex_);
+  this->ClearCache();
+  ClientBase::Disconnect();
+}
+
 Status Client::Connect(const std::string& ipc_socket) {
   return BasicIPCClient::Connect(ipc_socket, /*bulk_store_type=*/"Normal");
 }
@@ -527,6 +533,7 @@ Status Client::GetBuffers(
       shm_->PreMmap(item.store_fd, fd_recv, fd_recv_dedup);
     }
   }
+
   if (message_in.contains("fds") && fd_sent != fd_recv) {
     json error = json::object();
     error["error"] =
@@ -820,6 +827,12 @@ Status PlasmaClient::Open(std::string const& ipc_socket) {
 
 Status PlasmaClient::Connect(const std::string& ipc_socket) {
   return BasicIPCClient::Connect(ipc_socket, /*bulk_store_type=*/"Plasma");
+}
+
+void PlasmaClient::Disconnect() {
+  std::lock_guard<std::recursive_mutex> guard(client_mutex_);
+  this->ClearCache();
+  ClientBase::Disconnect();
 }
 
 Status PlasmaClient::CreateBuffer(PlasmaID plasma_id, size_t size,

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -572,11 +572,11 @@ Status Client::PostSeal(ObjectMeta const& meta) {
 
   if (!remote_bids.empty()) {
     std::string message_out;
-    WritePinBlobsRequest(remote_bids, message_out);
+    WriteIncreaseReferenceCountRequest(remote_bids, message_out);
     RETURN_ON_ERROR(doWrite(message_out));
     json message_in;
     RETURN_ON_ERROR(doRead(message_in));
-    RETURN_ON_ERROR(ReadPinBlobsReply(message_in));
+    RETURN_ON_ERROR(ReadIncreaseReferenceCountReply(message_in));
   }
   return Status::OK();
 }

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -607,7 +607,8 @@ Status Client::DelData(const std::vector<ObjectID>& ids, const bool force,
                        const bool deep) {
   ENSURE_CONNECTED(this);
   for (auto id : ids) {
-    RETURN_ON_ERROR(Release(id));
+    // May contain duplicated blob ids.
+    VINEYARD_DISCARD(Release(id));
   }
   std::string message_out;
   WriteDelDataWithFeedbacksRequest(ids, force, deep, /*fastpath=*/false,

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -167,7 +167,6 @@ class UsageTracker : public LifeCycleTracker<ID, P, UsageTracker<ID, P, Der>> {
     if (elem == object_in_use_.end()) {
       object_in_use_[id] = std::make_shared<P>(payload);
       object_in_use_[id]->ref_cnt = 0;
-    } else {
     }
     return this->IncreaseReferenceCount(id);
   }
@@ -529,6 +528,8 @@ class Client : public BasicIPCClient,
    */
   bool IsSharedMemory(const uintptr_t target, ObjectID& object_id) const;
 
+  bool IsInUse(ObjectID const& id);
+
   /**
    * Get the allocated size for the given object.
    */
@@ -550,6 +551,8 @@ class Client : public BasicIPCClient,
   Status ShallowCopy(PlasmaID const plasma_id, ObjectID& target_id,
                      PlasmaClient& source_client);
 
+  Status Release(std::vector<ObjectID> const& ids);
+
   Status Release(ObjectID const& id) override;
 
   Status DelData(const ObjectID id, const bool force = false,
@@ -566,6 +569,8 @@ class Client : public BasicIPCClient,
 
   /// For UsageTracker only
   Status OnDelete(ObjectID const& id);
+
+  Status PostSeal(ObjectMeta const& meta_data);
 
  protected:
   Status GetDependency(ObjectID const& id, std::set<ObjectID>& bids);

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -195,9 +195,9 @@ class UsageTracker : public LifeCycleTracker<ID, P, UsageTracker<ID, P, Der>> {
   Status OnDelete(ID const& id) { return Self().OnDelete(id); }
 
   // Clear cache when re-connect a new socket.
-  void ClearCache() { 
+  void ClearCache() {
     base_t::ClearCache();
-    object_in_use_.clear(); 
+    object_in_use_.clear();
   }
 
  private:

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -171,9 +171,7 @@ class UsageTracker : public LifeCycleTracker<ID, P, UsageTracker<ID, P, Der>> {
     return this->IncreaseReferenceCount(id);
   }
 
-  Status RemoveUsage(ID const& id) { 
-    return this->DecreaseReferenceCount(id); 
-  }
+  Status RemoveUsage(ID const& id) { return this->DecreaseReferenceCount(id); }
 
   Status DeleteUsage(ID const& id) {
     auto elem = object_in_use_.find(id);

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -121,25 +121,29 @@ class SharedMemoryManager {
   std::map<uintptr_t, MmapEntry*> segments_;
 };
 
-}  // namespace detail
-
-// Track the reference count in client-side to support object RAII.
+/**
+ * @brief UsageTracker is a CRTP class optimize the LifeCycleTracker by caching
+ * the reference count and payload on client to avoid frequent IPCs like
+ * `IncreaseReferenceCountRequest` with server. It requires the derived class to
+ * implement the:
+ *  - OnRelease(ID) method to describe what will happens when ref_count reaches
+ * zero.
+ *  - OnDelete(ID) method to describe what will happens what reaches reaches
+ * zero and the object is marked as to be deleted.
+ */
 template <typename ID, typename P, typename Der>
 class UsageTracker : public LifeCycleTracker<ID, P, UsageTracker<ID, P, Der>> {
  public:
   using base_t = LifeCycleTracker<ID, P, UsageTracker<ID, P, Der>>;
   UsageTracker() {}
 
-  Status FetchAndModify(ID const& id, int64_t& ref_cnt, int64_t change) {
-    auto elem = object_in_use_.find(id);
-    if (elem != object_in_use_.end()) {
-      elem->second->ref_cnt += change;
-      ref_cnt = elem->second->ref_cnt;
-      return Status::OK();
-    }
-    return Status::ObjectNotExists();
-  }
-
+  /**
+   * @brief Fetch the blob payload from the client-side cache.
+   *
+   * @param id The object id.
+   * @param payload The payload of the object.
+   * @returns Status::OK() if the reference count is increased successfully.
+   */
   Status FetchOnLocal(ID const& id, P& payload) {
     auto elem = object_in_use_.find(id);
     if (elem != object_in_use_.end()) {
@@ -153,6 +157,12 @@ class UsageTracker : public LifeCycleTracker<ID, P, UsageTracker<ID, P, Der>> {
     return Status::ObjectNotExists();
   }
 
+  /**
+   * @brief Mark the blob in the client-side cache as sealed, to keep
+   * consistent with server on blob visibility.
+   *
+   * @param id The object id.
+   */
   Status SealUsage(ID const& id) {
     auto elem = object_in_use_.find(id);
     if (elem != object_in_use_.end()) {
@@ -162,6 +172,11 @@ class UsageTracker : public LifeCycleTracker<ID, P, UsageTracker<ID, P, Der>> {
     return Status::ObjectNotExists();
   }
 
+  /**
+   * @brief Increase the Reference Count, add it to cache if not exists.
+   *
+   * @param id The object id.
+   */
   Status AddUsage(ID const& id, P const& payload) {
     auto elem = object_in_use_.find(id);
     if (elem == object_in_use_.end()) {
@@ -171,8 +186,18 @@ class UsageTracker : public LifeCycleTracker<ID, P, UsageTracker<ID, P, Der>> {
     return this->IncreaseReferenceCount(id);
   }
 
+  /**
+   * @brief Decrease the Reference Count.
+   *
+   * @param id The object id.
+   */
   Status RemoveUsage(ID const& id) { return this->DecreaseReferenceCount(id); }
 
+  /**
+   * @brief Try to delete the blob from the client-side cache.
+   *
+   * @param id The object id.
+   */
   Status DeleteUsage(ID const& id) {
     auto elem = object_in_use_.find(id);
     if (elem != object_in_use_.end()) {
@@ -181,6 +206,25 @@ class UsageTracker : public LifeCycleTracker<ID, P, UsageTracker<ID, P, Der>> {
     }
     // May already be deleted when `ref_cnt == 0`
     return Status::OK();
+  }
+
+  void ClearCache() {
+    base_t::ClearCache();
+    object_in_use_.clear();
+  }
+
+ public:
+  /**
+   * @brief change the reference count of the object on the client-side cache.
+   */
+  Status FetchAndModify(ID const& id, int64_t& ref_cnt, int64_t change) {
+    auto elem = object_in_use_.find(id);
+    if (elem != object_in_use_.end()) {
+      elem->second->ref_cnt += change;
+      ref_cnt = elem->second->ref_cnt;
+      return Status::OK();
+    }
+    return Status::ObjectNotExists();
   }
 
   Status OnRelease(ID const& id) {
@@ -193,17 +237,15 @@ class UsageTracker : public LifeCycleTracker<ID, P, UsageTracker<ID, P, Der>> {
 
   Status OnDelete(ID const& id) { return Self().OnDelete(id); }
 
-  // Clear cache when re-connect a new socket.
-  void ClearCache() {
-    base_t::ClearCache();
-    object_in_use_.clear();
-  }
-
  private:
   inline Der& Self() { return static_cast<Der&>(*this); }
   // Track the objects' usage.
   std::unordered_map<ID, std::shared_ptr<P>> object_in_use_;
+
+  friend class LifeCycleTracker<ID, P, Der>;
 };
+
+}  // namespace detail
 
 class BasicIPCClient : public ClientBase {
  public:
@@ -246,7 +288,7 @@ class PlasmaClient;
  *        and manipulate objects in vineyard.
  */
 class Client : public BasicIPCClient,
-               public UsageTracker<ObjectID, Payload, Client> {
+               protected detail::UsageTracker<ObjectID, Payload, Client> {
  public:
   Client() {}
 
@@ -528,6 +570,11 @@ class Client : public BasicIPCClient,
    */
   bool IsSharedMemory(const uintptr_t target, ObjectID& object_id) const;
 
+  /**
+   * @brief Check if the blob is a cold blob (no client is using it).
+   *
+   * Return true if the the blob is in-use.
+   */
   bool IsInUse(ObjectID const& id);
 
   /**
@@ -551,28 +598,68 @@ class Client : public BasicIPCClient,
   Status ShallowCopy(PlasmaID const plasma_id, ObjectID& target_id,
                      PlasmaClient& source_client);
 
+  /**
+   * @brief Decrease the reference count of the object. It will trigger
+   * `OnRelease` behavior when reference count reaches zero. See UsageTracker.
+   */
   Status Release(std::vector<ObjectID> const& ids);
 
   Status Release(ObjectID const& id) override;
 
+  /**
+   * @brief Delete metadata in vineyard. When the object is a used by other
+   * object, it will be deleted only when the `force` parameter is specified.
+   *
+   * @param id The ID to delete.
+   * @param force Whether to delete the object forcely. Forcely delete an object
+   *        means the object and objects which use this object will be delete.
+   *        Default is false.
+   * @param deep Whether to delete the member of this object. Default is true.
+   *        Note that when deleting object which has *direct* blob members, the
+   *        processing on those blobs yields a "deep" behavior.
+   *
+   * @return Status that indicates whether the delete action has succeeded.
+   */
   Status DelData(const ObjectID id, const bool force = false,
                  const bool deep = true);
-
+  /**
+   * @brief Delete multiple metadatas in vineyard.
+   *
+   * @param ids The IDs to delete.
+   * @param force Whether to delete the object forcely. Forcely delete an object
+   *        means the object and objects which use this object will be delete.
+   *        Default is false.
+   * @param deep Whether to delete the member of this object. Default is true.
+   *        Note that when deleting objects which have *direct* blob members,
+   *        the processing on those blobs yields a "deep" behavior.
+   *
+   * @return Status that indicates whether the delete action has succeeded.
+   */
   Status DelData(const std::vector<ObjectID>& ids, const bool force = false,
                  const bool deep = true);
 
-  /// For UsageTracker only
-  Status OnFetch(ObjectID const& id, std::shared_ptr<Payload> const& payload);
-
-  /// For UsageTracker only
+ protected:
+  /**
+   * @brief Required by `UsageTracker`. When reference count reaches zero, send
+   * the `ReleaseRequest` to server.
+   */
   Status OnRelease(ObjectID const& id);
 
-  /// For UsageTracker only
+  /**
+   * @brief Required by `UsageTracker`. Currently, the deletion does not respect
+   * the reference count, it will send the DelData to server and do the deletion
+   * forcely.
+   */
   Status OnDelete(ObjectID const& id);
 
+  /**
+   * @brief Increase reference count after a new object is sealed.
+   */
   Status PostSeal(ObjectMeta const& meta_data);
 
- protected:
+  /**
+   * @brief Send request to server to get all underlying blobs of a object.
+   */
   Status GetDependency(ObjectID const& id, std::set<ObjectID>& bids);
 
   Status CreateBuffer(const size_t size, ObjectID& id, Payload& payload,
@@ -615,16 +702,22 @@ class Client : public BasicIPCClient,
    */
   Status DropBuffer(const ObjectID id, const int fd);
 
+  /**
+   * @brief mark the blob as sealed to control the visibility of a blob, client
+   * can never `Get` an unsealed blob.
+   */
   Status Seal(ObjectID const& object_id);
 
  private:
   friend class Blob;
   friend class BlobWriter;
+  friend class ObjectBuilder;
+  friend class detail::UsageTracker<ObjectID, Payload, Client>;
 };
 
 class PlasmaClient
     : public BasicIPCClient,
-      public UsageTracker<PlasmaID, PlasmaPayload, PlasmaClient> {
+      public detail::UsageTracker<PlasmaID, PlasmaPayload, PlasmaClient> {
  public:
   PlasmaClient() {}
 
@@ -675,9 +768,6 @@ class PlasmaClient
   Status GetPayloads(std::set<PlasmaID> const& plasma_ids,
                      std::map<PlasmaID, PlasmaPayload>& plasma_payloads);
 
-  /**
-   * Used only for integration.
-   */
   Status GetBuffers(
       std::set<PlasmaID> const& plasma_ids,
       std::map<PlasmaID, std::shared_ptr<arrow::Buffer>>& buffers);
@@ -688,24 +778,40 @@ class PlasmaClient
   Status ShallowCopy(ObjectID const id, std::set<PlasmaID>& target_pids,
                      Client& source_client);
 
+  /**
+   * @brief mark the blob as sealed to control the visibility of a blob, client
+   * can never `Get` an unsealed blob.
+   */
   Status Seal(PlasmaID const& object_id);
 
+  /**
+   * @brief Decrease the reference count of a plasma object. It will trigger
+   * `OnRelease` behavior when reference count reaches zero. See UsageTracker.
+   */
   Status Release(PlasmaID const& id);
 
+  /**
+   * @brief Delete a plasma object. It will trigger `OnDelete` behavior when
+   * reference count reaches zero. See UsageTracker.
+   */
   Status Delete(PlasmaID const& id);
 
-  /// For UsageTracker only
-  Status OnFetch(PlasmaID const& id,
-                 std::shared_ptr<PlasmaPayload> const& plasma_payload);
-
-  /// For UsageTracker only
+ protected:
+  /**
+   * @brief Required by `UsageTracker`. When reference count reaches zero, send
+   * the `ReleaseRequest` to server.
+   */
   Status OnRelease(PlasmaID const& id);
 
-  /// For UsageTracker only
+  /**
+   * @brief Required by `UsageTracker`. Deletion will be defered until its
+   * reference count reaches zero.
+   */
   Status OnDelete(PlasmaID const& id);
 
- private:
-  using ClientBase::Release;  // avoid warning
+  using ClientBase::Release;
+
+  friend class detail::UsageTracker<PlasmaID, PlasmaPayload, PlasmaClient>;
 };
 
 }  // namespace vineyard

--- a/src/client/client_base.cc
+++ b/src/client/client_base.cc
@@ -110,14 +110,7 @@ Status ClientBase::SyncMetaData() {
 
 Status ClientBase::DelData(const ObjectID id, const bool force,
                            const bool deep) {
-  ENSURE_CONNECTED(this);
-  std::string message_out;
-  WriteDelDataRequest(id, force, deep, false, message_out);
-  RETURN_ON_ERROR(doWrite(message_out));
-  json message_in;
-  RETURN_ON_ERROR(doRead(message_in));
-  RETURN_ON_ERROR(ReadDelDataReply(message_in));
-  return Status::OK();
+  return DelData(std::vector<ObjectID>{id}, force, deep);
 }
 
 Status ClientBase::DelData(const std::vector<ObjectID>& ids, const bool force,

--- a/src/client/client_base.h
+++ b/src/client/client_base.h
@@ -140,7 +140,7 @@ class ClientBase {
    * @param force Whether to delete the object forcely. Forcely delete an object
    *        means the object and objects which use this object will be delete.
    *        Default is false.
-   * @param deep Whether to delete the member of this object. Default is false.
+   * @param deep Whether to delete the member of this object. Default is true.
    *        Note that when deleting object which has *direct* blob members, the
    *        processing on those blobs yields a "deep" behavior.
    *
@@ -155,7 +155,7 @@ class ClientBase {
    * @param force Whether to delete the object forcely. Forcely delete an object
    *        means the object and objects which use this object will be delete.
    *        Default is false.
-   * @param deep Whether to delete the member of this object. Default is false.
+   * @param deep Whether to delete the member of this object. Default is true.
    *        Note that when deleting objects which have *direct* blob members,
    *        the processing on those blobs yields a "deep" behavior.
    *

--- a/src/client/ds/i_object.cc
+++ b/src/client/ds/i_object.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "client/ds/i_object.h"
 
+#include "client/client.h"
 #include "client/client_base.h"
 
 namespace vineyard {
@@ -57,7 +58,9 @@ bool const Object::IsPersist() const {
 bool const Object::IsGlobal() const { return meta_.IsGlobal(); }
 
 std::shared_ptr<Object> ObjectBuilder::Seal(Client& client) {
-  return this->_Seal(client);
+  auto object = this->_Seal(client);
+  VINEYARD_CHECK_OK(client.PostSeal(object->meta()));
+  return object;
 }
 
 }  // namespace vineyard

--- a/src/common/memory/payload.cc
+++ b/src/common/memory/payload.cc
@@ -32,7 +32,6 @@ void Payload::ToJSON(json& tree) const {
   tree["data_size"] = data_size;
   tree["map_size"] = map_size;
   tree["pointer"] = reinterpret_cast<uintptr_t>(pointer);
-  tree["pointer"] = reinterpret_cast<uintptr_t>(pointer);
   tree["is_sealed"] = is_sealed;
   tree["is_owner"] = is_owner;
 }
@@ -42,7 +41,6 @@ void Payload::FromJSON(const json& tree) {
   store_fd = tree["store_fd"].get<int>();
   data_offset = tree["data_offset"].get<ptrdiff_t>();
   data_size = tree["data_size"].get<int64_t>();
-  map_size = tree["map_size"].get<int64_t>();
   map_size = tree["map_size"].get<int64_t>();
   pointer = reinterpret_cast<uint8_t*>(tree["pointer"].get<uintptr_t>());
   is_sealed = tree["is_sealed"].get<bool>();

--- a/src/common/memory/payload.cc
+++ b/src/common/memory/payload.cc
@@ -32,6 +32,7 @@ void Payload::ToJSON(json& tree) const {
   tree["data_size"] = data_size;
   tree["map_size"] = map_size;
   tree["pointer"] = reinterpret_cast<uintptr_t>(pointer);
+  tree["pointer"] = reinterpret_cast<uintptr_t>(pointer);
   tree["is_sealed"] = is_sealed;
   tree["is_owner"] = is_owner;
 }
@@ -41,6 +42,7 @@ void Payload::FromJSON(const json& tree) {
   store_fd = tree["store_fd"].get<int>();
   data_offset = tree["data_offset"].get<ptrdiff_t>();
   data_size = tree["data_size"].get<int64_t>();
+  map_size = tree["map_size"].get<int64_t>();
   map_size = tree["map_size"].get<int64_t>();
   pointer = reinterpret_cast<uint8_t*>(tree["pointer"].get<uintptr_t>());
   is_sealed = tree["is_sealed"].get<bool>();
@@ -67,8 +69,8 @@ void PlasmaPayload::ToJSON(json& tree) const {
   tree["data_offset"] = data_offset;
   tree["data_size"] = data_size;
   tree["map_size"] = map_size;
-  tree["pointer"] = reinterpret_cast<uintptr_t>(pointer);
   tree["ref_cnt"] = ref_cnt;
+  tree["pointer"] = reinterpret_cast<uintptr_t>(pointer);
   tree["is_sealed"] = is_sealed;
   tree["is_owner"] = is_owner;
 }
@@ -81,8 +83,8 @@ void PlasmaPayload::FromJSON(const json& tree) {
   data_offset = tree["data_offset"].get<ptrdiff_t>();
   data_size = tree["data_size"].get<int64_t>();
   map_size = tree["map_size"].get<int64_t>();
-  pointer = reinterpret_cast<uint8_t*>(tree["pointer"].get<uintptr_t>());
   ref_cnt = tree["ref_cnt"].get<int64_t>();
+  pointer = reinterpret_cast<uint8_t*>(tree["pointer"].get<uintptr_t>());
   is_sealed = tree["is_sealed"].get<bool>();
   is_owner = tree["is_owner"].get<bool>();
   pointer = nullptr;

--- a/src/common/memory/payload.h
+++ b/src/common/memory/payload.h
@@ -32,6 +32,7 @@ struct Payload {
   ptrdiff_t data_offset;
   int64_t data_size;
   int64_t map_size;
+  int64_t ref_cnt;
   uint8_t* pointer;  // the direct pointer for this blob on the server side
   bool is_sealed;
   bool is_owner;
@@ -43,6 +44,7 @@ struct Payload {
         data_offset(0),
         data_size(0),
         map_size(0),
+        ref_cnt(0),
         pointer(nullptr),
         is_sealed(0),
         is_owner(1) {}
@@ -55,6 +57,7 @@ struct Payload {
         data_offset(offset),
         data_size(size),
         map_size(msize),
+        ref_cnt(0),
         pointer(ptr),
         is_sealed(0),
         is_owner(1) {}
@@ -67,6 +70,7 @@ struct Payload {
         data_offset(offset),
         data_size(size),
         map_size(msize),
+        ref_cnt(0),
         pointer(ptr),
         is_sealed(0),
         is_owner(1) {}
@@ -107,38 +111,33 @@ struct Payload {
 struct PlasmaPayload : public Payload {
   PlasmaID plasma_id;
   int64_t plasma_size;
-  int64_t ref_cnt;
 
-  PlasmaPayload() : Payload(), plasma_id(), plasma_size(0), ref_cnt(0) {}
+  PlasmaPayload() : Payload(), plasma_id(), plasma_size(0) {}
 
   PlasmaPayload(PlasmaID plasma_id, ObjectID object_id, int64_t plasma_size,
                 int64_t size, uint8_t* ptr, int fd, int64_t msize,
                 ptrdiff_t offset)
       : Payload(object_id, size, ptr, fd, msize, offset),
         plasma_id(plasma_id),
-        plasma_size(plasma_size),
-        ref_cnt(0) {}
+        plasma_size(plasma_size) {}
 
   PlasmaPayload(PlasmaID plasma_id, ObjectID object_id, int64_t plasma_size,
                 int64_t size, uint8_t* ptr, int fd, int arena_fd, int64_t msize,
                 ptrdiff_t offset)
       : Payload(object_id, size, ptr, fd, arena_fd, msize, offset),
         plasma_id(plasma_id),
-        plasma_size(plasma_size),
-        ref_cnt(0) {}
+        plasma_size(plasma_size) {}
 
   PlasmaPayload(PlasmaID plasma_id, int64_t size, uint8_t* ptr, int fd,
                 int64_t msize, ptrdiff_t offset)
       : Payload(EmptyBlobID(), size, ptr, fd, msize, offset),
         plasma_id(plasma_id),
-        plasma_size(0),
-        ref_cnt(0) {}
+        plasma_size(0) {}
 
   explicit PlasmaPayload(Payload _p)
       : Payload(_p),
         plasma_id(PlasmaIDFromString(ObjectIDToString(_p.object_id))),
-        plasma_size(0),
-        ref_cnt(0) {}
+        plasma_size(0) {}
 
   static std::shared_ptr<PlasmaPayload> MakeEmpty() {
     static std::shared_ptr<PlasmaPayload> payload =

--- a/src/common/util/lifecycle.h
+++ b/src/common/util/lifecycle.h
@@ -74,7 +74,7 @@ class LifeCycleTracker {
     return Status::OK();
   }
 
-  void ClearCache() { 
+  void ClearCache() {
     for (auto const& id : pending_to_delete_) {
       VINEYARD_CHECK_OK(Self().OnDelete(id));
     }

--- a/src/common/util/lifecycle.h
+++ b/src/common/util/lifecycle.h
@@ -55,8 +55,8 @@ class LifeCycleTracker {
 
     VINEYARD_CHECK_OK(Self().OnRelease(id));
 
-    if (pending_to_delete.count(id) > 0) {
-      pending_to_delete.erase(id);
+    if (pending_to_delete_.count(id) > 0) {
+      pending_to_delete_.erase(id);
       VINEYARD_CHECK_OK(Self().OnDelete(id));
     }
     return Status::OK();
@@ -67,7 +67,7 @@ class LifeCycleTracker {
     int64_t ref_cnt = 0;
     RETURN_ON_ERROR(FetchAndModify(id, ref_cnt, 0));
     if (ref_cnt != 0) {
-      pending_to_delete.emplace(id);
+      pending_to_delete_.emplace(id);
     } else {
       VINEYARD_CHECK_OK(Self().OnDelete(id));
     }
@@ -80,14 +80,14 @@ class LifeCycleTracker {
   }
 
   bool IsInDeletion(ID const& id) {
-    return pending_to_delete.find(id) != pending_to_delete.end();
+    return pending_to_delete_.find(id) != pending_to_delete_.end();
   }
 
  private:
   inline Der& Self() { return static_cast<Der&>(*this); }
   /// Cache the objects that client wants to delete but `ref_count > 0`
   /// Race condition should be settled by Der.
-  std::unordered_set<ID> pending_to_delete;
+  std::unordered_set<ID> pending_to_delete_;
 };
 
 }  // namespace vineyard

--- a/src/common/util/lifecycle.h
+++ b/src/common/util/lifecycle.h
@@ -74,6 +74,13 @@ class LifeCycleTracker {
     return Status::OK();
   }
 
+  void ClearCache() { 
+    for (auto const& id : pending_to_delete_) {
+      VINEYARD_CHECK_OK(Self().OnDelete(id));
+    }
+    pending_to_delete_.clear();
+  }
+
  protected:
   Status FetchAndModify(ID const& id, int64_t& ref_cnt, int64_t change) {
     return Self().FetchAndModify(id, ref_cnt, change);

--- a/src/common/util/protocols.cc
+++ b/src/common/util/protocols.cc
@@ -137,8 +137,8 @@ CommandType ParseCommandType(const std::string& str_type) {
     return CommandType::DelDataWithFeedbacksRequest;
   } else if (str_type == "is_in_use_request") {
     return CommandType::IsInUseRequest;
-  } else if (str_type == "pin_blobs_request") {
-    return CommandType::PinBlobsRequest;
+  } else if (str_type == "increase_reference_count_request") {
+    return CommandType::IncreaseReferenceCountRequest;
   } else {
     return CommandType::NullCommand;
   }
@@ -1544,27 +1544,29 @@ Status ReadIsInUseReply(json const& root, bool& is_in_use) {
   return Status::OK();
 }
 
-void WritePinBlobsRequest(const std::vector<ObjectID>& ids, std::string& msg) {
+void WriteIncreaseReferenceCountRequest(const std::vector<ObjectID>& ids,
+                                        std::string& msg) {
   json root;
-  root["type"] = "pin_blobs_request";
+  root["type"] = "increase_reference_count_request";
   root["ids"] = std::vector<ObjectID>{ids};
   encode_msg(root, msg);
 }
 
-Status ReadPinBlobsRequest(json const& root, std::vector<ObjectID>& ids) {
-  RETURN_ON_ASSERT(root["type"] == "pin_blobs_request");
+Status ReadIncreaseReferenceCountRequest(json const& root,
+                                         std::vector<ObjectID>& ids) {
+  RETURN_ON_ASSERT(root["type"] == "increase_reference_count_request");
   ids = root["ids"].get_to(ids);
   return Status::OK();
 }
 
-void WritePinBlobsReply(std::string& msg) {
+void WriteIncreaseReferenceCountReply(std::string& msg) {
   json root;
-  root["type"] = "pin_blobs_reply";
+  root["type"] = "increase_reference_count_reply";
   encode_msg(root, msg);
 }
 
-Status ReadPinBlobsReply(json const& root) {
-  RETURN_ON_ASSERT(root["type"] == "pin_blobs_reply");
+Status ReadIncreaseReferenceCountReply(json const& root) {
+  RETURN_ON_ASSERT(root["type"] == "increase_reference_count_reply");
   return Status::OK();
 }
 

--- a/src/common/util/protocols.cc
+++ b/src/common/util/protocols.cc
@@ -135,6 +135,10 @@ CommandType ParseCommandType(const std::string& str_type) {
     return CommandType::ReleaseRequest;
   } else if (str_type == "del_data_with_feedbacks_request") {
     return CommandType::DelDataWithFeedbacksRequest;
+  } else if (str_type == "is_in_use_request") {
+    return CommandType::IsInUseRequest;
+  } else if (str_type == "pin_blobs_request") {
+    return CommandType::PinBlobsRequest;
   } else {
     return CommandType::NullCommand;
   }
@@ -1510,6 +1514,57 @@ Status ReadDelDataWithFeedbacksReply(json const& root,
                                      std::vector<ObjectID>& deleted_bids) {
   RETURN_ON_ASSERT(root["type"] == "del_data_with_feedbacks_reply");
   deleted_bids = root["deleted_bids"].get_to(deleted_bids);
+  return Status::OK();
+}
+
+// IsInUse
+void WriteIsInUseRequest(const ObjectID& id, std::string& msg) {
+  json root;
+  root["type"] = "is_in_use_request";
+  root["id"] = id;
+  encode_msg(root, msg);
+}
+
+Status ReadIsInUseRequest(json const& root, ObjectID& id) {
+  RETURN_ON_ASSERT(root["type"] == "is_in_use_request");
+  id = root["id"].get<ObjectID>();
+  return Status::OK();
+}
+
+void WriteIsInUseReply(const bool is_in_use, std::string& msg) {
+  json root;
+  root["type"] = "is_in_use_reply";
+  root["is_in_use"] = is_in_use;
+  encode_msg(root, msg);
+}
+
+Status ReadIsInUseReply(json const& root, bool& is_in_use) {
+  RETURN_ON_ASSERT(root["type"] == "is_in_use_reply");
+  is_in_use = root["is_in_use"].get<bool>();
+  return Status::OK();
+}
+
+void WritePinBlobsRequest(const std::vector<ObjectID>& ids, std::string& msg) {
+  json root;
+  root["type"] = "pin_blobs_request";
+  root["ids"] = std::vector<ObjectID>{ids};
+  encode_msg(root, msg);
+}
+
+Status ReadPinBlobsRequest(json const& root, std::vector<ObjectID>& ids) {
+  RETURN_ON_ASSERT(root["type"] == "pin_blobs_request");
+  ids = root["ids"].get_to(ids);
+  return Status::OK();
+}
+
+void WritePinBlobsReply(std::string& msg) {
+  json root;
+  root["type"] = "pin_blobs_reply";
+  encode_msg(root, msg);
+}
+
+Status ReadPinBlobsReply(json const& root) {
+  RETURN_ON_ASSERT(root["type"] == "pin_blobs_reply");
   return Status::OK();
 }
 

--- a/src/common/util/protocols.cc
+++ b/src/common/util/protocols.cc
@@ -131,6 +131,10 @@ CommandType ParseCommandType(const std::string& str_type) {
     return CommandType::PlasmaDelDataRequest;
   } else if (str_type == "move_buffers_ownership_request") {
     return CommandType::MoveBuffersOwnershipRequest;
+  } else if (str_type == "release_request") {
+    return CommandType::ReleaseRequest;
+  } else if (str_type == "del_data_with_feedbacks_request") {
+    return CommandType::DelDataWithFeedbacksRequest;
   } else {
     return CommandType::NullCommand;
   }
@@ -1442,6 +1446,70 @@ void WriteMoveBuffersOwnershipReply(std::string& msg) {
 
 Status ReadMoveBuffersOwnershipReply(json const& root) {
   CHECK_IPC_ERROR(root, "move_buffers_ownership_reply");
+  return Status::OK();
+}
+
+void WriteReleaseRequest(ObjectID const& object_id, std::string& msg) {
+  json root;
+  root["type"] = "release_request";
+  root["object_id"] = object_id;
+  encode_msg(root, msg);
+}
+
+Status ReadReleaseRequest(json const& root, ObjectID& object_id) {
+  RETURN_ON_ASSERT(root["type"] == "release_request");
+  object_id = root["object_id"].get<ObjectID>();
+  return Status::OK();
+}
+
+void WriteReleaseReply(std::string& msg) {
+  json root;
+  root["type"] = "release_reply";
+  encode_msg(root, msg);
+}
+
+Status ReadReleaseReply(json const& root) {
+  CHECK_IPC_ERROR(root, "release_reply");
+  return Status::OK();
+}
+
+void WriteDelDataWithFeedbacksRequest(const std::vector<ObjectID>& id,
+                                      const bool force, const bool deep,
+                                      const bool fastpath, std::string& msg) {
+  json root;
+  root["type"] = "del_data_with_feedbacks_request";
+  root["id"] = std::vector<ObjectID>{id};
+  root["force"] = force;
+  root["deep"] = deep;
+  root["fastpath"] = fastpath;
+
+  encode_msg(root, msg);
+}
+
+Status ReadDelDataWithFeedbacksRequest(json const& root,
+                                       std::vector<ObjectID>& ids, bool& force,
+                                       bool& deep, bool& fastpath) {
+  RETURN_ON_ASSERT(root["type"] == "del_data_with_feedbacks_request");
+  ids = root["id"].get_to(ids);
+  force = root.value("force", false);
+  deep = root.value("deep", false);
+  fastpath = root.value("fastpath", false);
+  return Status::OK();
+}
+
+void WriteDelDataWithFeedbacksReply(const std::vector<ObjectID>& deleted_bids,
+                                    std::string& msg) {
+  json root;
+  root["type"] = "del_data_with_feedbacks_reply";
+  root["deleted_bids"] = deleted_bids;
+
+  encode_msg(root, msg);
+}
+
+Status ReadDelDataWithFeedbacksReply(json const& root,
+                                     std::vector<ObjectID>& deleted_bids) {
+  RETURN_ON_ASSERT(root["type"] == "del_data_with_feedbacks_reply");
+  deleted_bids = root["deleted_bids"].get_to(deleted_bids);
   return Status::OK();
 }
 

--- a/src/common/util/protocols.h
+++ b/src/common/util/protocols.h
@@ -84,6 +84,8 @@ enum class CommandType {
   MoveBuffersOwnershipRequest = 50,
   ReleaseRequest = 51,
   DelDataWithFeedbacksRequest = 52,
+  IsInUseRequest = 53,
+  PinBlobsRequest = 54,
 };
 
 CommandType ParseCommandType(const std::string& str_type);
@@ -524,6 +526,22 @@ void WriteDelDataWithFeedbacksReply(const std::vector<ObjectID>& deleted_bids,
 
 Status ReadDelDataWithFeedbacksReply(json const& root,
                                      std::vector<ObjectID>& deleted_bids);
+
+void WriteIsInUseRequest(const ObjectID& id, std::string& msg);
+
+Status ReadIsInUseRequest(json const& root, ObjectID& id);
+
+void WriteIsInUseReply(const bool is_in_use, std::string& msg);
+
+Status ReadIsInUseReply(json const& root, bool& is_in_use);
+
+void WritePinBlobsRequest(const std::vector<ObjectID>& ids, std::string& msg);
+
+Status ReadPinBlobsRequest(json const& root, std::vector<ObjectID>& ids);
+
+void WritePinBlobsReply(std::string& msg);
+
+Status ReadPinBlobsReply(json const& root);
 
 }  // namespace vineyard
 

--- a/src/common/util/protocols.h
+++ b/src/common/util/protocols.h
@@ -85,7 +85,7 @@ enum class CommandType {
   ReleaseRequest = 51,
   DelDataWithFeedbacksRequest = 52,
   IsInUseRequest = 53,
-  PinBlobsRequest = 54,
+  IncreaseReferenceCountRequest = 54,
 };
 
 CommandType ParseCommandType(const std::string& str_type);
@@ -535,13 +535,15 @@ void WriteIsInUseReply(const bool is_in_use, std::string& msg);
 
 Status ReadIsInUseReply(json const& root, bool& is_in_use);
 
-void WritePinBlobsRequest(const std::vector<ObjectID>& ids, std::string& msg);
+void WriteIncreaseReferenceCountRequest(const std::vector<ObjectID>& ids,
+                                        std::string& msg);
 
-Status ReadPinBlobsRequest(json const& root, std::vector<ObjectID>& ids);
+Status ReadIncreaseReferenceCountRequest(json const& root,
+                                         std::vector<ObjectID>& ids);
 
-void WritePinBlobsReply(std::string& msg);
+void WriteIncreaseReferenceCountReply(std::string& msg);
 
-Status ReadPinBlobsReply(json const& root);
+Status ReadIncreaseReferenceCountReply(json const& root);
 
 }  // namespace vineyard
 

--- a/src/common/util/protocols.h
+++ b/src/common/util/protocols.h
@@ -82,6 +82,8 @@ enum class CommandType {
   PlasmaReleaseRequest = 48,
   PlasmaDelDataRequest = 49,
   MoveBuffersOwnershipRequest = 50,
+  ReleaseRequest = 51,
+  DelDataWithFeedbacksRequest = 52,
 };
 
 CommandType ParseCommandType(const std::string& str_type);
@@ -500,6 +502,28 @@ Status ReadMoveBuffersOwnershipRequest(json const& root,
 void WriteMoveBuffersOwnershipReply(std::string& msg);
 
 Status ReadMoveBuffersOwnershipReply(json const& root);
+
+void WriteReleaseRequest(ObjectID const& object_id, std::string& msg);
+
+Status ReadReleaseRequest(json const& root, ObjectID& object_id);
+
+void WriteReleaseReply(std::string& msg);
+
+Status ReadReleaseReply(json const& root);
+
+void WriteDelDataWithFeedbacksRequest(const std::vector<ObjectID>& id,
+                                      const bool force, const bool deep,
+                                      const bool fastpath, std::string& msg);
+
+Status ReadDelDataWithFeedbacksRequest(json const& root,
+                                       std::vector<ObjectID>& id, bool& force,
+                                       bool& deep, bool& fastpath);
+
+void WriteDelDataWithFeedbacksReply(const std::vector<ObjectID>& deleted_bids,
+                                    std::string& msg);
+
+Status ReadDelDataWithFeedbacksReply(json const& root,
+                                     std::vector<ObjectID>& deleted_bids);
 
 }  // namespace vineyard
 

--- a/src/server/async/socket_server.cc
+++ b/src/server/async/socket_server.cc
@@ -57,7 +57,7 @@ bool SocketConnection::Stop() {
     std::unordered_set<ObjectID> ids;
     auto status = server_ptr_->GetBulkStore()->PopList(this->getConnId(), ids);
     if (!status.ok()) {
-      LOG(ERROR) << "PopList failed, conn_id: " << this->getConnId()
+      LOG(INFO) << "No dependent objects, conn_id: " << this->getConnId()
                  << ", status: " << status.ToString();
     }
   }

--- a/src/server/async/socket_server.cc
+++ b/src/server/async/socket_server.cc
@@ -55,7 +55,7 @@ bool SocketConnection::Stop() {
   auto self(shared_from_this());
   if (server_ptr_->GetBulkStoreType() == "Normal") {
     std::unordered_set<ObjectID> ids;
-    auto status = server_ptr_->GetBulkStore()->PopList(this->getConnId(), ids);
+    auto status = server_ptr_->GetBulkStore()->ReleaseConnection(this->getConnId());
     if (!status.ok()) {
       LOG(INFO) << "No dependent objects, conn_id: " << this->getConnId()
                 << ", status: " << status.ToString();

--- a/src/server/async/socket_server.cc
+++ b/src/server/async/socket_server.cc
@@ -58,7 +58,7 @@ bool SocketConnection::Stop() {
     auto status = server_ptr_->GetBulkStore()->PopList(this->getConnId(), ids);
     if (!status.ok()) {
       LOG(INFO) << "No dependent objects, conn_id: " << this->getConnId()
-                 << ", status: " << status.ToString();
+                << ", status: " << status.ToString();
     }
   }
 

--- a/src/server/async/socket_server.cc
+++ b/src/server/async/socket_server.cc
@@ -60,11 +60,6 @@ bool SocketConnection::Stop() {
       LOG(ERROR) << "PopList failed, conn_id: " << this->getConnId()
                  << ", status: " << status.ToString();
     }
-    // release all the depenedent objects
-    for (auto& id : ids) {
-      VINEYARD_CHECK_OK(
-          server_ptr_->GetBulkStore()->Release(id, this->getConnId()));
-    }
   }
 
   // do cleanup: clean up streams associated with this client

--- a/src/server/async/socket_server.cc
+++ b/src/server/async/socket_server.cc
@@ -321,8 +321,8 @@ bool SocketConnection::processMessage(const std::string& message_in) {
   case CommandType::IsInUseRequest: {
     return doIsInUse(root);
   }
-  case CommandType::PinBlobsRequest: {
-    return doPinBlobs(root);
+  case CommandType::IncreaseReferenceCountRequest: {
+    return doIncreaseReferenceCount(root);
   }
   default: {
     LOG(ERROR) << "Got unexpected command: " << type;
@@ -1322,14 +1322,14 @@ bool SocketConnection::doIsInUse(json const& root) {
   return false;
 }
 
-bool SocketConnection::doPinBlobs(json const& root) {
+bool SocketConnection::doIncreaseReferenceCount(json const& root) {
   auto self(shared_from_this());
   std::vector<ObjectID> ids;
-  TRY_READ_REQUEST(ReadPinBlobsRequest, root, ids);
+  TRY_READ_REQUEST(ReadIncreaseReferenceCountRequest, root, ids);
   RESPONSE_ON_ERROR(server_ptr_->GetBulkStore()->AddDependency(
       std::unordered_set<ObjectID>(ids.begin(), ids.end()), this->getConnId()));
   std::string message_out;
-  WritePinBlobsReply(message_out);
+  WriteIncreaseReferenceCountReply(message_out);
   this->doWrite(message_out);
   return false;
 }

--- a/src/server/async/socket_server.cc
+++ b/src/server/async/socket_server.cc
@@ -55,7 +55,8 @@ bool SocketConnection::Stop() {
   auto self(shared_from_this());
   if (server_ptr_->GetBulkStoreType() == "Normal") {
     std::unordered_set<ObjectID> ids;
-    auto status = server_ptr_->GetBulkStore()->ReleaseConnection(this->getConnId());
+    auto status =
+        server_ptr_->GetBulkStore()->ReleaseConnection(this->getConnId());
     if (!status.ok()) {
       LOG(INFO) << "No dependent objects, conn_id: " << this->getConnId()
                 << ", status: " << status.ToString();

--- a/src/server/async/socket_server.cc
+++ b/src/server/async/socket_server.cc
@@ -51,6 +51,22 @@ bool SocketConnection::Stop() {
     // already stopped, or haven't started
     return false;
   }
+
+  auto self(shared_from_this());
+  if (server_ptr_->GetBulkStoreType() == "Normal") {
+    std::unordered_set<ObjectID> ids;
+    auto status = server_ptr_->GetBulkStore()->PopList(this->getConnId(), ids);
+    if (!status.ok()) {
+      LOG(ERROR) << "PopList failed, conn_id: " << this->getConnId()
+                 << ", status: " << status.ToString();
+    }
+    // release all the depenedent objects
+    for (auto& id : ids) {
+      VINEYARD_CHECK_OK(
+          server_ptr_->GetBulkStore()->Release(id, this->getConnId()));
+    }
+  }
+
   // do cleanup: clean up streams associated with this client
   for (auto stream_id : associated_streams_) {
     VINEYARD_SUPPRESS(server_ptr_->GetStreamStore()->Drop(stream_id));
@@ -300,6 +316,12 @@ bool SocketConnection::processMessage(const std::string& message_in) {
   case CommandType::MoveBuffersOwnershipRequest: {
     return doMoveBuffersOwnership(root);
   }
+  case CommandType::ReleaseRequest: {
+    return doRelease(root);
+  }
+  case CommandType::DelDataWithFeedbacksRequest: {
+    return doDelDataWithFeedbacks(root);
+  }
   default: {
     LOG(ERROR) << "Got unexpected command: " << type;
     return false;
@@ -328,6 +350,8 @@ bool SocketConnection::doGetBuffers(const json& root) {
 
   TRY_READ_REQUEST(ReadGetBuffersRequest, root, ids);
   RESPONSE_ON_ERROR(server_ptr_->GetBulkStore()->Get(ids, objects));
+  RESPONSE_ON_ERROR(server_ptr_->GetBulkStore()->AddDependency(
+      std::unordered_set<ObjectID>(ids.begin(), ids.end()), this->getConnId()));
 
   std::vector<int> fd_to_send;
   for (auto object : objects) {
@@ -389,6 +413,8 @@ bool SocketConnection::doGetRemoteBuffers(const json& root) {
 
   TRY_READ_REQUEST(ReadGetBuffersRequest, root, ids);
   RESPONSE_ON_ERROR(server_ptr_->GetBulkStore()->Get(ids, objects));
+  RESPONSE_ON_ERROR(server_ptr_->GetBulkStore()->AddDependency(
+      std::unordered_set<ObjectID>(ids.begin(), ids.end()), this->getConnId()));
   WriteGetBuffersReply(objects, {}, message_out);
 
   this->doWrite(message_out, [this, self, objects](const Status& status) {
@@ -1116,6 +1142,9 @@ bool SocketConnection::doGetBuffersByPlasma(json const& root) {
   TRY_READ_REQUEST(ReadGetBuffersByPlasmaRequest, root, plasma_ids);
   RESPONSE_ON_ERROR(
       server_ptr_->GetBulkStore<PlasmaID>()->Get(plasma_ids, plasma_objects));
+  RESPONSE_ON_ERROR(server_ptr_->GetBulkStore<PlasmaID>()->AddDependency(
+      std::unordered_set<PlasmaID>(plasma_ids.begin(), plasma_ids.end()),
+      getConnId()));
   WriteGetBuffersByPlasmaReply(plasma_objects, message_out);
 
   /* NOTE: Here we send the file descriptor after the objects.
@@ -1149,6 +1178,8 @@ bool SocketConnection::doSealBlob(json const& root) {
   ObjectID id;
   TRY_READ_REQUEST(ReadSealRequest, root, id);
   RESPONSE_ON_ERROR(server_ptr_->GetBulkStore()->Seal(id));
+  RESPONSE_ON_ERROR(
+      server_ptr_->GetBulkStore()->AddDependency(id, getConnId()));
   std::string message_out;
   WriteSealReply(message_out);
   this->doWrite(message_out);
@@ -1160,6 +1191,8 @@ bool SocketConnection::doSealPlasmaBlob(json const& root) {
   PlasmaID id;
   TRY_READ_REQUEST(ReadPlasmaSealRequest, root, id);
   RESPONSE_ON_ERROR(server_ptr_->GetBulkStore<PlasmaID>()->Seal(id));
+  RESPONSE_ON_ERROR(
+      server_ptr_->GetBulkStore<PlasmaID>()->AddDependency(id, getConnId()));
   std::string message_out;
   WriteSealReply(message_out);
   this->doWrite(message_out);
@@ -1225,6 +1258,52 @@ bool SocketConnection::doMoveBuffersOwnership(json const& root) {
   std::string message_out;
   WriteMoveBuffersOwnershipReply(message_out);
   this->doWrite(message_out);
+  return false;
+}
+
+bool SocketConnection::doRelease(json const& root) {
+  auto self(shared_from_this());
+  ObjectID id;  // Must be a blob id.
+  TRY_READ_REQUEST(ReadReleaseRequest, root, id);
+  RESPONSE_ON_ERROR(
+      server_ptr_->GetBulkStore<ObjectID>()->Release(id, getConnId()));
+  std::string message_out;
+  WriteReleaseReply(message_out);
+  this->doWrite(message_out);
+  return false;
+}
+
+bool SocketConnection::doDelDataWithFeedbacks(json const& root) {
+  auto self(shared_from_this());
+  std::vector<ObjectID> ids;
+  bool force, deep, fastpath;
+  double startTime = GetCurrentTime();
+  TRY_READ_REQUEST(ReadDelDataWithFeedbacksRequest, root, ids, force, deep,
+                   fastpath);
+  RESPONSE_ON_ERROR(server_ptr_->DelData(
+      ids, force, deep, fastpath,
+      [self, startTime](const Status& status,
+                        std::vector<ObjectID> const& delete_ids) {
+        std::string message_out;
+        if (status.ok()) {
+          std::vector<ObjectID> deleted_bids;
+          for (auto id : delete_ids) {
+            if (IsBlob(id)) {
+              deleted_bids.emplace_back(id);
+            }
+          }
+          WriteDelDataWithFeedbacksReply(deleted_bids, message_out);
+        } else {
+          LOG(ERROR) << status.ToString();
+          WriteErrorReply(status, message_out);
+        }
+        self->doWrite(message_out);
+        double endTime = GetCurrentTime();
+        LOG_SUMMARY("data_request_duration_microseconds", "delete",
+                    (endTime - startTime) * 1000000);
+        LOG_COUNTER("data_requests_total", "delete");
+        return Status::OK();
+      }));
   return false;
 }
 

--- a/src/server/async/socket_server.h
+++ b/src/server/async/socket_server.h
@@ -153,7 +153,7 @@ class SocketConnection : public std::enable_shared_from_this<SocketConnection> {
 
   bool doIsInUse(json const& root);
 
-  bool doPinBlobs(json const& root);
+  bool doIncreaseReferenceCount(json const& root);
 
  protected:
   template <typename FROM, typename TO>

--- a/src/server/async/socket_server.h
+++ b/src/server/async/socket_server.h
@@ -151,6 +151,10 @@ class SocketConnection : public std::enable_shared_from_this<SocketConnection> {
 
   bool doDelDataWithFeedbacks(json const& root);
 
+  bool doIsInUse(json const& root);
+
+  bool doPinBlobs(json const& root);
+
  protected:
   template <typename FROM, typename TO>
   Status MoveBuffers(std::map<FROM, TO> mapping, vs_ptr_t& source_session) {

--- a/src/server/async/socket_server.h
+++ b/src/server/async/socket_server.h
@@ -147,6 +147,10 @@ class SocketConnection : public std::enable_shared_from_this<SocketConnection> {
 
   bool doMoveBuffersOwnership(json const& root);
 
+  bool doRelease(json const& root);
+
+  bool doDelDataWithFeedbacks(json const& root);
+
  protected:
   template <typename FROM, typename TO>
   Status MoveBuffers(std::map<FROM, TO> mapping, vs_ptr_t& source_session) {
@@ -168,6 +172,16 @@ class SocketConnection : public std::enable_shared_from_this<SocketConnection> {
 
     RETURN_ON_ERROR(
         server_ptr_->GetBulkStore<TO>()->MoveOwnership(to_process_ids));
+
+    // FIXME: this is a hack to make sure Moved buffers will never be released.
+    int64_t ref_cnt;
+    for (auto const& item : mapping) {
+      VINEYARD_CHECK_OK(source_session->GetBulkStore<FROM>()->FetchAndModify(
+          item.first, ref_cnt, 1));
+      VINEYARD_CHECK_OK(source_session->GetBulkStore<TO>()->FetchAndModify(
+          item.second, ref_cnt, 1));
+    }
+
     return Status::OK();
   }
 

--- a/src/server/async/socket_server.h
+++ b/src/server/async/socket_server.h
@@ -178,7 +178,7 @@ class SocketConnection : public std::enable_shared_from_this<SocketConnection> {
     for (auto const& item : mapping) {
       VINEYARD_CHECK_OK(source_session->GetBulkStore<FROM>()->FetchAndModify(
           item.first, ref_cnt, 1));
-      VINEYARD_CHECK_OK(source_session->GetBulkStore<TO>()->FetchAndModify(
+      VINEYARD_CHECK_OK(server_ptr_->GetBulkStore<TO>()->FetchAndModify(
           item.second, ref_cnt, 1));
     }
 

--- a/src/server/memory/memory.cc
+++ b/src/server/memory/memory.cc
@@ -494,16 +494,9 @@ Status BulkStore::FetchAndModify(const ObjectID& id, int64_t& ref_cnt,
   return Status::OK();
 }
 
-Status BulkStore::OnDelete(ObjectID const& id) {
-  return BulkStoreBase<ObjectID, Payload>::Delete(id);
-}
-
 // TODO(mengke): If reference count reaches 0 and marked as to be deleted, send
 // DelData request to server.
-Status BulkStore::Delete(ObjectID const& id) {
-  // Currently, the deletion does not respect the reference count.
-  return BulkStoreBase::Delete(id);
-}
+Status BulkStore::OnDelete(ObjectID const& id) { return Delete(id); }
 
 // implementation for PlasmaBulkStore
 Status PlasmaBulkStore::Create(size_t const data_size, size_t const plasma_size,
@@ -550,7 +543,7 @@ Status PlasmaBulkStore::FetchAndModify(const PlasmaID& id, int64_t& ref_cnt,
                                        int64_t changes) {
   typename object_map_t::const_accessor accessor;
   if (!objects_.find(accessor, id)) {
-    // NB: Keep consistent with the the Get opeartion.
+    // N.B.: Keep consistent with the the Get opeartion.
     return Status::OK();
   } else {
     accessor->second->ref_cnt += changes;

--- a/src/server/memory/memory.cc
+++ b/src/server/memory/memory.cc
@@ -550,8 +550,8 @@ Status PlasmaBulkStore::FetchAndModify(const PlasmaID& id, int64_t& ref_cnt,
                                        int64_t changes) {
   typename object_map_t::const_accessor accessor;
   if (!objects_.find(accessor, id)) {
-    return Status::ObjectNotExists("object " + IDToString(id) +
-                                   " cannot be found");
+    // NB: Keep consistent with the the Get opeartion.
+    return Status::OK();
   } else {
     accessor->second->ref_cnt += changes;
     ref_cnt = accessor->second->ref_cnt;

--- a/src/server/memory/memory.cc
+++ b/src/server/memory/memory.cc
@@ -494,8 +494,6 @@ Status BulkStore::FetchAndModify(const ObjectID& id, int64_t& ref_cnt,
   return Status::OK();
 }
 
-// TODO(mengke): If reference count reaches 0 and marked as to be deleted, send
-// DelData request to server.
 Status BulkStore::OnDelete(ObjectID const& id) { return Delete(id); }
 
 // implementation for PlasmaBulkStore

--- a/src/server/memory/memory.cc
+++ b/src/server/memory/memory.cc
@@ -469,6 +469,45 @@ Status BulkStore::Create(const size_t data_size, ObjectID& object_id,
   return Status::OK();
 }
 
+Status BulkStore::OnRelease(ObjectID const& id) {
+  typename object_map_t::const_accessor accessor;
+  if (!objects_.find(accessor, id)) {
+    return Status::ObjectNotExists("object " + IDToString(id) +
+                                   " cannot be found");
+  } else {
+    RETURN_ON_ERROR(this->MarkAsCold(id, accessor->second));
+  }
+  return Status::OK();
+}
+
+Status BulkStore::Release(ObjectID const& id, int conn) {
+  return this->RemoveDependency(id, conn);
+}
+
+Status BulkStore::FetchAndModify(const ObjectID& id, int64_t& ref_cnt,
+                                 int64_t changes) {
+  typename object_map_t::const_accessor accessor;
+  if (!objects_.find(accessor, id)) {
+    return Status::ObjectNotExists("object " + IDToString(id) +
+                                   " cannot be found");
+  } else {
+    accessor->second->ref_cnt += changes;
+    ref_cnt = accessor->second->ref_cnt;
+  }
+  return Status::OK();
+}
+
+Status BulkStore::OnDelete(ObjectID const& id) {
+  return BulkStoreBase<ObjectID, Payload>::Delete(id);
+}
+
+// TODO(mengke): If reference count reaches 0 and marked as to be deleted, send
+// DelData request to server.
+Status BulkStore::Delete(ObjectID const& id) {
+  // Currently, the deletion does not respect the reference count.
+  return BulkStoreBase::Delete(id);
+}
+
 // implementation for PlasmaBulkStore
 Status PlasmaBulkStore::Create(size_t const data_size, size_t const plasma_size,
                                PlasmaID const& plasma_id, ObjectID& object_id,

--- a/src/server/memory/memory.cc
+++ b/src/server/memory/memory.cc
@@ -488,8 +488,8 @@ Status BulkStore::FetchAndModify(const ObjectID& id, int64_t& ref_cnt,
                                  int64_t changes) {
   typename object_map_t::const_accessor accessor;
   if (!objects_.find(accessor, id)) {
-    return Status::ObjectNotExists("object " + IDToString(id) +
-                                   " cannot be found");
+    // NB: Keep consistent with the the Get opeartion.
+    return Status::OK();
   } else {
     accessor->second->ref_cnt += changes;
     ref_cnt = accessor->second->ref_cnt;

--- a/src/server/memory/memory.cc
+++ b/src/server/memory/memory.cc
@@ -471,10 +471,7 @@ Status BulkStore::Create(const size_t data_size, ObjectID& object_id,
 
 Status BulkStore::OnRelease(ObjectID const& id) {
   typename object_map_t::const_accessor accessor;
-  if (!objects_.find(accessor, id)) {
-    return Status::ObjectNotExists("object " + IDToString(id) +
-                                   " cannot be found");
-  } else {
+  if (objects_.find(accessor, id)) {
     RETURN_ON_ERROR(this->MarkAsCold(id, accessor->second));
   }
   return Status::OK();

--- a/src/server/memory/memory.h
+++ b/src/server/memory/memory.h
@@ -39,114 +39,11 @@
 #include "oneapi/tbb/concurrent_hash_map.h"
 
 #include "common/memory/payload.h"
-#include "common/util/lifecycle.h"
 #include "common/util/logging.h"
 #include "common/util/status.h"
+#include "server/memory/usage.h"
 
 namespace vineyard {
-
-//  Track Dependency lest dangling objects and double deletion.
-template <typename ID, typename P, typename Der>
-class DependencyTracker
-    : public LifeCycleTracker<ID, P, DependencyTracker<ID, P, Der>> {
- public:
-  using dependency_map_t = tbb::concurrent_hash_map</*socket_connection*/ int,
-                                                    std::unordered_set<ID>>;
-
-  DependencyTracker() {}
-
-  Status AddDependency(std::unordered_set<ID> const& ids, int conn) {
-    for (auto const& id : ids) {
-      RETURN_ON_ERROR(AddDependency(id, conn));
-    }
-    return Status::OK();
-  }
-
-  Status AddDependency(ID const& id, int conn) {
-    RETURN_ON_ERROR(this->IncreaseReferenceCount(id));
-
-    typename dependency_map_t::accessor accessor;
-    if (!dependency_.find(accessor, conn)) {
-      dependency_.emplace(conn, std::unordered_set<ID>());
-    }
-
-    if (dependency_.find(accessor, conn)) {
-      auto& objects = accessor->second;
-      if (objects.find(id) == objects.end()) {
-        objects.emplace(id);
-      }
-    }
-    return Status::OK();
-  }
-
-  Status RemoveDependency(std::unordered_set<ID> const& ids, int conn) {
-    for (auto const& id : ids) {
-      RETURN_ON_ERROR(RemoveDependency(id, conn));
-    }
-    return Status::OK();
-  }
-
-  Status RemoveDependency(ID const& id, int conn) {
-    typename dependency_map_t::accessor accessor;
-    if (!dependency_.find(accessor, conn)) {
-      return Status::Invalid("connection not exist.");
-    } else {
-      auto& objects = accessor->second;
-      if (objects.find(id) == objects.end()) {
-        return Status::ObjectNotExists();
-      } else {
-        objects.erase(id);
-      }
-    }
-
-    RETURN_ON_ERROR(this->DecreaseReferenceCount(id));
-
-    return Status::OK();
-  }
-
-  /**
-   * Note:
-   * If object_id exists in dependency_, then its reference count should
-   * determinately greater than 0, thus it will determinately not be deleted.
-   * Delete will not remove dependency.
-   */
-  Status PreDelete(ID const& id) {
-    return LifeCycleTracker<ID, P, DependencyTracker<ID, P, Der>>::PreDelete(
-        id);
-  }
-
-  /// remove dependency of all objects in dependency_[conn].
-  Status PopList(int conn, std::unordered_set<ID>& objects) {
-    typename dependency_map_t::const_accessor accessor;
-    if (!dependency_.find(accessor, conn)) {
-      return Status::Invalid("connection not exist.");
-    } else {
-      objects = accessor->second;
-      auto status = Status::OK();
-      for (auto& elem : objects) {
-        // try our best to remove dependency.
-        auto _status = RemoveDependency(elem, conn);
-        if (!_status.ok()) {
-          status = _status;
-        }
-      }
-      return status;
-    }
-  }
-
-  Status FetchAndModify(ID const& id, int64_t& ref_cnt, int64_t changes) {
-    auto status = Self().FetchAndModify(id, ref_cnt, changes);
-    return status;
-  }
-
-  Status OnRelease(ID const& id) { return Self().OnRelease(id); }
-
-  Status OnDelete(ID const& id) { return Self().OnDelete(id); }
-
- private:
-  inline Der& Self() { return static_cast<Der&>(*this); }
-  dependency_map_t dependency_;
-};
 
 template <typename ID, typename P>
 class BulkStoreBase {
@@ -204,10 +101,21 @@ class BulkStoreBase {
   object_map_t objects_;
 };
 
-class BulkStore : public BulkStoreBase<ObjectID, Payload> {
+class BulkStore : public BulkStoreBase<ObjectID, Payload>,
+                  public ColdObjectTracker<ObjectID, Payload, BulkStore> {
  public:
   Status Create(const size_t size, ObjectID& object_id,
                 std::shared_ptr<Payload>& object);
+
+  Status FetchAndModify(ObjectID const& id, int64_t& ref_cnt, int64_t changes);
+
+  Status OnRelease(ObjectID const& id);
+
+  Status OnDelete(ObjectID const& id);
+
+  Status Release(ObjectID const& id, int conn);
+
+  Status Delete(ObjectID const& id);
 };
 
 class PlasmaBulkStore

--- a/src/server/memory/usage.h
+++ b/src/server/memory/usage.h
@@ -50,7 +50,6 @@ class DependencyTracker
   }
 
   Status AddDependency(ID const& id, int conn) {
-
     typename dependency_map_t::accessor accessor;
     if (!dependency_.find(accessor, conn)) {
       dependency_.emplace(conn, std::unordered_set<ID>());
@@ -148,8 +147,14 @@ class ColdObjectTracker
     return Status::OK();
   }
 
-  using base_t::AddDependency;
   using base_t::RemoveDependency;
+
+  Status AddDependency(std::unordered_set<ID> const& ids, int conn) {
+    for (auto const& id : ids) {
+      RETURN_ON_ERROR(AddDependency(id, conn));
+    }
+    return Status::OK();
+  }
 
   Status AddDependency(ID const& id, int conn) {
     RETURN_ON_ERROR(base_t::AddDependency(id, conn));
@@ -163,6 +168,16 @@ class ColdObjectTracker
       if (!cold_objects_.find(accessor, id)) {
         cold_objects_.emplace(id, payload);
       }
+    }
+    return Status::OK();
+  }
+
+  Status IsInUse(ID const& id, bool& is_in_use) {
+    typename cold_object_map_t::const_accessor accessor;
+    if (cold_objects_.find(accessor, id)) {
+      is_in_use = false;
+    } else {
+      is_in_use = true;
     }
     return Status::OK();
   }

--- a/src/server/memory/usage.h
+++ b/src/server/memory/usage.h
@@ -50,7 +50,6 @@ class DependencyTracker
   }
 
   Status AddDependency(ID const& id, int conn) {
-    RETURN_ON_ERROR(this->IncreaseReferenceCount(id));
 
     typename dependency_map_t::accessor accessor;
     if (!dependency_.find(accessor, conn)) {
@@ -61,6 +60,7 @@ class DependencyTracker
       auto& objects = accessor->second;
       if (objects.find(id) == objects.end()) {
         objects.emplace(id);
+        RETURN_ON_ERROR(this->IncreaseReferenceCount(id));
       }
     }
     return Status::OK();

--- a/src/server/memory/usage.h
+++ b/src/server/memory/usage.h
@@ -164,7 +164,7 @@ class ColdObjectTracker
 
   Status MarkAsCold(ID const& id, std::shared_ptr<P> payload) {
     typename cold_object_map_t::accessor accessor;
-    if(payload->IsSealed()){
+    if (payload->IsSealed()) {
       if (!cold_objects_.find(accessor, id)) {
         cold_objects_.emplace(id, payload);
       }

--- a/src/server/memory/usage.h
+++ b/src/server/memory/usage.h
@@ -164,8 +164,10 @@ class ColdObjectTracker
 
   Status MarkAsCold(ID const& id, std::shared_ptr<P> payload) {
     typename cold_object_map_t::accessor accessor;
-    if (!cold_objects_.find(accessor, id)) {
-      cold_objects_.emplace(id, payload);
+    if(payload->IsSealed()){
+      if (!cold_objects_.find(accessor, id)) {
+        cold_objects_.emplace(id, payload);
+      }
     }
     return Status::OK();
   }

--- a/src/server/memory/usage.h
+++ b/src/server/memory/usage.h
@@ -1,0 +1,184 @@
+/** Copyright 2020-2022 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef SRC_SERVER_MEMORY_USAGE_H_
+#define SRC_SERVER_MEMORY_USAGE_H_
+
+#include <map>
+#include <memory>
+#include <set>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "oneapi/tbb/concurrent_hash_map.h"
+
+#include "common/memory/payload.h"
+#include "common/util/lifecycle.h"
+#include "common/util/logging.h"
+#include "common/util/status.h"
+
+namespace vineyard {
+
+template <typename ID, typename P, typename Der>
+class DependencyTracker
+    : public LifeCycleTracker<ID, P, DependencyTracker<ID, P, Der>> {
+ public:
+  using dependency_map_t = tbb::concurrent_hash_map</*socket_connection*/ int,
+                                                    std::unordered_set<ID>>;
+
+  DependencyTracker() {}
+
+  Status AddDependency(std::unordered_set<ID> const& ids, int conn) {
+    for (auto const& id : ids) {
+      RETURN_ON_ERROR(AddDependency(id, conn));
+    }
+    return Status::OK();
+  }
+
+  Status AddDependency(ID const& id, int conn) {
+    RETURN_ON_ERROR(this->IncreaseReferenceCount(id));
+
+    typename dependency_map_t::accessor accessor;
+    if (!dependency_.find(accessor, conn)) {
+      dependency_.emplace(conn, std::unordered_set<ID>());
+    }
+
+    if (dependency_.find(accessor, conn)) {
+      auto& objects = accessor->second;
+      if (objects.find(id) == objects.end()) {
+        objects.emplace(id);
+      }
+    }
+    return Status::OK();
+  }
+
+  Status RemoveDependency(std::unordered_set<ID> const& ids, int conn) {
+    for (auto const& id : ids) {
+      RETURN_ON_ERROR(RemoveDependency(id, conn));
+    }
+    return Status::OK();
+  }
+
+  Status RemoveDependency(ID const& id, int conn) {
+    typename dependency_map_t::accessor accessor;
+    if (!dependency_.find(accessor, conn)) {
+      return Status::Invalid("connection not exist.");
+    } else {
+      auto& objects = accessor->second;
+      if (objects.find(id) == objects.end()) {
+        return Status::ObjectNotExists();
+      } else {
+        objects.erase(id);
+      }
+    }
+
+    RETURN_ON_ERROR(this->DecreaseReferenceCount(id));
+
+    return Status::OK();
+  }
+
+  /**
+   * Note:
+   * If object_id exists in dependency_, then its reference count should
+   * determinately greater than 0, thus it will determinately not be deleted.
+   * Delete will not remove dependency.
+   */
+  Status PreDelete(ID const& id) {
+    return LifeCycleTracker<ID, P, DependencyTracker<ID, P, Der>>::PreDelete(
+        id);
+  }
+
+  /// get the dependency of all objects in given connection.
+  Status PopList(int conn, std::unordered_set<ID>& objects) {
+    typename dependency_map_t::const_accessor accessor;
+    if (!dependency_.find(accessor, conn)) {
+      return Status::Invalid("connection not exist.");
+    } else {
+      objects = accessor->second;
+      auto status = Status::OK();
+      for (auto& elem : objects) {
+        // try our best to remove dependency.
+        auto _status = RemoveDependency(elem, conn);
+        if (!_status.ok()) {
+          status = _status;
+        }
+      }
+      return status;
+    }
+  }
+
+  Status FetchAndModify(ID const& id, int64_t& ref_cnt, int64_t changes) {
+    return Self().FetchAndModify(id, ref_cnt, changes);
+  }
+
+  Status OnRelease(ID const& id) { return Self().OnRelease(id); }
+
+  Status OnDelete(ID const& id) { return Self().OnDelete(id); }
+
+ private:
+  inline Der& Self() { return static_cast<Der&>(*this); }
+  dependency_map_t dependency_;
+};
+
+template <typename ID, typename P, typename Der>
+class ColdObjectTracker
+    : public DependencyTracker<ID, P, ColdObjectTracker<ID, P, Der>> {
+ public:
+  using cold_object_map_t = tbb::concurrent_hash_map<ID, std::shared_ptr<P>>;
+
+  ColdObjectTracker() {}
+
+  Status RemoveFromColdList(ID const& id) {
+    typename cold_object_map_t::accessor accessor;
+    if (cold_objects_.find(accessor, id)) {
+      cold_objects_.erase(id);
+    }
+    return Status::OK();
+  }
+
+  using DependencyTracker<ID, P, ColdObjectTracker<ID, P, Der>>::AddDependency;
+  using DependencyTracker<ID, P,
+                          ColdObjectTracker<ID, P, Der>>::RemoveDependency;
+
+  Status AddDependency(ID const& id, int conn) {
+    RETURN_ON_ERROR(this->AddDependency(id, conn));
+    RETURN_ON_ERROR(this->RemoveFromColdList(id));
+  }
+
+  Status MarkAsCold(ID const& id, std::shared_ptr<P> payload) {
+    typename cold_object_map_t::accessor accessor;
+    if (!cold_objects_.find(accessor, id)) {
+      cold_objects_.emplace(id, payload);
+    }
+    return Status::OK();
+  }
+
+  Status FetchAndModify(ID const& id, int64_t& ref_cnt, int64_t changes) {
+    return Self().FetchAndModify(id, ref_cnt, changes);
+  }
+
+  Status OnRelease(ID const& id) { return Self().OnRelease(id); }
+
+  Status OnDelete(ID const& id) { return Self().OnDelete(id); }
+
+ private:
+  inline Der& Self() { return static_cast<Der&>(*this); }
+  cold_object_map_t cold_objects_;
+};
+
+}  // namespace vineyard
+
+#endif  // SRC_SERVER_MEMORY_USAGE_H_

--- a/src/server/server/vineyard_server.h
+++ b/src/server/server/vineyard_server.h
@@ -147,6 +147,10 @@ class VineyardServer : public std::enable_shared_from_this<VineyardServer> {
   Status DelData(const std::vector<ObjectID>& id, const bool force,
                  const bool deep, const bool fastpath, callback_t<> callback);
 
+  Status DelData(const std::vector<ObjectID>& id, const bool force,
+                 const bool deep, const bool fastpath,
+                 callback_t<std::vector<ObjectID> const&> callback);
+
   Status DeleteBlobBatch(const std::set<ObjectID>& blobs);
 
   Status DeleteAllAt(const json& meta, InstanceID const instance_id);

--- a/src/server/services/meta_service.h
+++ b/src/server/services/meta_service.h
@@ -276,14 +276,14 @@ class IMetaService : public std::enable_shared_from_this<IMetaService> {
       callback_t<const json&, std::vector<ObjectID> const&, std::vector<op_t>&,
                  bool&>
           callback_after_ready,
-      callback_t<> callback_after_finish) {
+      callback_t<std::vector<ObjectID> const&> callback_after_finish) {
     auto self(shared_from_this());
     server_ptr_->GetMetaContext().post([self, object_ids, force, deep,
                                         callback_after_ready,
                                         callback_after_finish]() {
       if (self->stopped_.load()) {
         VINEYARD_DISCARD(callback_after_finish(
-            Status::AlreadyStopped("etcd metadata service")));
+            Status::AlreadyStopped("etcd metadata service"), {}));
       }
 
       // generated ops.
@@ -304,7 +304,7 @@ class IMetaService : public std::enable_shared_from_this<IMetaService> {
       auto s = callback_after_ready(Status::OK(), self->meta_,
                                     processed_delete_set, ops, sync_remote);
       if (!s.ok()) {
-        VINEYARD_DISCARD(callback_after_finish(s));
+        VINEYARD_DISCARD(callback_after_finish(s, {}));
         return;
       }
 
@@ -312,7 +312,7 @@ class IMetaService : public std::enable_shared_from_this<IMetaService> {
       self->metaUpdate(ops, false);
 
       if (!sync_remote) {
-        VINEYARD_DISCARD(callback_after_finish(s));
+        VINEYARD_DISCARD(callback_after_finish(s, processed_delete_set));
         return;
       }
 
@@ -338,15 +338,30 @@ class IMetaService : public std::enable_shared_from_this<IMetaService> {
                 // update rev_ to the revision after unlock.
                 unsigned rev_after_unlock = 0;
                 VINEYARD_DISCARD(lock->Release(rev_after_unlock));
-                return callback_after_finish(status);
+                return callback_after_finish(status, {});
               });
               return Status::OK();
             } else {
               LOG(ERROR) << status.ToString();
-              return callback_after_finish(status);  // propogate the error.
+              return callback_after_finish(status, {});  // propogate the error.
             }
           });
     });
+  }
+
+  inline void RequestToDelete(
+      const std::vector<ObjectID>& object_ids, const bool force,
+      const bool deep,
+      callback_t<const json&, std::vector<ObjectID> const&, std::vector<op_t>&,
+                 bool&>
+          callback_after_ready,
+      callback_t<> callback_after_finish) {
+    RequestToDelete(
+        object_ids, force, deep, callback_after_ready,
+        [callback_after_finish](Status const& status,
+                                std::vector<ObjectID> const& deleted_ids) {
+          return callback_after_finish(status);
+        });
   }
 
   inline void RequestToShallowCopy(

--- a/src/server/services/meta_service.h
+++ b/src/server/services/meta_service.h
@@ -350,21 +350,6 @@ class IMetaService : public std::enable_shared_from_this<IMetaService> {
     });
   }
 
-  inline void RequestToDelete(
-      const std::vector<ObjectID>& object_ids, const bool force,
-      const bool deep,
-      callback_t<const json&, std::vector<ObjectID> const&, std::vector<op_t>&,
-                 bool&>
-          callback_after_ready,
-      callback_t<> callback_after_finish) {
-    RequestToDelete(
-        object_ids, force, deep, callback_after_ready,
-        [callback_after_finish](Status const& status,
-                                std::vector<ObjectID> const& deleted_ids) {
-          return callback_after_finish(status);
-        });
-  }
-
   inline void RequestToShallowCopy(
       callback_t<const json&, std::vector<op_t>&, bool&> callback_after_ready,
       callback_t<> callback_after_finish) {

--- a/test/deep_copy_test.cc
+++ b/test/deep_copy_test.cc
@@ -49,6 +49,7 @@ int main(int argc, char** argv) {
   ObjectID target_id = InvalidObjectID();
   VINEYARD_CHECK_OK(client.DeepCopy(id, target_id));
   CHECK(target_id != InvalidObjectID());
+  std::cout << "Deep copied object id: " << target_id << std::endl;
 
   auto copied_vec =
       std::dynamic_pointer_cast<Array<double>>(client.GetObject(target_id));

--- a/test/delete_test.cc
+++ b/test/delete_test.cc
@@ -73,7 +73,8 @@ int main(int argc, char** argv) {
   CHECK(exists);
   VINEYARD_CHECK_OK(client.Exists(blob_id, exists));
   CHECK(exists);
-  LOG(INFO) << "delete id: " << id << ": " << ObjectIDToString(id);
+  LOG(INFO) << "delete id = " << ObjectIDToString(id)
+            << ", blob id = " << ObjectIDToString(blob_id);
   VINEYARD_CHECK_OK(client.DelData(id, false, true));
   VINEYARD_CHECK_OK(client.Exists(id, exists));
   CHECK(!exists);
@@ -225,6 +226,8 @@ int main(int argc, char** argv) {
     CHECK(blob_id != InvalidObjectID());
   }
 
+  LOG(INFO) << "deep deletion id = " << ObjectIDToString(id)
+            << ", blob id = " << ObjectIDToString(blob_id);
   // force deletion
   VINEYARD_CHECK_OK(client.Exists(id, exists));
   CHECK(exists);
@@ -243,6 +246,8 @@ int main(int argc, char** argv) {
     CHECK(s.ok() && buffers.size() == 0);
   }
 
+  LOG(INFO) << "deep deletion OK";
+
   {
     // prepare data
     std::vector<double> double_array = {1.0, 7.0, 3.0, 4.0, 2.0};
@@ -254,6 +259,9 @@ int main(int argc, char** argv) {
     blob_id = sealed_double_array->meta().GetMemberMeta("buffer_").GetId();
     CHECK(blob_id != InvalidObjectID());
   }
+
+  LOG(INFO) << "multiple deletion id = " << ObjectIDToString(id)
+            << ", blob id = " << ObjectIDToString(blob_id);
 
   // shallow delete multiple objects
   VINEYARD_CHECK_OK(client.Exists(id, exists));
@@ -316,6 +324,8 @@ int main(int argc, char** argv) {
     tuple_builder.SetValue(2, pair_builder3.Seal(client));
     nested_tuple_id = tuple_builder.Seal(client)->id();
   }
+  LOG(INFO) << "nest deletion id = " << ObjectIDToString(nested_tuple_id);
+
   VINEYARD_CHECK_OK(client.DelData(nested_tuple_id, true, true));
 
   std::shared_ptr<InstanceStatus> status_after;

--- a/test/release_test.cc
+++ b/test/release_test.cc
@@ -1,0 +1,128 @@
+/** Copyright 2020-2022 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#if defined(__APPLE__) && defined(__clang__)
+#define private public
+#define protected public
+#endif
+
+#include <memory>
+#include <string>
+#include <thread>
+#include <unordered_map>
+
+#include "arrow/api.h"
+#include "arrow/io/api.h"
+
+#include "basic/ds/array.h"
+#include "basic/ds/sequence.h"
+#include "client/client.h"
+#include "client/ds/object_meta.h"
+#include "common/util/logging.h"
+
+using namespace vineyard;  // NOLINT(build/namespaces)
+
+int main(int argc, char** argv) {
+  if (argc < 2) {
+    printf("usage ./release_test <ipc_socket>");
+    return 1;
+  }
+  std::string ipc_socket = std::string(argv[1]);
+
+  Client client1, client2;
+  VINEYARD_CHECK_OK(client1.Connect(ipc_socket));
+  VINEYARD_CHECK_OK(client2.Connect(ipc_socket));
+  LOG(INFO) << "Connected to IPCServer: " << ipc_socket;
+
+  ObjectID id = InvalidObjectID(), blob_id = InvalidObjectID(),
+           copy_id = InvalidObjectID();
+
+  {
+    // prepare data
+    std::vector<double> double_array = {1.0, 7.0, 3.0, 4.0, 2.0};
+    ArrayBuilder<double> builder(client1, double_array);
+    auto sealed_double_array =
+        std::dynamic_pointer_cast<Array<double>>(builder.Seal(client1));
+    id = sealed_double_array->id();
+    blob_id = ObjectIDFromString(sealed_double_array->meta()
+                                     .MetaData()["buffer_"]["id"]
+                                     .get_ref<std::string const&>());
+    CHECK(blob_id != InvalidObjectID());
+  }
+
+  {  // basic
+    CHECK(client1.IsInUse(blob_id));
+    VINEYARD_CHECK_OK(client1.Release({id, blob_id}));
+    CHECK(!client1.IsInUse(blob_id));
+  }
+
+  {  // single client
+    auto obj = client1.GetObject(id);
+    CHECK(obj != nullptr);
+    CHECK(client1.IsInUse(blob_id));
+    auto blob = client1.GetObject(blob_id);
+    CHECK(blob != nullptr);
+
+    VINEYARD_CHECK_OK(client1.Release({id}));
+    CHECK(client1.IsInUse(blob_id));
+    VINEYARD_CHECK_OK(client1.Release({blob_id}));
+    CHECK(!client1.IsInUse(blob_id));
+  }
+
+  {  // multiple clients
+    auto blob1 = client1.GetObject(blob_id);
+    CHECK(blob1 != nullptr);
+    auto blob2 = client2.GetObject(blob_id);
+    CHECK(blob2 != nullptr);
+    VINEYARD_CHECK_OK(client1.Release({blob_id}));
+    CHECK(client1.IsInUse(blob_id));
+    VINEYARD_CHECK_OK(client2.Release({blob_id}));
+    CHECK(!client2.IsInUse(blob_id));
+  }
+
+  {  // diamond reference count
+    VINEYARD_CHECK_OK(client1.ShallowCopy(id, copy_id));
+    auto obj1 = client1.GetObject(id);
+    auto obj2 = client1.GetObject(copy_id);
+    CHECK(obj1 != obj2);
+    SequenceBuilder pair_builder1(client1);
+    pair_builder1.SetSize(2);
+    pair_builder1.SetValue(0, obj1);
+    pair_builder1.SetValue(1, obj2);
+    auto wrapper = pair_builder1.Seal(client1);
+    CHECK(wrapper != nullptr);
+    VINEYARD_CHECK_OK(client1.Release({wrapper->id()}));
+    CHECK(client1.IsInUse(blob_id));
+    VINEYARD_CHECK_OK(client1.Release({id}));
+    CHECK(client1.IsInUse(blob_id));
+    VINEYARD_CHECK_OK(client1.Release({copy_id}));
+    CHECK(!client1.IsInUse(blob_id));
+  }
+
+  {  // auto release in disconnection
+    auto obj = client1.GetObject(id);
+    CHECK(obj != nullptr);
+    CHECK(client2.IsInUse(blob_id));
+    client1.Disconnect();
+    sleep(5);
+    CHECK(!client2.IsInUse(blob_id));
+  }
+
+  LOG(INFO) << "Passed release tests...";
+
+  client2.Disconnect();
+
+  return 0;
+}

--- a/test/runner.py
+++ b/test/runner.py
@@ -319,6 +319,7 @@ def run_single_vineyardd_tests(tests):
         run_test(tests, 'name_test')
         run_test(tests, 'persist_test')
         run_test(tests, 'plasma_test')
+        run_test(tests, 'release_test')
         run_test(tests, 'rpc_delete_test', '127.0.0.1:%d' % rpc_socket_port)
         run_test(tests, 'rpc_get_object_test', '127.0.0.1:%d' % rpc_socket_port)
         run_test(tests, 'rpc_test', '127.0.0.1:%d' % rpc_socket_port)


### PR DESCRIPTION
**Goal：**

- On the server-side, maintain a cold object list. To this end, a reference count is added to the `payload`, and when the reference count is 0, it will be recorded in the `cold_object_list`.
- The assumptions to be satisfied: the blob in the `cold_object_list` are not in-use by anyone, and it is safe to do something on them.
- `cold_object_list` is just a record and does not trigger evict/spill/checkpoint. (provides opportunities for these behaviors)

**Design：**

- Track reference counts on `blob` only.
- An unsealed `blob` cannot be counted as a cold object at any time
- There is a cache on the client-side to cache the previously requested blob and keep the availability of these blobs consistent with the server-side
  - For the client-side, a client will cache the reference of a blob after it gets/creates it when the local reference count reaches zero, the client will send a release request to the server to decrease the server-side reference count.
  - For the server-side, each client  will only add at most one to the reference count on the server-side, and for a blob, its reference count is the number of clients it is dependent on
- Server-side reference count:
  - Reference count increases in the following cases：
    - Inc 1 to the first `Get` by the client.
    - Inc 1 when sealed by the client.
    - Inc 1 when received `IncreaseReferenceCountRequest`
    - When the reference count  >0, remove it from the `cold_object_list`.
  -  Reference count decreases in the following cases：
     - Dec 1 when receives a `ReleaseRequest`
     - When the client is disconnected, the server automatically releases all the objects in this client, which requires us to maintain a map of all the objects in each client.
     - When the reference count becomes 0, add it to the `cold_object_list`.
- Client-side reference count:
  - Reference count increases in the following cases：
    - Inc 1 when calling `client.CreateBuffer`
    - Inc 1 when sealing a new object depends on this blob.
    - Inc 1 when hit the cache in `client.Get`
    - If the cache does not have this entry, add it when first `Get`/`Create`
  - Reference count decreases in the following cases：
    - Dec 1 when calling `client.Release`
    - When the client-side reference count reaches 0, send a `ReleaseRequest` to server.
- Corner cases:
  - `DelData` may still force the deletion of these blobs, ignoring their reference counts.
    - When a blob is deleted, it is also removed from the `cold_object_list`.
    - When an object is deleted, 
      - First, all its dependent blobs are released (reducing the local reference count), and 
      - Then the server tells the client which blobs have been really deleted and the client moves them out of the cache.
  - `ShallowCopy` between sessions:
    - In `RemoveOwnership` and `MoveOwnership`, increase an extra reference count for them so that they can never be counted as cold objects.


