### PR TITLE
Fix the bug that macosx thread explicitly marked deleted

### DIFF
--- a/modules/graph/fragment/arrow_fragment.h
+++ b/modules/graph/fragment/arrow_fragment.h
@@ -92,7 +92,7 @@ class BasicArrowFragmentBuilder
       auto fn = [this, i](Client* client) {
         vineyard::TableBuilder vt(*client, vertex_tables_[i]);
         this->set_vertex_tables_(
-            i, std::dynamic_pointer_cast<vineyard::Table>(vt.Seal(client)));
+            i, std::dynamic_pointer_cast<vineyard::Table>(vt.Seal(*client)));
 
         vineyard::NumericArrayBuilder<vid_t> ovgid_list_builder(
             *client, ovgid_lists_[i]);

--- a/modules/graph/fragment/arrow_fragment.vineyard-mod
+++ b/modules/graph/fragment/arrow_fragment.vineyard-mod
@@ -973,16 +973,16 @@ class [[vineyard]] ArrowFragment
     ThreadGroup tg;
     {
       // ivnums, ovnums, tvnums
-      auto fn = [this, &builder, &ivnums, &ovnums, &tvnums](Client& client) {
-        vineyard::ArrayBuilder<vid_t> ivnums_builder(client, ivnums);
-        vineyard::ArrayBuilder<vid_t> ovnums_builder(client, ovnums);
-        vineyard::ArrayBuilder<vid_t> tvnums_builder(client, tvnums);
-        builder.set_ivnums_(ivnums_builder.Seal(client));
-        builder.set_ovnums_(ovnums_builder.Seal(client));
-        builder.set_tvnums_(tvnums_builder.Seal(client));
+      auto fn = [this, &builder, &ivnums, &ovnums, &tvnums](Client* client) {
+        vineyard::ArrayBuilder<vid_t> ivnums_builder(*client, ivnums);
+        vineyard::ArrayBuilder<vid_t> ovnums_builder(*client, ovnums);
+        vineyard::ArrayBuilder<vid_t> tvnums_builder(*client, tvnums);
+        builder.set_ivnums_(ivnums_builder.Seal(*client));
+        builder.set_ovnums_(ovnums_builder.Seal(*client));
+        builder.set_tvnums_(tvnums_builder.Seal(*client));
         return Status::OK();
       };
-      tg.AddTask(fn, std::ref(client));
+      tg.AddTask(fn, &client);
     }
 
     // Extra ovgid, ovg2l
@@ -995,49 +995,49 @@ class [[vineyard]] ArrowFragment
       }
     }
     for (label_id_t i = 0; i < total_vertex_label_num; ++i) {
-      auto fn = [this, &builder, i, &ovgid_lists, &ovg2l_maps](Client& client) {
+      auto fn = [this, &builder, i, &ovgid_lists, &ovg2l_maps](Client* client) {
         if (i >= vertex_label_num_ || ovgid_lists[i]->length() != 0) {
           vineyard::NumericArrayBuilder<vid_t> ovgid_list_builder(
-              client, ovgid_lists[i]);
-          builder.set_ovgid_lists_(i, ovgid_list_builder.Seal(client));
+              *client, ovgid_lists[i]);
+          builder.set_ovgid_lists_(i, ovgid_list_builder.Seal(*client));
         }
 
         if (i >= vertex_label_num_ || !ovg2l_maps[i].empty()) {
           vineyard::HashmapBuilder<vid_t, vid_t> ovg2l_builder(
-              client, std::move(ovg2l_maps[i]));
-          builder.set_ovg2l_maps_(i, ovg2l_builder.Seal(client));
+              *client, std::move(ovg2l_maps[i]));
+          builder.set_ovg2l_maps_(i, ovg2l_builder.Seal(*client));
         }
         return Status::OK();
       };
-      tg.AddTask(fn, std::ref(client));
+      tg.AddTask(fn, &client);
     }
 
     // Extra ie_list, oe_list, ie_offset_list, oe_offset_list
     for (label_id_t i = 0; i < total_vertex_label_num; ++i) {
       for (label_id_t j = 0; j < total_edge_label_num; ++j) {
         auto fn = [this, &builder, i, j, &ie_lists, &oe_lists,
-                   &ie_offsets_lists, &oe_offsets_lists](Client& client) {
+                   &ie_offsets_lists, &oe_offsets_lists](Client* client) {
           if (directed_) {
             if (!(i < vertex_label_num_ && j < edge_label_num_)) {
-              vineyard::FixedSizeBinaryArrayBuilder ie_builder(client,
+              vineyard::FixedSizeBinaryArrayBuilder ie_builder(*client,
                                                                ie_lists[i][j]);
-              builder.set_ie_lists_(i, j, ie_builder.Seal(client));
+              builder.set_ie_lists_(i, j, ie_builder.Seal(*client));
             }
             vineyard::NumericArrayBuilder<int64_t> ieo_builder(
-                client, ie_offsets_lists[i][j]);
-            builder.set_ie_offsets_lists_(i, j, ieo_builder.Seal(client));
+                *client, ie_offsets_lists[i][j]);
+            builder.set_ie_offsets_lists_(i, j, ieo_builder.Seal(*client));
           }
           if (!(i < vertex_label_num_ && j < edge_label_num_)) {
-            vineyard::FixedSizeBinaryArrayBuilder oe_builder(client,
+            vineyard::FixedSizeBinaryArrayBuilder oe_builder(*client,
                                                              oe_lists[i][j]);
-            builder.set_oe_lists_(i, j, oe_builder.Seal(client));
+            builder.set_oe_lists_(i, j, oe_builder.Seal(*client));
           }
           vineyard::NumericArrayBuilder<int64_t> oeo_builder(
-              client, oe_offsets_lists[i][j]);
-          builder.set_oe_offsets_lists_(i, j, oeo_builder.Seal(client));
+              *client, oe_offsets_lists[i][j]);
+          builder.set_oe_offsets_lists_(i, j, oeo_builder.Seal(*client));
           return Status::OK();
         };
-        tg.AddTask(fn, std::ref(client));
+        tg.AddTask(fn, &client);
       }
     }
 
@@ -1413,14 +1413,14 @@ class [[vineyard]] ArrowFragment
 
     ThreadGroup tg;
     {
-      auto fn = [this, &builder, &ovnums, &tvnums](Client& client) {
-        vineyard::ArrayBuilder<vid_t> ovnums_builder(client, ovnums);
-        vineyard::ArrayBuilder<vid_t> tvnums_builder(client, tvnums);
-        builder.set_ovnums_(ovnums_builder.Seal(client));
-        builder.set_tvnums_(tvnums_builder.Seal(client));
+      auto fn = [this, &builder, &ovnums, &tvnums](Client* client) {
+        vineyard::ArrayBuilder<vid_t> ovnums_builder(*client, ovnums);
+        vineyard::ArrayBuilder<vid_t> tvnums_builder(*client, tvnums);
+        builder.set_ovnums_(ovnums_builder.Seal(*client));
+        builder.set_tvnums_(tvnums_builder.Seal(*client));
         return Status::OK();
       };
-      tg.AddTask(fn, std::ref(client));
+      tg.AddTask(fn, &client);
     }
 
     // If the map have no new entries, clear it to indicate using the old map
@@ -1431,70 +1431,70 @@ class [[vineyard]] ArrowFragment
       }
     }
     for (label_id_t i = 0; i < vertex_label_num_; ++i) {
-      auto fn = [this, &builder, i, &ovgid_lists, &ovg2l_maps](Client& client) {
+      auto fn = [this, &builder, i, &ovgid_lists, &ovg2l_maps](Client* client) {
         if (ovgid_lists[i]->length() != 0) {
           vineyard::NumericArrayBuilder<vid_t> ovgid_list_builder(
-              client, ovgid_lists[i]);
-          builder.set_ovgid_lists_(i, ovgid_list_builder.Seal(client));
+              *client, ovgid_lists[i]);
+          builder.set_ovgid_lists_(i, ovgid_list_builder.Seal(*client));
         }
 
         if (!ovg2l_maps[i].empty()) {
           vineyard::HashmapBuilder<vid_t, vid_t> ovg2l_builder(
-              client, std::move(ovg2l_maps[i]));
-          builder.set_ovg2l_maps_(i, ovg2l_builder.Seal(client));
+              *client, std::move(ovg2l_maps[i]));
+          builder.set_ovg2l_maps_(i, ovg2l_builder.Seal(*client));
         }
         return Status::OK();
       };
-      tg.AddTask(fn, std::ref(client));
+      tg.AddTask(fn, &client);
     }
 
     // Extra ie_list, oe_list, ie_offset_list, oe_offset_list
     for (label_id_t i = 0; i < vertex_label_num_; ++i) {
       for (label_id_t j = 0; j < extra_edge_label_num; ++j) {
         auto fn = [this, &builder, i, j, &ie_lists, &oe_lists,
-                   &ie_offsets_lists, &oe_offsets_lists](Client& client) {
+                   &ie_offsets_lists, &oe_offsets_lists](Client* client) {
           label_id_t edge_label_id = edge_label_num_ + j;
           if (directed_) {
-            vineyard::FixedSizeBinaryArrayBuilder ie_builder(client,
+            vineyard::FixedSizeBinaryArrayBuilder ie_builder(*client,
                                                              ie_lists[i][j]);
-            builder.set_ie_lists_(i, edge_label_id, ie_builder.Seal(client));
+            builder.set_ie_lists_(i, edge_label_id, ie_builder.Seal(*client));
 
             vineyard::NumericArrayBuilder<int64_t> ieo_builder(
-                client, ie_offsets_lists[i][j]);
+                *client, ie_offsets_lists[i][j]);
             builder.set_ie_offsets_lists_(i, edge_label_id,
-                                          ieo_builder.Seal(client));
+                                          ieo_builder.Seal(*client));
           }
-          vineyard::FixedSizeBinaryArrayBuilder oe_builder(client,
+          vineyard::FixedSizeBinaryArrayBuilder oe_builder(*client,
                                                            oe_lists[i][j]);
-          builder.set_oe_lists_(i, edge_label_id, oe_builder.Seal(client));
+          builder.set_oe_lists_(i, edge_label_id, oe_builder.Seal(*client));
 
           vineyard::NumericArrayBuilder<int64_t> oeo_builder(
-              client, oe_offsets_lists[i][j]);
+              *client, oe_offsets_lists[i][j]);
           builder.set_oe_offsets_lists_(i, edge_label_id,
-                                        oeo_builder.Seal(client));
+                                        oeo_builder.Seal(*client));
           return Status::OK();
         };
-        tg.AddTask(fn, std::ref(client));
+        tg.AddTask(fn, &client);
       }
     }
     for (label_id_t i = 0; i < vertex_label_num_; ++i) {
       for (label_id_t j = 0; j < edge_label_num_; ++j) {
         auto fn = [this, &builder, i, j, &ie_offsets_lists_expanded,
-                   &oe_offsets_lists_expanded](Client& client) {
+                   &oe_offsets_lists_expanded](Client* client) {
           label_id_t edge_label_id = j;
           if (directed_) {
             vineyard::NumericArrayBuilder<int64_t> ieo_builder_expanded(
-                client, ie_offsets_lists_expanded[i][j]);
+                *client, ie_offsets_lists_expanded[i][j]);
             builder.set_ie_offsets_lists_(i, edge_label_id,
-                                          ieo_builder_expanded.Seal(client));
+                                          ieo_builder_expanded.Seal(*client));
           }
           vineyard::NumericArrayBuilder<int64_t> oeo_builder_expanded(
-              client, oe_offsets_lists_expanded[i][j]);
+              *client, oe_offsets_lists_expanded[i][j]);
           builder.set_oe_offsets_lists_(i, edge_label_id,
-                                        oeo_builder_expanded.Seal(client));
+                                        oeo_builder_expanded.Seal(*client));
           return Status::OK();
         };
-        tg.AddTask(fn, std::ref(client));
+        tg.AddTask(fn, &client);
       }
     }
     tg.TakeResults();


### PR DESCRIPTION
The issue would be caused by some certain version of AppleClang.

See also https://stackoverflow.com/questions/27109545/macosx-thread-explicitly-marked-deleted

The error message is
```
/usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/fragment/arrow_fragment.vineyard.h:1536:10: note: in instantiation of function template specialization 'vineyard::ThreadGroup::AddTask<(lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/fragment/arrow_fragment.vineyard.h:1522:17) &, std::reference_wrapper<vineyard::Client>>' requested here
      tg.AddTask(fn, std::ref(client));
         ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.0.sdk/usr/include/c++/v1/type_traits:1916:5: note: '~__nat' has been explicitly marked deleted here
    ~__nat() = delete;
    ^
In file included from /Users/bifenglin/Code/GraphScope/learning_engine/graph-learn/graphlearn/core/graph/storage/vineyard_storage_utils.cc:1:
In file included from /Users/bifenglin/Code/GraphScope/learning_engine/graph-learn/./graphlearn/core/graph/storage/vineyard_storage_utils.h:8:
In file included from /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/fragment/arrow_fragment.h:41:
In file included from /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/fragment/arrow_fragment.vineyard.h:55:
In file included from /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/utils/thread_group.h:18:
/Library/Developer/CommandLineTools/SDKs/MacOSX12.0.sdk/usr/include/c++/v1/future:1684:12: error: attempt to use a deleted function
    return _VSTD::__invoke(__f_.first(), _VSTD::forward<_ArgTypes>(__arg)...);
           ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.0.sdk/usr/include/c++/v1/__config:856:15: note: expanded from macro '_VSTD'
#define _VSTD std::_LIBCPP_ABI_NAMESPACE
              ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.0.sdk/usr/include/c++/v1/future:1640:14: note: in instantiation of member function 'std::__packaged_task_func<std::__bind<(lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/utils/thread_group.h:53:25), unsigned int &, (lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/fragment/arrow_fragment.vineyard.h:1542:19) &, std::reference_wrapper<vineyard::Client>>, std::allocator<std::__bind<(lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/utils/thread_group.h:53:25), unsigned int &, (lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/fragment/arrow_fragment.vineyard.h:1542:19) &, std::reference_wrapper<vineyard::Client>>>, vineyard::Status ()>::operator()' requested here
    explicit __packaged_task_func(_Fp&& __f) : __f_(_VSTD::move(__f), __default_init_tag()) {}
             ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.0.sdk/usr/include/c++/v1/future:1751:32: note: in instantiation of member function 'std::__packaged_task_func<std::__bind<(lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/utils/thread_group.h:53:25), unsigned int &, (lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/fragment/arrow_fragment.vineyard.h:1542:19) &, std::reference_wrapper<vineyard::Client>>, std::allocator<std::__bind<(lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/utils/thread_group.h:53:25), unsigned int &, (lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/fragment/arrow_fragment.vineyard.h:1542:19) &, std::reference_wrapper<vineyard::Client>>>, vineyard::Status ()>::__packaged_task_func' requested here
        ::new ((void*)&__buf_) _FF(_VSTD::forward<_Fp>(__f));
                               ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.0.sdk/usr/include/c++/v1/future:1893:45: note: in instantiation of function template specialization 'std::__packaged_task_function<vineyard::Status ()>::__packaged_task_function<std::__bind<(lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/utils/thread_group.h:53:25), unsigned int &, (lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/fragment/arrow_fragment.vineyard.h:1542:19) &, std::reference_wrapper<vineyard::Client>>>' requested here
        explicit packaged_task(_Fp&& __f) : __f_(_VSTD::forward<_Fp>(__f)) {}
                                            ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.0.sdk/usr/include/c++/v1/memory:2627:37: note: in instantiation of function template specialization 'std::packaged_task<vineyard::Status ()>::packaged_task<std::__bind<(lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/utils/thread_group.h:53:25), unsigned int &, (lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/fragment/arrow_fragment.vineyard.h:1542:19) &, std::reference_wrapper<vineyard::Client>>, void>' requested here
        ::new ((void*)__get_elem()) _Tp(_VSTD::forward<_Args>(__args)...);
                                    ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.0.sdk/usr/include/c++/v1/memory:3385:55: note: in instantiation of function template specialization 'std::__shared_ptr_emplace<std::packaged_task<vineyard::Status ()>, std::allocator<std::packaged_task<vineyard::Status ()>>>::__shared_ptr_emplace<std::__bind<(lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/utils/thread_group.h:53:25), unsigned int &, (lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/fragment/arrow_fragment.vineyard.h:1542:19) &, std::reference_wrapper<vineyard::Client>>>' requested here
    ::new ((void*)_VSTD::addressof(*__guard.__get())) _ControlBlock(__a, _VSTD::forward<_Args>(__args)...);
                                                      ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.0.sdk/usr/include/c++/v1/memory:3394:19: note: in instantiation of function template specialization 'std::allocate_shared<std::packaged_task<vineyard::Status ()>, std::allocator<std::packaged_task<vineyard::Status ()>>, std::__bind<(lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/utils/thread_group.h:53:25), unsigned int &, (lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/fragment/arrow_fragment.vineyard.h:1542:19) &, std::reference_wrapper<vineyard::Client>>, void>' requested here
    return _VSTD::allocate_shared<_Tp>(allocator<_Tp>(), _VSTD::forward<_Args>(__args)...);
                  ^
/usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/utils/thread_group.h:70:22: note: in instantiation of function template specialization 'std::make_shared<std::packaged_task<vineyard::Status ()>, std::__bind<(lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/utils/thread_group.h:53:25), unsigned int &, (lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/fragment/arrow_fragment.vineyard.h:1542:19) &, std::reference_wrapper<vineyard::Client>>, void>' requested here
    auto task = std::make_shared<std::packaged_task<return_t()>>(
                     ^
/usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/fragment/arrow_fragment.vineyard.h:1565:12: note: in instantiation of function template specialization 'vineyard::ThreadGroup::AddTask<(lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/fragment/arrow_fragment.vineyard.h:1542:19) &, std::reference_wrapper<vineyard::Client>>' requested here
        tg.AddTask(fn, std::ref(client));
           ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.0.sdk/usr/include/c++/v1/type_traits:1916:5: note: '~__nat' has been explicitly marked deleted here
    ~__nat() = delete;
    ^
In file included from /Users/bifenglin/Code/GraphScope/learning_engine/graph-learn/graphlearn/core/graph/storage/vineyard_storage_utils.cc:1:
In file included from /Users/bifenglin/Code/GraphScope/learning_engine/graph-learn/./graphlearn/core/graph/storage/vineyard_storage_utils.h:8:
In file included from /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/fragment/arrow_fragment.h:41:
In file included from /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/fragment/arrow_fragment.vineyard.h:55:
In file included from /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/utils/thread_group.h:18:
/Library/Developer/CommandLineTools/SDKs/MacOSX12.0.sdk/usr/include/c++/v1/future:1684:12: error: attempt to use a deleted function
    return _VSTD::__invoke(__f_.first(), _VSTD::forward<_ArgTypes>(__arg)...);
           ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.0.sdk/usr/include/c++/v1/__config:856:15: note: expanded from macro '_VSTD'
#define _VSTD std::_LIBCPP_ABI_NAMESPACE
              ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.0.sdk/usr/include/c++/v1/future:1640:14: note: in instantiation of member function 'std::__packaged_task_func<std::__bind<(lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/utils/thread_group.h:53:25), unsigned int &, (lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/fragment/arrow_fragment.vineyard.h:1570:19) &, std::reference_wrapper<vineyard::Client>>, std::allocator<std::__bind<(lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/utils/thread_group.h:53:25), unsigned int &, (lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/fragment/arrow_fragment.vineyard.h:1570:19) &, std::reference_wrapper<vineyard::Client>>>, vineyard::Status ()>::operator()' requested here
    explicit __packaged_task_func(_Fp&& __f) : __f_(_VSTD::move(__f), __default_init_tag()) {}
             ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.0.sdk/usr/include/c++/v1/future:1751:32: note: in instantiation of member function 'std::__packaged_task_func<std::__bind<(lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/utils/thread_group.h:53:25), unsigned int &, (lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/fragment/arrow_fragment.vineyard.h:1570:19) &, std::reference_wrapper<vineyard::Client>>, std::allocator<std::__bind<(lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/utils/thread_group.h:53:25), unsigned int &, (lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/fragment/arrow_fragment.vineyard.h:1570:19) &, std::reference_wrapper<vineyard::Client>>>, vineyard::Status ()>::__packaged_task_func' requested here
        ::new ((void*)&__buf_) _FF(_VSTD::forward<_Fp>(__f));
                               ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.0.sdk/usr/include/c++/v1/future:1893:45: note: in instantiation of function template specialization 'std::__packaged_task_function<vineyard::Status ()>::__packaged_task_function<std::__bind<(lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/utils/thread_group.h:53:25), unsigned int &, (lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/fragment/arrow_fragment.vineyard.h:1570:19) &, std::reference_wrapper<vineyard::Client>>>' requested here
        explicit packaged_task(_Fp&& __f) : __f_(_VSTD::forward<_Fp>(__f)) {}
                                            ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.0.sdk/usr/include/c++/v1/memory:2627:37: note: in instantiation of function template specialization 'std::packaged_task<vineyard::Status ()>::packaged_task<std::__bind<(lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/utils/thread_group.h:53:25), unsigned int &, (lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/fragment/arrow_fragment.vineyard.h:1570:19) &, std::reference_wrapper<vineyard::Client>>, void>' requested here
        ::new ((void*)__get_elem()) _Tp(_VSTD::forward<_Args>(__args)...);
                                    ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.0.sdk/usr/include/c++/v1/memory:3385:55: note: in instantiation of function template specialization 'std::__shared_ptr_emplace<std::packaged_task<vineyard::Status ()>, std::allocator<std::packaged_task<vineyard::Status ()>>>::__shared_ptr_emplace<std::__bind<(lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/utils/thread_group.h:53:25), unsigned int &, (lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/fragment/arrow_fragment.vineyard.h:1570:19) &, std::reference_wrapper<vineyard::Client>>>' requested here
    ::new ((void*)_VSTD::addressof(*__guard.__get())) _ControlBlock(__a, _VSTD::forward<_Args>(__args)...);
                                                      ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.0.sdk/usr/include/c++/v1/memory:3394:19: note: in instantiation of function template specialization 'std::allocate_shared<std::packaged_task<vineyard::Status ()>, std::allocator<std::packaged_task<vineyard::Status ()>>, std::__bind<(lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/utils/thread_group.h:53:25), unsigned int &, (lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/fragment/arrow_fragment.vineyard.h:1570:19) &, std::reference_wrapper<vineyard::Client>>, void>' requested here
    return _VSTD::allocate_shared<_Tp>(allocator<_Tp>(), _VSTD::forward<_Args>(__args)...);
                  ^
/usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/utils/thread_group.h:70:22: note: in instantiation of function template specialization 'std::make_shared<std::packaged_task<vineyard::Status ()>, std::__bind<(lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/utils/thread_group.h:53:25), unsigned int &, (lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/fragment/arrow_fragment.vineyard.h:1570:19) &, std::reference_wrapper<vineyard::Client>>, void>' requested here
    auto task = std::make_shared<std::packaged_task<return_t()>>(
                     ^
/usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/fragment/arrow_fragment.vineyard.h:1585:12: note: in instantiation of function template specialization 'vineyard::ThreadGroup::AddTask<(lambda at /usr/local/lib/cmake/vineyard/../../../include/vineyard/graph/fragment/arrow_fragment.vineyard.h:1570:19) &, std::reference_wrapper<vineyard::Client>>' requested here
        tg.AddTask(fn, std::ref(client));
           ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.0.sdk/usr/include/c++/v1/type_traits:1916:5: note: '~__nat' has been explicitly marked deleted here
    ~__nat() = delete;
    ^
16 errors generated.
make[3]: *** [CMakeFiles/graphlearn_shared.dir/graphlearn/core/graph/storage/vineyard_storage_utils.cc.o] Error 1
make[2]: *** [CMakeFiles/graphlearn_shared.dir/all] Error 2
make[1]: *** [all] Error 2
make: *** [gle] Error 2
```