### PR TITLE
Use cpu_count() as the default parallelism for IO serialization/deserialization

### DIFF
--- a/modules/io/python/drivers/io/adaptors/deserializer.py
+++ b/modules/io/python/drivers/io/adaptors/deserializer.py
@@ -19,6 +19,7 @@
 import io
 import json
 import logging
+import multiprocessing
 import os
 import sys
 from queue import Empty as QueueEmptyException
@@ -197,7 +198,7 @@ def deserialize(vineyard_socket, object_id, proc_num, proc_index):
     # copy blobs
     executor = ThreadStreamExecutor(
         ReconstructExecututor,
-        parallism=1,
+        parallism=multiprocessing.cpu_count(),
         client=client,
         task_queue=queue,
         result_queue=rqueue,

--- a/modules/io/python/drivers/io/adaptors/read_bytes_collection.py
+++ b/modules/io/python/drivers/io/adaptors/read_bytes_collection.py
@@ -19,6 +19,7 @@
 import base64
 import json
 import logging
+import multiprocessing
 import os
 import sys
 from queue import Empty as QueueEmptyException
@@ -194,7 +195,7 @@ def read_bytes_collection(
     logger.info("start reading blobs ...")
     executor = ThreadStreamExecutor(
         ReadToByteStreamExecutor,
-        parallism=1,
+        parallism=multiprocessing.cpu_count(),
         client=client,
         fs=fs,
         task_queue=queue,

--- a/modules/io/python/drivers/io/adaptors/serializer.py
+++ b/modules/io/python/drivers/io/adaptors/serializer.py
@@ -19,6 +19,7 @@
 import base64
 import json
 import logging
+import multiprocessing
 import os
 import sys
 from queue import Empty as QueueEmptyException
@@ -183,7 +184,7 @@ def serialize(vineyard_socket, object_id, serialization_options):
     # easy to be implemented as a threaded executor in a future
     executor = ThreadStreamExecutor(
         SerializeExecutor,
-        parallism=1,
+        parallism=multiprocessing.cpu_count(),
         task_queue=queue,
         serialization_options=serialization_options,
     )

--- a/modules/io/python/drivers/io/adaptors/write_bytes_collection.py
+++ b/modules/io/python/drivers/io/adaptors/write_bytes_collection.py
@@ -19,6 +19,7 @@
 import base64
 import json
 import logging
+import multiprocessing
 import os
 import sys
 from queue import Empty as QueueEmptyException
@@ -156,7 +157,7 @@ def write_bytes_collection(
     # write streams to file
     executor = ThreadStreamExecutor(
         WriteBytesExecutor,
-        parallism=1,
+        parallism=multiprocessing.cpu_count(),
         client=client,
         prefix=worker_prefix,
         storage_options=storage_options,

--- a/python/vineyard/io/utils.py
+++ b/python/vineyard/io/utils.py
@@ -19,6 +19,7 @@
 import concurrent
 import concurrent.futures
 import json
+import multiprocessing
 import os
 import traceback
 
@@ -96,8 +97,11 @@ class BaseStreamExecutor:
 
 
 class ThreadStreamExecutor:
-    def __init__(self, executor_cls, parallism: int = 1, **kwargs):
-        self._parallism = parallism
+    def __init__(self, executor_cls, parallism: int = None, **kwargs):
+        if parallism is None:
+            self._parallism = multiprocessing.cpu_count()
+        else:
+            self._parallism = parallism
         self._executors = [executor_cls(**kwargs) for _ in range(self._parallism)]
 
     def execute(self):


### PR DESCRIPTION

What do these changes do?
-------------------------

Use `cpu_count()` to leveraging multi-threading serilaization/deserilization.

Related issue number
--------------------

N/A
