### PR TITLE
Fixes decompressing un-continuous chunks of a blob. 

### DIFF
--- a/modules/io/python/drivers/io/adaptors/deserializer.py
+++ b/modules/io/python/drivers/io/adaptors/deserializer.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 #
 
+import io
 import json
 import logging
 import os
@@ -40,8 +41,6 @@ from vineyard.io.utils import report_exception
 from vineyard.io.utils import report_success
 
 logger = logging.getLogger('vineyard')
-
-CHUNK_SIZE = 1024 * 1024 * 128
 
 
 def decompress_chunk(blob: memoryview, serialization_options: Dict[str, str]):
@@ -69,18 +68,29 @@ def copy_bytestream_to_blob(client, bs: ByteStream, blob: BlobBuilder):
     offset = 0
     reader = bs.open_reader(client)
     buffer = blob.buffer
+    raw_buffer = io.BytesIO()
     while True:
         try:
             chunk = reader.next()
         except (StopIteration, vineyard.StreamDrainedException):
             break
-        chunk = decompress_chunk(chunk, serialization_options)
         assert offset + len(chunk) <= len(
             buffer
-        ), "Failed to reconstruct blobs: buffer out of range"
-        if len(chunk) > 0:
-            vineyard.memory_copy(buffer, offset, chunk)
-            offset += len(chunk)
+        ), "Failed to reconstruct blobs: buffer out of range: %d vs. %d" % (
+            offset + len(chunk),
+            len(buffer),
+        )
+        raw_buffer.write(chunk)
+    blob_data = decompress_chunk(raw_buffer.getbuffer(), serialization_options)
+    assert len(blob_data) <= len(
+        buffer
+    ), "The source and destination buffer sizes don't match: %d vs. %d" % (
+        len(blob_data),
+        len(buffer),
+    )
+    if len(blob_data) > 0:
+        vineyard.memory_copy(buffer, offset, blob_data)
+        offset += len(blob_data)
     return blob.seal(client)
 
 

--- a/modules/io/python/drivers/io/adaptors/deserializer.py
+++ b/modules/io/python/drivers/io/adaptors/deserializer.py
@@ -74,12 +74,6 @@ def copy_bytestream_to_blob(client, bs: ByteStream, blob: BlobBuilder):
             chunk = reader.next()
         except (StopIteration, vineyard.StreamDrainedException):
             break
-        assert offset + len(chunk) <= len(
-            buffer
-        ), "Failed to reconstruct blobs: buffer out of range: %d vs. %d" % (
-            offset + len(chunk),
-            len(buffer),
-        )
         raw_buffer.write(chunk)
     blob_data = decompress_chunk(raw_buffer.getbuffer(), serialization_options)
     assert len(blob_data) <= len(


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

A compressed blob might be sent to a stream as several chunks.

Related issue number
--------------------

Follow-up work for #784 
