### PR TITLE
Add the build-repo-tarball CI to github actions

### DIFF
--- a/.github/workflows/build-repo-tarball.yaml
+++ b/.github/workflows/build-repo-tarball.yaml
@@ -1,0 +1,59 @@
+# Copyright 2020-2022 Alibaba Group Holding Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Build Repository Tarball
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build-repo-tarball:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Make the repository tarball
+        run: |
+          ./misc/git-archive-submodules.sh
+      - name: Extract tag name
+        id: tag
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
+        run: echo ::set-output name=TAG::${GITHUB_REF#refs/tags/}
+
+      - name: Upload wheels to tagged release
+        uses: svenstaro/upload-release-action@v2
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'v6d-io/v6d' }}
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: v6d-*.*
+          file_glob: true
+          tag: ${{ steps.tag.outputs.TAG }}
+          prerelease: false
+          overwrite: true
+          body: "vineyard repository tarball ${{ steps.tag.outputs.TAG }}"
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ github.event_name == 'workflow_dispatch'}}
+        with:
+          name: vineyard-tarball-${{ github.sha }}
+          path: v6d-*.*


### PR DESCRIPTION

What do these changes do?
-------------------------

Add the github action script for building a source tarball with submodules.

Related issue number
--------------------

See also #757.

