### PR TITLE
Revisit the implementation of is_shared_memory testing

### DIFF
--- a/src/client/client.h
+++ b/src/client/client.h
@@ -94,6 +94,10 @@ class SharedMemoryManager {
   Status Mmap(int fd, int64_t map_size, uint8_t* pointer, bool readonly,
               bool realign, uint8_t** ptr);
 
+  Status Mmap(int fd, ObjectID id, int64_t map_size, size_t data_size,
+              size_t data_offset, uint8_t* pointer, bool readonly, bool realign,
+              uint8_t** ptr);
+
   // compute if the given fd requireds a recv_fd and mmap
   int PreMmap(int fd);
 
@@ -110,7 +114,7 @@ class SharedMemoryManager {
 
  private:
   ObjectID resolveObjectID(const uintptr_t target, const uintptr_t key,
-                           const MmapEntry* entry);
+                           const uintptr_t data_size, const ObjectID object_id);
 
   // UNIX-domain socket
   int vineyard_conn_ = -1;
@@ -119,7 +123,7 @@ class SharedMemoryManager {
   std::unordered_map<int, std::unique_ptr<MmapEntry>> mmap_table_;
 
   // sorted shm segments for fast "if exists" query
-  std::map<uintptr_t, MmapEntry*> segments_;
+  std::map<uintptr_t, std::pair<size_t, ObjectID>> segments_;
 };
 
 /**

--- a/src/client/ds/blob.cc
+++ b/src/client/ds/blob.cc
@@ -241,9 +241,10 @@ std::shared_ptr<Object> BlobWriter::_Seal(Client& client) {
   // get blob and re-map
   uint8_t *mmapped_ptr = nullptr, *dist = nullptr;
   if (payload_.data_size > 0) {
-    VINEYARD_CHECK_OK(client.shm_->Mmap(payload_.store_fd, payload_.map_size,
-                                        payload_.pointer - payload_.data_offset,
-                                        false, true, &mmapped_ptr));
+    VINEYARD_CHECK_OK(client.shm_->Mmap(
+        payload_.store_fd, payload_.object_id, payload_.map_size,
+        payload_.data_size, payload_.data_offset,
+        payload_.pointer - payload_.data_offset, false, true, &mmapped_ptr));
     dist = mmapped_ptr + payload_.data_offset;
   }
   auto buffer = arrow::Buffer::Wrap(dist, payload_.data_size);

--- a/test/runner.py
+++ b/test/runner.py
@@ -352,9 +352,7 @@ def run_single_vineyardd_tests(tests):
         run_test(tests, 'session_test')
         run_test(tests, 'signature_test')
         run_test(tests, 'shallow_copy_test')
-        # FIXME: Exists() in client.h can't find the correct ObjectID from pointer
-        # since #839
-        # run_test(tests, 'shared_memory_test')
+        run_test(tests, 'shared_memory_test')
         run_test(tests, 'stream_test')
         run_test(tests, 'tensor_test')
         run_test(tests, 'typename_test')


### PR DESCRIPTION


What do these changes do?
-------------------------

After #839 the objec id for `vineyard::Blob` no longer implies the pointer semantic. To keep track of the shared memory pieces inside the given client, we maintain a blob set and query over the blob set for give raw pointer to resolve the corresponding blob objects.

Related issue number
--------------------

Follow-up work for #839.
