### PR TITLE
On M1 mac the error is a RuntimeError.

### DIFF
--- a/python/vineyard/deploy/utils.py
+++ b/python/vineyard/deploy/utils.py
@@ -107,7 +107,7 @@ def find_port_probe(start=2048, end=20480):
         try:
             if port not in [conn.laddr.port for conn in psutil.net_connections()]:
                 yield port
-        except psutil.AccessDenied:
+        except (psutil.AccessDenied, RuntimeError):
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                 if s.connect_ex(('localhost', port)) != 0:
                     yield port


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

Add `RuntimeError` to the catch list as well.

Related issue number
--------------------

Fixes #846.

