### PR TITLE
Avoid errors when build empty chunks into a byte stream

### DIFF
--- a/modules/io/python/drivers/io/adaptors/deserializer.py
+++ b/modules/io/python/drivers/io/adaptors/deserializer.py
@@ -58,8 +58,9 @@ def copy_bytestream_to_blob(client, bs: ByteStream, blob: BlobBuilder):
         assert offset + len(chunk) <= len(
             buffer
         ), "Failed to reconstruct blobs: buffer out of range"
-        vineyard.memory_copy(buffer, offset, chunk)
-        offset += len(chunk)
+        if len(chunk) > 0:
+            vineyard.memory_copy(buffer, offset, chunk)
+            offset += len(chunk)
     return blob.seal(client)
 
 

--- a/modules/io/python/drivers/io/adaptors/parse_dataframe_to_bytes.py
+++ b/modules/io/python/drivers/io/adaptors/parse_dataframe_to_bytes.py
@@ -63,8 +63,9 @@ def parse_dataframe(vineyard_socket, stream_id, proc_num, proc_index):
 
             # write to byte stream
             first_write = False
-            chunk = stream_writer.next(len(csv_content))
-            vineyard.memory_copy(chunk, 0, csv_content)
+            if len(csv_content) > 0:
+                chunk = stream_writer.next(len(csv_content))
+                vineyard.memory_copy(chunk, 0, csv_content)
     except Exception:
         report_exception()
         stream_writer.fail()

--- a/modules/io/python/drivers/io/adaptors/read_bytes.py
+++ b/modules/io/python/drivers/io/adaptors/read_bytes.py
@@ -158,8 +158,9 @@ def read_bytes(  # noqa: C901
                     if size <= 0:
                         break
                     begin += size - 1
-                    chunk = writer.next(size)
-                    vineyard.memory_copy(chunk, 0, buffer)
+                    if size > 0:
+                        chunk = writer.next(size)
+                        vineyard.memory_copy(chunk, 0, buffer)
         writer.finish()
     except Exception:
         report_exception()

--- a/modules/io/python/drivers/io/adaptors/read_bytes_collection.py
+++ b/modules/io/python/drivers/io/adaptors/read_bytes_collection.py
@@ -79,9 +79,10 @@ def read_byte_stream(
             begin, end = 0, total_size
             while begin < end:
                 buffer = read_block(f, begin, min(chunk_size, end - begin))
-                chunk = writer.next(len(buffer))
-                vineyard.memory_copy(chunk, 0, buffer)
-                begin += len(buffer)
+                if len(buffer) > 0:
+                    chunk = writer.next(len(buffer))
+                    vineyard.memory_copy(chunk, 0, buffer)
+                    begin += len(buffer)
         except Exception:
             report_exception()
             writer.fail()

--- a/modules/io/python/drivers/io/adaptors/serializer.py
+++ b/modules/io/python/drivers/io/adaptors/serializer.py
@@ -58,9 +58,10 @@ def serialize_blob_to_stream(
     writer: ByteStream.Writer = stream.open_writer()
     while offset < total_size:
         current_chunk_size = min(chunk_size, total_size - offset)
-        chunk = writer.next(current_chunk_size)
-        vineyard.memory_copy(chunk, 0, blob[offset : offset + current_chunk_size])
-        offset += current_chunk_size
+        if current_chunk_size > 0:
+            chunk = writer.next(current_chunk_size)
+            vineyard.memory_copy(chunk, 0, blob[offset : offset + current_chunk_size])
+            offset += current_chunk_size
     logger.info('finished processing blob at %s', stream.params.get('path', 'UNKNOWN'))
     writer.finish()
 

--- a/python/pybind11_utils.cc
+++ b/python/pybind11_utils.cc
@@ -217,7 +217,7 @@ Status copy_memoryview_to_memoryview(PyObject* src, PyObject* dst,
   }
 
   // skip none buffers
-  if (src_buffer.data() == nullptr) {
+  if (src_buffer.data() == nullptr || src_buffer.size() == 0) {
     return Status::OK();
   }
 

--- a/python/vineyard/io/byte.py
+++ b/python/vineyard/io/byte.py
@@ -149,8 +149,9 @@ class ByteStream(BaseStream):
         def _try_flush_buffer(self, force=False):
             view = self._buffer.getbuffer()
             if len(view) >= self._buffer_size_limit or (force and len(view) > 0):
-                chunk = self.next(len(view))
-                memory_copy(chunk, 0, view)
+                if len(view) > 0:
+                    chunk = self.next(len(view))
+                    memory_copy(chunk, 0, view)
                 self._buffer = BytesIO()
 
         def finish(self):

--- a/python/vineyard/io/dataframe.py
+++ b/python/vineyard/io/dataframe.py
@@ -144,8 +144,9 @@ class DataframeStream(BaseStream):
             with pa.ipc.new_stream(sink, batch.schema) as writer:
                 writer.write(batch)
             view = sink.getbuffer()
-            buffer = self.next(len(view))
-            memory_copy(buffer, 0, view)
+            if len(view) > 0:
+                buffer = self.next(len(view))
+                memory_copy(buffer, 0, view)
 
         def write_table(self, table: pa.Table):
             for batch in table.to_batches():


### PR DESCRIPTION
What do these changes do?
-------------------------

- Fixes the check in `copy_memoryview_to_memoryview`: avoid errors when copying empty blob
- Add severals checks to avoid empty chunks during building a byte stream.

Related issue number
--------------------

Fixes #781

