### PR TITLE
Change `blob_id` from memory address to randomly generated number.

### DIFF
--- a/src/common/util/uuid.h
+++ b/src/common/util/uuid.h
@@ -87,8 +87,9 @@ inline ObjectID GenerateBlobID(const uintptr_t ptr) {
   return (0x7FFFFFFFFFFFFFFFUL & static_cast<uint64_t>(__rdtsc())) |
          0x8000000000000000UL;
 #else
-  return (0x7FFFFFFFFFFFFFFFUL & static_cast<uint64_t>(rand())) |
-         0x8000000000000000UL;  // NOLINT(runtime/threadsafe_fn)
+  return 0x8000000000000000UL |
+         (0x7FFFFFFFFFFFFFFFUL &
+          static_cast<uint64_t>(rand()));  // NOLINT(runtime/threadsafe_fn)
 #endif
 }
 

--- a/src/common/util/uuid.h
+++ b/src/common/util/uuid.h
@@ -82,16 +82,14 @@ auto static_if(T t) {
   return static_if(std::integral_constant<bool, B>{}, t, [](auto&&...) {});
 }
 
-// blob id: 1 + memory address (in vineyardd)
-// non-blob id: 0 + random (rdstc)
-inline void* GetBlobAddr(ObjectID const id) {
-  return (id & 0x8000000000000000UL)
-             ? reinterpret_cast<void*>(id & 0x7FFFFFFFFFFFFFFFUL)
-             : nullptr;
-}
-
 inline ObjectID GenerateBlobID(const uintptr_t ptr) {
-  return 0x8000000000000000UL | reinterpret_cast<uintptr_t>(ptr);
+#if defined(__x86_64__)
+  return (0x7FFFFFFFFFFFFFFFUL & static_cast<uint64_t>(__rdtsc())) |
+         0x8000000000000000UL;
+#else
+  return (0x7FFFFFFFFFFFFFFFUL & static_cast<uint64_t>(rand())) |
+         0x8000000000000000UL;  // NOLINT(runtime/threadsafe_fn)
+#endif
 }
 
 inline SessionID GenerateSessionID() {


### PR DESCRIPTION
As titled. The memory address becomes invalid after reloading a spilled blob.