### PR TITLE
Add the contrib directory to vineyard include dirs.

### DIFF
--- a/vineyard-config.in.cmake
+++ b/vineyard-config.in.cmake
@@ -51,7 +51,8 @@ include("${CMAKE_CURRENT_LIST_DIR}/vineyard-targets.cmake")
 
 set(VINEYARD_LIBRARIES @VINEYARD_INSTALL_LIBS@)
 set(VINEYARD_INCLUDE_DIR "${VINEYARD_HOME}/include"
-                         "${VINEYARD_HOME}/include/vineyard")
+                         "${VINEYARD_HOME}/include/vineyard"
+                         "${VINEYARD_HOME}/include/vineyard/contrib")
 set(VINEYARD_INCLUDE_DIRS "${VINEYARD_INCLUDE_DIR}")
 
 set(VINEYARDD_EXECUTABLE "${VINEYARD_HOME}/bin/vineyardd")


### PR DESCRIPTION
What do these changes do?
-------------------------

As titled. to make sure `VINEYARD_INCLUDE_DIRS` behaves as expected.

Related issue number
--------------------

N/A
