### PR TITLE
Add a Client::CreateMetaData overloading to allow placing metadata to specified instance

### DIFF
--- a/python/client.cc
+++ b/python/client.cc
@@ -114,6 +114,16 @@ void bind_client(py::module& mod) {
           },
           "metadata"_a)
       .def(
+          "create_metadata",
+          [](ClientBase* self, ObjectMeta& metadata,
+             InstanceID const& instance_id) -> ObjectMeta& {
+            ObjectID object_id;
+            throw_on_error(
+                self->CreateMetaData(metadata, instance_id, object_id));
+            return metadata;
+          },
+          "metadata"_a, "instance_id"_a)
+      .def(
           "delete",
           [](ClientBase* self, const ObjectIDWrapper object_id,
              const bool force, const bool deep) {

--- a/python/vineyard/_vineyard_docs.py
+++ b/python/vineyard/_vineyard_docs.py
@@ -495,6 +495,20 @@ Parameters:
 
 Returns:
     The result created metadata.
+
+.. method:: create_metadata(metadata: ObjectMeta, instance_id: InstanceID) -> ObjectMeta
+    :noindex:
+
+Create metadata in vineyardd with a specified instance id.
+
+Parameters:
+    metadata: ObjectMeta
+        The metadata that will be created on vineyardd.
+    instance_id: InstanceID
+        The instance to place the object metadata.
+
+Returns:
+    The result created metadata.
 ''',
 )
 

--- a/src/client/client_base.h
+++ b/src/client/client_base.h
@@ -114,6 +114,22 @@ class ClientBase {
   Status CreateMetaData(ObjectMeta& meta_data, ObjectID& id);
 
   /**
+   * @brief Create the metadata in the vineyard server with specified instance
+   * id, after created, the resulted object id in the `meta_data` will be
+   * filled.
+   *
+   * The specified instance id is required that the metadata can be created
+   * using the RPC client on the specified instance as a placeholder.
+   *
+   * @param meta_data The metadata that will be created in vineyard.
+   * @param id The returned object ID of the created metadata.
+   *
+   * @return Status that indicates whether the create action has succeeded.
+   */
+  Status CreateMetaData(ObjectMeta& meta_data, InstanceID const& instance_id,
+                        ObjectID& id);
+
+  /**
    * @brief Get the meta-data of the requested object
    *
    * @param id The ID of the requested object


### PR DESCRIPTION


What do these changes do?
-------------------------

It will be used when we need to create a global object with several local parts as place holder.

Related issue number
--------------------

N/A
