### PR TITLE
Enhance the status check macro implementation.

### DIFF
--- a/misc/cpplint.py
+++ b/misc/cpplint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (c) 2009 Google Inc. All rights reserved.
 #

--- a/modules/graph/loader/arrow_fragment_loader.h
+++ b/modules/graph/loader/arrow_fragment_loader.h
@@ -562,7 +562,7 @@ class ArrowFragmentLoader {
   bool generate_eid_;
 
   std::function<void(IIOAdaptor*)> io_deleter_ = [](IIOAdaptor* adaptor) {
-    VINEYARD_CHECK_OK(adaptor->Close());
+    VINEYARD_DISCARD(adaptor->Close());
     delete adaptor;
   };
 };

--- a/src/common/util/status.h
+++ b/src/common/util/status.h
@@ -43,56 +43,55 @@
 
 // raise a std::runtime_error (inherits std::exception), don't FATAL
 #ifndef VINEYARD_CHECK_OK
-#define VINEYARD_CHECK_OK(status)                                              \
-  do {                                                                         \
-    auto _ret = (status);                                                      \
-    if (!_ret.ok()) {                                                          \
-      std::clog << "[error] Check failed: " << _ret.ToString() << " in \""     \
-                << #status << "\""                                             \
-                << ", in function " << VINEYARD_TO_STRING(__PRETTY_FUNCTION__) \
-                << ", file " << __FILE__ << ", line "                          \
-                << VINEYARD_TO_STRING(__LINE__) << std::endl;                  \
-      throw std::runtime_error(                                                \
-          "Check failed: " + _ret.ToString() +                                 \
-          " in \"" #status "\", in function " +                                \
-          std::string(VINEYARD_TO_STRING(__PRETTY_FUNCTION__)) + ", file " +   \
-          __FILE__ + ", line " + VINEYARD_TO_STRING(__LINE__));                \
-    }                                                                          \
+#define VINEYARD_CHECK_OK(status)                                             \
+  do {                                                                        \
+    auto _ret = (status);                                                     \
+    if (!_ret.ok()) {                                                         \
+      std::clog << "[error] Check failed: " << _ret.ToString() << " in \""    \
+                << #status << "\""                                            \
+                << ", in function " << __PRETTY_FUNCTION__ << ", file "       \
+                << __FILE__ << ", line " << VINEYARD_TO_STRING(__LINE__)      \
+                << std::endl;                                                 \
+      throw std::runtime_error("Check failed: " + _ret.ToString() +           \
+                               " in \"" #status "\", in function " +          \
+                               std::string(__PRETTY_FUNCTION__) + ", file " + \
+                               __FILE__ + ", line " +                         \
+                               VINEYARD_TO_STRING(__LINE__));                 \
+    }                                                                         \
   } while (0)
 #endif  // VINEYARD_CHECK_OK
 
 // check the condition, raise and runtime error, rather than `FATAL` when false
 #ifndef VINEYARD_ASSERT_NO_VERBOSE
-#define VINEYARD_ASSERT_NO_VERBOSE(condition)                                  \
-  do {                                                                         \
-    if (!(condition)) {                                                        \
-      std::clog << "[error] Assertion failed in \"" #condition "\""            \
-                << ", in function " << VINEYARD_TO_STRING(__PRETTY_FUNCTION__) \
-                << ", file " << __FILE__ << ", line "                          \
-                << VINEYARD_TO_STRING(__LINE__) << std::endl;                  \
-      throw std::runtime_error(                                                \
-          "Assertion failed in \"" #condition "\", in function " +             \
-          std::string(VINEYARD_TO_STRING(__PRETTY_FUNCTION__)) + ", file " +   \
-          __FILE__ + ", line " + VINEYARD_TO_STRING(__LINE__));                \
-    }                                                                          \
+#define VINEYARD_ASSERT_NO_VERBOSE(condition)                             \
+  do {                                                                    \
+    if (!(condition)) {                                                   \
+      std::clog << "[error] Assertion failed in \"" #condition "\""       \
+                << ", in function '" << __PRETTY_FUNCTION__ << "', file " \
+                << __FILE__ << ", line " << VINEYARD_TO_STRING(__LINE__)  \
+                << std::endl;                                             \
+      throw std::runtime_error(                                           \
+          "Assertion failed in \"" #condition "\", in function '" +       \
+          std::string(__PRETTY_FUNCTION__) + "', file " + __FILE__ +      \
+          ", line " + VINEYARD_TO_STRING(__LINE__));                      \
+    }                                                                     \
   } while (0)
 #endif  // VINEYARD_ASSERT_NO_VERBOSE
 
 // check the condition, raise and runtime error, rather than `FATAL` when false
 #ifndef VINEYARD_ASSERT_VERBOSE
-#define VINEYARD_ASSERT_VERBOSE(condition, message)                            \
-  do {                                                                         \
-    if (!(condition)) {                                                        \
-      std::clog << "[error] Assertion failed in \"" #condition "\": "          \
-                << ", in function " << VINEYARD_TO_STRING(__PRETTY_FUNCTION__) \
-                << ", file " << __FILE__ << ", line "                          \
-                << VINEYARD_TO_STRING(__LINE__) << message << std::endl;       \
-      throw std::runtime_error(                                                \
-          "Assertion failed in \"" #condition "\": " + std::string(message) +  \
-          ", in function " +                                                   \
-          std::string(VINEYARD_TO_STRING(__PRETTY_FUNCTION__)) + ", file " +   \
-          __FILE__ + ", line " + VINEYARD_TO_STRING(__LINE__));                \
-    }                                                                          \
+#define VINEYARD_ASSERT_VERBOSE(condition, message)                           \
+  do {                                                                        \
+    if (!(condition)) {                                                       \
+      std::clog << "[error] Assertion failed in \"" #condition "\": "         \
+                << std::string(message) << ", in function '"                  \
+                << __PRETTY_FUNCTION__ << "', file " << __FILE__ << ", line " \
+                << VINEYARD_TO_STRING(__LINE__) << std::endl;                 \
+      throw std::runtime_error(                                               \
+          "Assertion failed in \"" #condition "\": " + std::string(message) + \
+          ", in function '" + std::string(__PRETTY_FUNCTION__) + "', file " + \
+          __FILE__ + ", line " + VINEYARD_TO_STRING(__LINE__));               \
+    }                                                                         \
   } while (0)
 #endif  // VINEYARD_ASSERT_VERBOSE
 


### PR DESCRIPTION

What do these changes do?
-------------------------

The `__PRETTY_FUNCTION__` (as well as `__func__`, `__FUNCTION__`) cannot be too long otherwise the GCC will raise an internal error (segmentation fault).

Related issue number
--------------------

Fixes #768 

