### PR TITLE
Enable mutable blob support.

### DIFF
--- a/python/client.cc
+++ b/python/client.cc
@@ -477,24 +477,25 @@ void bind_client(py::module& mod) {
            })
       .def(
           "get_blob",
-          [](Client* self, const ObjectIDWrapper object_id) {
+          [](Client* self, const ObjectIDWrapper object_id, const bool unsafe) {
             std::shared_ptr<Blob> blob;
-            throw_on_error(self->GetBlob(object_id, blob));
+            throw_on_error(self->GetBlob(object_id, unsafe, blob));
             return blob;
           },
-          "object_id"_a)
+          "object_id"_a, py::arg("unsafe") = false)
       .def(
           "get_blobs",
-          [](Client* self, std::vector<ObjectIDWrapper> object_ids) {
+          [](Client* self, std::vector<ObjectIDWrapper> object_ids,
+             const bool unsafe) {
             std::vector<ObjectID> unwrapped_object_ids(object_ids.size());
             for (size_t idx = 0; idx < object_ids.size(); ++idx) {
               unwrapped_object_ids[idx] = object_ids[idx];
             }
             std::vector<std::shared_ptr<Blob>> blobs;
-            throw_on_error(self->GetBlobs(unwrapped_object_ids, blobs));
+            throw_on_error(self->GetBlobs(unwrapped_object_ids, unsafe, blobs));
             return blobs;
           },
-          "object_ids"_a)
+          "object_ids"_a, py::arg("unsafe") = false)
       .def(
           "get_object",
           [](Client* self, const ObjectIDWrapper object_id) {
@@ -636,25 +637,27 @@ void bind_client(py::module& mod) {
           "remote_blob_builder"_a)
       .def(
           "get_remote_blob",
-          [](RPCClient* self, const ObjectIDWrapper object_id) {
+          [](RPCClient* self, const ObjectIDWrapper object_id,
+             const bool unsafe) {
             std::shared_ptr<RemoteBlob> remote_blob;
-            throw_on_error(self->GetRemoteBlob(object_id, remote_blob));
+            throw_on_error(self->GetRemoteBlob(object_id, unsafe, remote_blob));
             return remote_blob;
           },
-          "object_id"_a)
+          "object_id"_a, py::arg("unsafe") = false)
       .def(
           "get_remote_blobs",
-          [](RPCClient* self, std::vector<ObjectIDWrapper> object_ids) {
+          [](RPCClient* self, std::vector<ObjectIDWrapper> object_ids,
+             const bool unsafe) {
             std::vector<ObjectID> unwrapped_object_ids(object_ids.size());
             for (size_t idx = 0; idx < object_ids.size(); ++idx) {
               unwrapped_object_ids[idx] = object_ids[idx];
             }
             std::vector<std::shared_ptr<RemoteBlob>> remote_blobs;
-            throw_on_error(
-                self->GetRemoteBlobs(unwrapped_object_ids, remote_blobs));
+            throw_on_error(self->GetRemoteBlobs(unwrapped_object_ids, unsafe,
+                                                remote_blobs));
             return remote_blobs;
           },
-          "object_ids"_a)
+          "object_ids"_a, py::arg("unsafe") = false)
       .def(
           "get_object",
           [](RPCClient* self, const ObjectIDWrapper object_id) {

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -393,13 +393,34 @@ class Client : public BasicIPCClient,
   Status GetBlob(ObjectID const id, std::shared_ptr<Blob>& blob);
 
   /**
+   * @brief Get a blob from vineyard server, and optionally bypass the "sealed"
+   * check.
+   *
+   * @param id the blob to get.
+   *
+   * @return Status that indicates whether the get action has succeeded.
+   */
+  Status GetBlob(ObjectID const id, bool unsafe, std::shared_ptr<Blob>& blob);
+
+  /**
    * @brief Get a blob from vineyard server.
    *
    * @param id the blob to get.
    *
    * @return Status that indicates whether the get action has succeeded.
    */
-  Status GetBlobs(std::vector<ObjectID> const id,
+  Status GetBlobs(std::vector<ObjectID> const ids,
+                  std::vector<std::shared_ptr<Blob>>& blobs);
+
+  /**
+   * @brief Get a blob from vineyard server, and optionally bypass the "sealed"
+   * check.
+   *
+   * @param id the blob to get.
+   *
+   * @return Status that indicates whether the get action has succeeded.
+   */
+  Status GetBlobs(std::vector<ObjectID> const ids, const bool unsafe,
                   std::vector<std::shared_ptr<Blob>>& blobs);
 
   /**
@@ -707,12 +728,20 @@ class Client : public BasicIPCClient,
    * @param ids Object ids for the blobs to get.
    * @param buffers: The result immutable blobs will be added to `buffers`.
    *
-   * @return Status that indicates whether the create action has succeeded.
+   * @return Status that indicates whether the get action has succeeded.
    */
   Status GetBuffers(
       const std::set<ObjectID>& ids,
       std::map<ObjectID, std::shared_ptr<arrow::Buffer>>& buffers);
 
+  /**
+   * @brief Get the size of blobs from vineyard server.
+   *
+   * @param ids Object ids for the blobs to get.
+   * @param sizes: The result sizes of immutable blobs will be added to `sizes`.
+   *
+   * @return Status that indicates whether the get action has succeeded.
+   */
   Status GetBufferSizes(const std::set<ObjectID>& ids,
                         std::map<ObjectID, size_t>& sizes);
 
@@ -732,6 +761,13 @@ class Client : public BasicIPCClient,
   Status Seal(ObjectID const& object_id);
 
  private:
+  Status GetBuffers(
+      const std::set<ObjectID>& ids, const bool unsafe,
+      std::map<ObjectID, std::shared_ptr<arrow::Buffer>>& buffers);
+
+  Status GetBufferSizes(const std::set<ObjectID>& ids, const bool unsafe,
+                        std::map<ObjectID, size_t>& sizes);
+
   friend class Blob;
   friend class BlobWriter;
   friend class ObjectBuilder;
@@ -833,6 +869,14 @@ class PlasmaClient
   Status OnDelete(PlasmaID const& id);
 
   using ClientBase::Release;
+
+ private:
+  Status GetPayloads(std::set<PlasmaID> const& plasma_ids, const bool unsafe,
+                     std::map<PlasmaID, PlasmaPayload>& plasma_payloads);
+
+  Status GetBuffers(
+      std::set<PlasmaID> const& plasma_ids, const bool unsafe,
+      std::map<PlasmaID, std::shared_ptr<arrow::Buffer>>& buffers);
 
   friend class detail::UsageTracker<PlasmaID, PlasmaPayload, PlasmaClient>;
 };

--- a/src/client/rpc_client.h
+++ b/src/client/rpc_client.h
@@ -230,9 +230,39 @@ class RPCClient : public ClientBase {
   Status CreateRemoteBlob(std::shared_ptr<RemoteBlobWriter> const& buffer,
                           ObjectID& id);
 
+  /**
+   * @brief Get the remote blob of the connected vineyard server, using the RPC
+   * socket.
+   *
+   * Note that getting remote blobs requires an expensive copy over network.
+   */
   Status GetRemoteBlob(const ObjectID& id, std::shared_ptr<RemoteBlob>& buffer);
+  /**
+   * @brief Get the remote blob of the connected vineyard server, using the RPC
+   * socket, and optionally bypass the "seal" check.
+   *
+   * Note that getting remote blobs requires an expensive copy over network.
+   */
+
+  Status GetRemoteBlob(const ObjectID& id, const bool unsafe,
+                       std::shared_ptr<RemoteBlob>& buffer);
+  /**
+   * @brief Get the remote blobs of the connected vineyard server, using the RPC
+   * socket.
+   *
+   * Note that getting remote blobs requires an expensive copy over network.
+   */
+
   Status GetRemoteBlobs(std::vector<ObjectID> const& ids,
-                        std::vector<std::shared_ptr<RemoteBlob>>& buffers);
+                        std::vector<std::shared_ptr<RemoteBlob>>& remote_blobs);
+  /**
+   * @brief Get the remote blobs of the connected vineyard server, using the RPC
+   * socket. and optionally bypass the "seal" check.
+   *
+   * Note that getting remote blobs requires an expensive copy over network.
+   */
+  Status GetRemoteBlobs(std::vector<ObjectID> const& ids, const bool unsafe,
+                        std::vector<std::shared_ptr<RemoteBlob>>& remote_blobs);
 
  private:
   InstanceID remote_instance_id_;

--- a/src/common/util/lifecycle.h
+++ b/src/common/util/lifecycle.h
@@ -42,7 +42,7 @@ namespace detail {
  *  - `FetchAndModify(ID, int, int)` method to fetch the current `ref_count` and
  * modify it by the given value.
  */
-template <typename ID, typename P, typename Der>
+template <typename ID, typename P, typename Derived>
 class LifeCycleTracker {
  public:
   LifeCycleTracker() {}
@@ -102,7 +102,7 @@ class LifeCycleTracker {
   }
 
  private:
-  inline Der& Self() { return static_cast<Der&>(*this); }
+  inline Derived& Self() { return static_cast<Derived&>(*this); }
   /// Cache the objects that client wants to delete but `ref_count > 0`
   /// Race condition should be settled by Der.
   std::unordered_set<ID> pending_to_delete_;

--- a/src/common/util/protocols.cc
+++ b/src/common/util/protocols.cc
@@ -359,7 +359,8 @@ Status ReadCreateRemoteBufferRequest(const json& root, size_t& size) {
   return Status::OK();
 }
 
-void WriteGetBuffersRequest(const std::set<ObjectID>& ids, std::string& msg) {
+void WriteGetBuffersRequest(const std::set<ObjectID>& ids, const bool unsafe,
+                            std::string& msg) {
   json root;
   root["type"] = "get_buffers_request";
   int idx = 0;
@@ -367,16 +368,19 @@ void WriteGetBuffersRequest(const std::set<ObjectID>& ids, std::string& msg) {
     root[std::to_string(idx++)] = id;
   }
   root["num"] = ids.size();
+  root["unsafe"] = unsafe;
 
   encode_msg(root, msg);
 }
 
-Status ReadGetBuffersRequest(const json& root, std::vector<ObjectID>& ids) {
+Status ReadGetBuffersRequest(const json& root, std::vector<ObjectID>& ids,
+                             bool& unsafe) {
   RETURN_ON_ASSERT(root["type"] == "get_buffers_request");
   size_t num = root["num"].get<size_t>();
   for (size_t i = 0; i < num; ++i) {
     ids.push_back(root[std::to_string(i)].get<ObjectID>());
   }
+  unsafe = root.value("unsafe", false);
   return Status::OK();
 }
 
@@ -412,7 +416,7 @@ Status ReadGetBuffersReply(const json& root, std::vector<Payload>& objects,
 }
 
 void WriteGetRemoteBuffersRequest(const std::unordered_set<ObjectID>& ids,
-                                  std::string& msg) {
+                                  const bool unsafe, std::string& msg) {
   json root;
   root["type"] = "get_remote_buffers_request";
   int idx = 0;
@@ -420,17 +424,19 @@ void WriteGetRemoteBuffersRequest(const std::unordered_set<ObjectID>& ids,
     root[std::to_string(idx++)] = id;
   }
   root["num"] = ids.size();
+  root["unsafe"] = unsafe;
 
   encode_msg(root, msg);
 }
 
-Status ReadGetRemoteBuffersRequest(const json& root,
-                                   std::vector<ObjectID>& ids) {
+Status ReadGetRemoteBuffersRequest(const json& root, std::vector<ObjectID>& ids,
+                                   bool& unsafe) {
   RETURN_ON_ASSERT(root["type"] == "get_remote_buffers_request");
   size_t num = root["num"].get<size_t>();
   for (size_t i = 0; i < num; ++i) {
     ids.push_back(root[std::to_string(i)].get<ObjectID>());
   }
+  unsafe = root.value("unsafe", false);
   return Status::OK();
 }
 
@@ -1268,7 +1274,7 @@ Status ReadCreateBufferByPlasmaReply(json const& root, ObjectID& object_id,
 }
 
 void WriteGetBuffersByPlasmaRequest(std::set<PlasmaID> const& plasma_ids,
-                                    std::string& msg) {
+                                    const bool unsafe, std::string& msg) {
   json root;
   root["type"] = "get_buffers_by_plasma_request";
   int idx = 0;
@@ -1276,17 +1282,20 @@ void WriteGetBuffersByPlasmaRequest(std::set<PlasmaID> const& plasma_ids,
     root[std::to_string(idx++)] = eid;
   }
   root["num"] = plasma_ids.size();
+  root["unsafe"] = unsafe;
 
   encode_msg(root, msg);
 }
 
 Status ReadGetBuffersByPlasmaRequest(const json& root,
-                                     std::vector<PlasmaID>& plasma_ids) {
+                                     std::vector<PlasmaID>& plasma_ids,
+                                     bool& unsafe) {
   RETURN_ON_ASSERT(root["type"] == "get_buffers_by_plasma_request");
   size_t num = root["num"].get<size_t>();
   for (size_t i = 0; i < num; ++i) {
     plasma_ids.push_back(root[std::to_string(i)].get<PlasmaID>());
   }
+  unsafe = root.value("unsafe", false);
   return Status::OK();
 }
 

--- a/src/common/util/protocols.h
+++ b/src/common/util/protocols.h
@@ -217,9 +217,11 @@ void WriteCreateRemoteBufferRequest(const size_t size, std::string& msg);
 
 Status ReadCreateRemoteBufferRequest(const json& root, size_t& size);
 
-void WriteGetBuffersRequest(const std::set<ObjectID>& ids, std::string& msg);
+void WriteGetBuffersRequest(const std::set<ObjectID>& ids, const bool unsafe,
+                            std::string& msg);
 
-Status ReadGetBuffersRequest(const json& root, std::vector<ObjectID>& ids);
+Status ReadGetBuffersRequest(const json& root, std::vector<ObjectID>& ids,
+                             bool& unsafe);
 
 void WriteGetBuffersReply(const std::vector<std::shared_ptr<Payload>>& objects,
                           const std::vector<int>& fd_to_send, std::string& msg);
@@ -228,10 +230,10 @@ Status ReadGetBuffersReply(const json& root, std::vector<Payload>& objects,
                            std::vector<int>& fd_sent);
 
 void WriteGetRemoteBuffersRequest(const std::unordered_set<ObjectID>& ids,
-                                  std::string& msg);
+                                  const bool unsafe, std::string& msg);
 
-Status ReadGetRemoteBuffersRequest(const json& root,
-                                   std::vector<ObjectID>& ids);
+Status ReadGetRemoteBuffersRequest(const json& root, std::vector<ObjectID>& ids,
+                                   bool& unsafe);
 
 void WriteDropBufferRequest(const ObjectID id, std::string& msg);
 
@@ -431,10 +433,11 @@ Status ReadCreateBufferByPlasmaReply(json const& root, ObjectID& object_id,
                                      int& fd_sent);
 
 void WriteGetBuffersByPlasmaRequest(std::set<PlasmaID> const& plasma_ids,
-                                    std::string& msg);
+                                    const bool unsafe, std::string& msg);
 
 Status ReadGetBuffersByPlasmaRequest(json const& root,
-                                     std::vector<PlasmaID>& plasma_ids);
+                                     std::vector<PlasmaID>& plasma_ids,
+                                     bool& unsafe);
 
 void WriteGetBuffersByPlasmaReply(
     std::vector<std::shared_ptr<PlasmaPayload>> const& plasma_objects,

--- a/src/server/memory/memory.h
+++ b/src/server/memory/memory.h
@@ -54,7 +54,10 @@ class BulkStoreBase {
 
   Status Get(ID const& id, std::shared_ptr<P>& object);
 
-  Status GetUnchecked(ID const& id, std::shared_ptr<P>& object);
+  /**
+   * Like `Get()`, but optionally bypass the "sealed" check.
+   */
+  Status GetUnsafe(ID const& id, const bool unsafe, std::shared_ptr<P>& object);
 
   /**
    * This methods only return available objects, and doesn't fail when object
@@ -62,6 +65,9 @@ class BulkStoreBase {
    */
   Status Get(std::vector<ID> const& ids,
              std::vector<std::shared_ptr<P>>& objects);
+
+  Status GetUnsafe(std::vector<ID> const& ids, const bool unsafe,
+                   std::vector<std::shared_ptr<P>>& objects);
 
   bool Exists(ID const& object_id);
 

--- a/test/mutable_blob_test.cc
+++ b/test/mutable_blob_test.cc
@@ -1,0 +1,82 @@
+/** Copyright 2020-2021 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "arrow/api.h"
+#include "arrow/io/api.h"
+
+#include "basic/ds/array.h"
+#include "client/client.h"
+#include "client/ds/object_meta.h"
+#include "common/util/logging.h"
+
+using namespace vineyard;  // NOLINT(build/namespaces)
+
+int main(int argc, char** argv) {
+  if (argc < 2) {
+    printf("usage ./mutable_blob_test <ipc_socket>");
+    return 1;
+  }
+  std::string ipc_socket = std::string(argv[1]);
+
+  Client client1;
+  VINEYARD_CHECK_OK(client1.Connect(ipc_socket));
+  LOG(INFO) << "Connected to IPCServer: " << ipc_socket;
+
+  Client client2;
+  VINEYARD_CHECK_OK(client2.Connect(ipc_socket));
+  LOG(INFO) << "Connected to IPCServer: " << ipc_socket;
+
+  std::unique_ptr<BlobWriter> blob_writer;
+  std::shared_ptr<Blob> blob;
+
+  // create blob
+  VINEYARD_CHECK_OK(client1.CreateBlob(1024, blob_writer));
+
+  // cannot get by default
+  CHECK(client2.GetBlob(blob_writer->id(), blob).IsObjectNotSealed());
+
+  // cannot get as "safe"
+  CHECK(client2.GetBlob(blob_writer->id(), false, blob).IsObjectNotSealed());
+
+  // can get as "unsafe"
+  VINEYARD_CHECK_OK(client2.GetBlob(blob_writer->id(), true, blob));
+  CHECK_EQ(blob->id(), blob_writer->id());
+
+  // seal blob
+  blob_writer->Seal(client1);
+
+  // can get by default after seal
+  VINEYARD_CHECK_OK(client2.GetBlob(blob_writer->id(), blob));
+  CHECK_EQ(blob->id(), blob_writer->id());
+
+  // can get as "safe" after seal
+  VINEYARD_CHECK_OK(client2.GetBlob(blob_writer->id(), false, blob));
+  CHECK_EQ(blob->id(), blob_writer->id());
+
+  // can get as "unsafe" after seal
+  VINEYARD_CHECK_OK(client2.GetBlob(blob_writer->id(), true, blob));
+  CHECK_EQ(blob->id(), blob_writer->id());
+
+  LOG(INFO) << "Passed mutable blob test ...";
+
+  client1.Disconnect();
+  client2.Disconnect();
+
+  return 0;
+}

--- a/test/runner.py
+++ b/test/runner.py
@@ -339,6 +339,7 @@ def run_single_vineyardd_tests(tests):
         run_test(tests, 'large_meta_test')
         run_test(tests, 'list_object_test')
         run_test(tests, 'lru_test')
+        run_test(tests, 'mutable_blob_test')
         run_test(tests, 'name_test')
         run_test(tests, 'persist_test')
         run_test(tests, 'plasma_test')


### PR DESCRIPTION
What do these changes do?
-------------------------

- Enhance the `client.GetBlob` API a `unsafe` option to allow the client obtain a mutable (unsealed) blob from vineyard server.

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #843 

