### PR TITLE
Support lru in `ColdObjectTracker`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -774,6 +774,10 @@ if(BUILD_VINEYARD_TESTS)
             target_compile_options(${T_NAME} PRIVATE "-fno-access-control")
         endif()
 
+        if(${T_NAME} STREQUAL "lru_test")
+            target_link_libraries(${T_NAME} PRIVATE TBB::tbb)
+        endif()
+
         if(${T_NAME} STREQUAL "allocator_test"
                 OR ${T_NAME} STREQUAL "arena_test"
                 OR ${T_NAME} STREQUAL "jemalloc_test")

--- a/test/lru_test.cc
+++ b/test/lru_test.cc
@@ -1,0 +1,63 @@
+/** Copyright 2020-2022 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <memory>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#include "server/memory/usage.h"
+
+#define LRU \
+  detail::ColdObjectTracker<uint64_t, std::string, decltype(nullptr)>::LRU
+
+using namespace vineyard;  // NOLINT
+using namespace std;       // NOLINT
+
+void BasicTest() {
+  LRU lru_;
+  vector<uint64_t> ids;
+  vector<shared_ptr<string>> payloads;
+  ids.reserve(1000);
+  payloads.reserve(1000);
+  {
+    // insert
+    for (int i = 0; i < 1000; i++) {
+      ids.push_back(i);
+      payloads.push_back(make_shared<string>(to_string(i)));
+      lru_.Ref(ids.back(), payloads.back());
+    }
+  }
+  {
+    for (int i = 0; i < 1000; i++) {
+      CHECK(lru_.CheckExist(i));
+    }
+  }
+  {
+    // Pop and check if id pops from 999 to 0
+    for (int i = 0; i < 1000; i++) {
+      auto ret = lru_.PopLeastUsed();
+      CHECK(ret.first.ok());
+      CHECK(ret.second.first == static_cast<uint64_t>(i));
+    }
+  }
+}
+
+int main(int argc, char** argv) {
+  BasicTest();
+  LOG(INFO) << "Passed lru tests...";
+  return 0;
+}

--- a/test/runner.py
+++ b/test/runner.py
@@ -338,6 +338,7 @@ def run_single_vineyardd_tests(tests):
         run_test(tests, 'invalid_connect_test', '127.0.0.1:%d' % rpc_socket_port)
         run_test(tests, 'large_meta_test')
         run_test(tests, 'list_object_test')
+        run_test(tests, 'lru_test')
         run_test(tests, 'name_test')
         run_test(tests, 'persist_test')
         run_test(tests, 'plasma_test')


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

<!-- Please give a short brief about these changes. -->
In this PR, I will build a LRU for ColdObjectTracker, to keep track of the oldest unused `Obj ID`.
Mainly prepare for later implementation of `spill`.

In detail, I sketched a LRU by a `doubly-linked list` and  `hash table` -- A classic implementation of LRU. Due to the limitation of currently used cpp version (C++14), the synchronize mechanism I firstly choosed was `std::shared_mutex` in C++17, then I changed to `std:: shared_timed_mutex`, but they should have no difference in our scenario.  [see here](https://stackoverflow.com/questions/40207171/why-shared-timed-mutex-is-defined-in-c14-but-shared-mutex-in-c17)

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #724(partially) and https://github.com/v6d-io/v6d/issues/739

TODOs
-------

- [ ]  Add UnitTest 

- [x] Encounter a problem when I attempt to run test on my server. Plz kindly refer to disscussion ([Disccussion here](https://github.com/v6d-io/v6d/discussions/741))

Updates
--------
6.21 Add a basic unit test. Have a semantic problem with LRU -- Do we need update the position(like move it to the head position) for the blob when `CheckExists(id)` is called? @septicmk 