### PR TITLE
Revisit the python API and documentation for Kubernetes deployment

### DIFF
--- a/charts/vineyard/values.yaml
+++ b/charts/vineyard/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: docker.pkg.github.com/v6d-io/v6d/vineyardd
+  repository: vineyardcloudnative/vineyardd
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tagPrefix: ""

--- a/docs/notes/data-accessing.rst
+++ b/docs/notes/data-accessing.rst
@@ -3,7 +3,7 @@ Shared Data Accessing
 
 Vineyard supports distributed object sharing by-design, and provides both the IPCClient
 and RPCClient for data accessing. You would learn how accessing objects inside vineyard in
-various ways. For a basis about vineyard objects, please refer to :ref:`metadata-and-payloads`.
+various ways. For vineyard objects basics, please refer to :ref:`metadata-and-payloads`.
 
 .. figure:: ../images/vineyard_deployment.jpg
    :alt: Data Partitioning in Vineyard
@@ -17,11 +17,11 @@ partitioned into three chunks and each instance hold one chunk of type :code:`Te
 
 **From the perspective of computing engines**, the distributed computing engines launches
 workers upon the vineyard instances. Each worker connects the co-located local instance and
-is responsible for chunks in the local instance. E.g., we start a Dask cluster on vineyard
-cluster illustrated in the picture above, and each Dask worker is responsible for executing
-computation on its local chunks. Some computing tasks require communication between workers,
-e.g., aggregation. In such cases the communication is performed by the computing engines
-itself (here the Dask cluster).
+is responsible for processing chunks in the local instance. E.g., we start a Dask cluster on
+vineyard cluster illustrated in the picture above, and each Dask worker is responsible for
+executing computation on its local chunks. Some computing tasks require communication between
+workers, e.g., aggregation. In such cases the communication is performed by the computing
+engines itself (here the Dask cluster).
 
 .. tip::
 
@@ -65,7 +65,7 @@ Creating and accessing local objects in vineyard is easy as :code:`put` and :cod
     >>> import pandas as pd
     >>> import vineyard
     >>>
-    >>> vineyard_ipc_client = vineyard_ipc_client = vineyard.connect("/tmp/vineyard.sock")
+    >>> vineyard_ipc_client = vineyard.connect("/tmp/vineyard.sock")
     >>>
     >>> df = pd.DataFrame(np.random.rand(10, 2))
     >>>
@@ -178,7 +178,7 @@ cluster with network transferring cost.
 Accessing object metadata using RPCClient
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The method :meth:`vineyard.RPCClient.get_meta` can be used to accessing the object metadata,
+The method :meth:`vineyard.RPCClient.get_meta` can be used to access the object metadata,
 like :meth:`vineyard.IPCClient.get_meta`, but could be used over the connection to a remote
 instance,
 
@@ -188,6 +188,7 @@ instance,
     >>> import vineyard
     >>> vineyard_rpc_client = vineyard.connect("localhost", 9600)
     >>>
+    >>> # the `r` from the above "Local Objects" section 
     >>> meta = vineyard_rpc_client.get_meta(r)
     >>> meta.id
     o00053008257020f8

--- a/docs/notes/deploy-docker.rst
+++ b/docs/notes/deploy-docker.rst
@@ -9,13 +9,13 @@ on the Github Packages and can be pulled from:
 
 .. code:: shell
 
-    docker pull docker.pkg.github.com/v6d-io/v6d/vineyardd:latest
+    docker pull vineyardcloudnative/vineyardd:latest
 
 The docker images can be used in the following way
 
 .. code:: shell
 
-    docker run --rm -it docker.pkg.github.com/v6d-io/v6d/vineyardd:latest
+    docker run --rm -it vineyardcloudnative/vineyardd:latest
 
 Just like what you can do with a locally installed vineyard package.
 See also `Deploying on Linux/MacOS <https://v6d.io/v6d/notes/deploy-docker.html>`_.

--- a/docs/notes/deploy-kubernetes.rst
+++ b/docs/notes/deploy-kubernetes.rst
@@ -20,17 +20,57 @@ could also be shared using an ``emptyDir``.
 **Note** that when deploying vineyard on Kubernetes, it usually can only be connected
 from containers in the same pod, or pods on the same hosts.
 
-Deployment with Helm
-^^^^^^^^^^^^^^^^^^^^
+Deploying with Helm
+^^^^^^^^^^^^^^^^^^^
 
 Vineyard also has tight integration with Kubernetes and Helm. Vineyard can be deployed
 with ``helm``:
 
 .. code:: shell
 
-   helm repo add vineyard https://vineyard.oss-ap-southeast-1.aliyuncs.com/charts/
-   helm install vineyard vineyard/vineyard
+    helm repo add vineyard https://vineyard.oss-ap-southeast-1.aliyuncs.com/charts/
+    helm install vineyard vineyard/vineyard
 
 In the further vineyard will improve the integration with Kubernetes by abstract
 vineyard objects as as Kubernetes resources (i.e., CRDs), and leverage a vineyard
 operator to operate vineyard cluster.
+
+Deploying using Python API
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For environments where the Helm is not available, vineyard provides a Python API for
+deploying on Kubernetes,
+
+.. code:: python
+
+    from vineyard.deploy.kubernetes import start_vineyardd
+
+    resources = start_vineyardd()
+
+The deployed etcd pods, vineyard daemonset and services can be viewed as:
+
+.. code:: shell
+
+    $ kubectl -n vineyard get pods
+    NAME             READY   STATUS    RESTARTS   AGE
+    etcd0            1/1     Running   0          10s
+    vineyard-pwkcn   1/1     Running   0          10s
+
+    $ kubectl -n vineyard get daemonsets
+    NAME       DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
+    vineyard   1         1         1       1            1           <none>          14s
+
+    $ kubectl -n vineyard get services
+    NAME                TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
+    etcd-for-vineyard   ClusterIP   ........        <none>        2379/TCP   18s
+    vineyard-rpc        ClusterIP   ........        <none>        9600/TCP   18s
+
+Later the cluster can be stoped by releasing the resources with
+
+.. code:: python
+
+    from vineyard.deploy.kubernetes import delete_kubernetes_objects
+
+    delete_kubernetes_objects(resources)
+
+For more details about the API usage, please refer to the :ref:`vineyard-python-deployment-api`.

--- a/docs/notes/python-api.rst
+++ b/docs/notes/python-api.rst
@@ -94,6 +94,8 @@ Shared memory
 .. autoclass:: vineyard.shared_memory.ShareableList
     :members:
 
+.. _vineyard-python-deployment-api:
+
 Deployment
 ----------
 
@@ -103,6 +105,8 @@ Deployment
 .. autofunction:: vineyard.get_current_socket
 .. autofunction:: vineyard.deploy.local.start_vineyardd
 .. autofunction:: vineyard.deploy.distributed.start_vineyardd
+.. autofunction:: vineyard.deploy.kubernetes.start_vineyardd
+.. autofunction:: vineyard.deploy.kubernetes.delete_kubernetes_objects
 
 I/O Drivers
 -----------

--- a/misc/release-docker.sh
+++ b/misc/release-docker.sh
@@ -13,3 +13,9 @@ fi
 
 docker pull docker.pkg.github.com/v6d-io/v6d/vineyardd:$version
 docker pull docker.pkg.github.com/v6d-io/v6d/vineyardd:latest
+
+docker tag docker.pkg.github.com/v6d-io/v6d/vineyardd:$version vineyardcloudnative/vineyardd:$version
+docker tag docker.pkg.github.com/v6d-io/v6d/vineyardd:latest vineyardcloudnative/vineyardd:latest
+
+docker push vineyardcloudnative/vineyardd:$version
+docker push vineyardcloudnative/vineyardd:latest

--- a/modules/graph/loader/arrow_fragment_loader.cc
+++ b/modules/graph/loader/arrow_fragment_loader.cc
@@ -37,8 +37,6 @@ limitations under the License.
 #include "basic/stream/recordbatch_stream.h"
 #include "client/client.h"
 
-#define HASH_PARTITION
-
 namespace vineyard {
 
 template <typename LocalStreamT>

--- a/python/vineyard/contrib/airflow/docker/Dockerfile
+++ b/python/vineyard/contrib/airflow/docker/Dockerfile
@@ -6,5 +6,8 @@ USER airflow
 
 RUN pip install --no-cache-dir \
     numpy \
+    pandas \
+    vineyard==0.6.0 \
+    vineyard-migrate==0.6.0 \
     airflow-provider-vineyard==0.6.0
 ENV AIRFLOW__CORE__XCOM_BACKEND=vineyard.contrib.airflow.xcom.VineyardXCom

--- a/python/vineyard/contrib/airflow/values.yaml
+++ b/python/vineyard/contrib/airflow/values.yaml
@@ -45,7 +45,7 @@ scheduler:
   # Launch additional containers into scheduler.
   extraContainers:
     - name: vineyard
-      image: docker.pkg.github.com/v6d-io/v6d/vineyardd:v0.6.0
+      image: vineyardcloudnative/vineyardd:v0.6.0
       command:
       - /bin/bash
       - "-c"
@@ -128,7 +128,7 @@ workers:
 
   extraContainers:
     - name: vineyard
-      image: docker.pkg.github.com/v6d-io/v6d/vineyardd:v0.6.0
+      image: vineyardcloudnative/vineyardd:v0.6.0
       command:
       - /bin/bash
       - "-c"

--- a/python/vineyard/deploy/__init__.py
+++ b/python/vineyard/deploy/__init__.py
@@ -17,9 +17,5 @@
 #
 
 from . import distributed
+from . import kubernetes
 from . import local
-
-try:
-    from . import kubernetes
-except ImportError:
-    pass

--- a/python/vineyard/deploy/etcd.py
+++ b/python/vineyard/deploy/etcd.py
@@ -120,11 +120,12 @@ def start_etcd(host=None, etcd_executable=None, data_dir=None):
             pass
 
 
-def start_etcd_k8s(namespace):
+def start_etcd_k8s(namespace, k8s_client=None):
     if kubernetes is None:
-        raise RuntimeError('Please install the kubernetes python first')
-    kubernetes.config.load_kube_config()
-    k8s_client = kubernetes.client.ApiClient()
+        raise RuntimeError('Please install the package python "kubernetes" first')
+    if k8s_client is None:
+        kubernetes.config.load_kube_config()
+        k8s_client = kubernetes.client.ApiClient()
     return kubernetes.utils.create_from_yaml(
         k8s_client,
         os.path.join(os.path.dirname(__file__), 'etcd.yaml'),

--- a/python/vineyard/deploy/kubernetes.py
+++ b/python/vineyard/deploy/kubernetes.py
@@ -18,20 +18,27 @@
 
 import logging
 import os
+import re
 import tempfile
+import time
 
-import kubernetes
+try:
+    import kubernetes
+except ImportError:
+    kubernetes = None
 
 from .etcd import start_etcd_k8s
+from .utils import ensure_kubernetes_namespace
 
 logger = logging.getLogger('vineyard')
 
 
 def start_vineyardd(
     namespace='vineyard',
-    size='256Mi',
+    size='512Mi',
     socket='/var/run/vineyard.sock',
     rpc_socket_port=9600,
+    k8s_client=None,
 ):
     """Launch a vineyard cluster on kubernetes.
 
@@ -58,8 +65,27 @@ def start_vineyardd(
             The UNIX domain socket socket path that vineyard server will listen on.
         rpc_socket_port: int
             The port that vineyard will use to privode RPC service.
+        k8s_client: kubernetes.client.api.ApiClient
+            A kubernetes client. If not specified, vineyard will try to resolve the
+            kubernetes configuration from current context.
+
+    Returns:
+        A list of created kubernetes resources during the deploying process. The
+        resources can be later release using :meth:`delete_kubernetes_objects`.
+
+    See Also:
+        vineyard.deploy.kubernetes.delete_kubernetes_objects
     """
-    start_etcd_k8s(namespace)
+    if kubernetes is None:
+        raise RuntimeError('Please install the package python "kubernetes" first')
+
+    if k8s_client is None:
+        kubernetes.config.load_kube_config()
+        k8s_client = kubernetes.client.ApiClient()
+
+    created_objects = []
+    ensure_kubernetes_namespace(namespace, k8s_client=k8s_client)
+    created_objects.extend(start_etcd_k8s(namespace, k8s_client=k8s_client))
 
     with open(
         os.path.join(os.path.dirname(__file__), "vineyard.yaml.tpl"),
@@ -80,11 +106,176 @@ def start_vineyardd(
         with open(rendered.name, 'r', encoding='utf-8') as fp:
             logger.debug(fp.read())
 
-        kubernetes.config.load_kube_config()
-        k8s_client = kubernetes.client.ApiClient()
-        return kubernetes.utils.create_from_yaml(
-            k8s_client, rendered.name, namespace=namespace
+        created_objects.extend(
+            kubernetes.utils.create_from_yaml(
+                k8s_client, rendered.name, namespace=namespace
+            )
+        )
+        return created_objects
+
+
+def recursive_flatten(targets):
+    """Flatten the given maybe nested list as a 1-level list."""
+
+    def _recursive_flatten_impl(destination, targets):
+        if isinstance(targets, (list, tuple)):
+            for target in targets:
+                _recursive_flatten_impl(destination, target)
+        else:
+            destination.append(targets)
+
+    destination = []
+    _recursive_flatten_impl(destination, targets)
+    return destination
+
+
+def delete_kubernetes_objects(
+    targets, k8s_client=None, verbose=False, wait=False, timeout_seconds=60, **kwargs
+):
+    """Delete the given kubernetes resources.
+
+    Parameters:
+        target: List
+            List of Kubernetes objects
+        k8s_client:
+            The kubernetes client. If not specified, vineyard will try to resolve
+            the kubernetes configuration from current context.
+        verbose: bool
+            Whether to print the deletion logs.
+        wait: bool
+            Whether to wait for the deletion to complete.
+        timeout_seconds: int
+            The timeout in seconds for waiting for the deletion to complete.
+
+    See Also:
+        vineyard.deploy.kubernetes.start_vineyardd
+        vineyard.deploy.kubernetes.delete_kubernetes_object
+    """
+    for target in recursive_flatten(targets):
+        delete_kubernetes_object(
+            target,
+            k8s_client,
+            verbose=verbose,
+            wait=wait,
+            timeout_seconds=timeout_seconds,
+            **kwargs
         )
 
 
-__all__ = ['start_vineyardd']
+def delete_kubernetes_object(
+    target, k8s_client=None, verbose=False, wait=False, timeout_seconds=60, **kwargs
+):
+    """Delete the given kubernetes resource.
+
+    Parameters:
+        target: object
+            The Kubernetes objects that will be deleted.
+        k8s_client:
+            The kubernetes client. If not specified, vineyard will try to resolve
+            the kubernetes configuration from current context.
+        verbose: bool
+            Whether to print the deletion logs.
+        wait: bool
+            Whether to wait for the deletion to complete.
+        timeout_seconds: int
+            The timeout in seconds for waiting for the deletion to complete.
+
+    See Also:
+        vineyard.deploy.kubernetes.start_vineyardd
+        vineyard.deploy.kubernetes.delete_kubernetes_objects
+    """
+    if isinstance(target, (list, tuple)):
+        return delete_kubernetes_objects(
+            target, k8s_client, verbose=verbose, wait=wait, **kwargs
+        )
+
+    if kubernetes is None:
+        raise RuntimeError('Please install the package python "kubernetes" first')
+
+    if k8s_client is None:
+        kubernetes.config.load_kube_config()
+        k8s_client = kubernetes.client.ApiClient()
+
+    """Perform a delete action on valid kubernetes API object (i.e. List, Service, etc).
+    Args:
+        api_client: ApiClient
+            An kubernetes ApiClient object, initialized with the client args.
+        target: A valid kubernetes object.
+        verbose: bool, optional
+            If True, print confirmation from the delete action. Defaults to False.
+        wait: bool, optional
+            Waiting for delete object. Defaults to False.
+        timeout_seconds: int, optional
+            If waiting for delete timeout, just print a error message. Defaults to 60.
+    Returns:
+        Status: Return status for calls kubernetes delete method.
+    """
+    group, _, version = target.api_version.partition("/")
+    if version == "":
+        version = group
+        group = "core"
+    # Take care for the case e.g. api_type is "apiextensions.k8s.io"
+    # Only replace the last instance
+    group = "".join(group.rsplit(".k8s.io", 1))
+    # convert group name from DNS subdomain format to
+    # python class name convention
+    group = "".join(word.capitalize() for word in group.split("."))
+    fcn_to_call = "{0}{1}Api".format(group, version.capitalize())
+    k8s_api = getattr(kubernetes.client, fcn_to_call)(
+        k8s_client
+    )  # pylint: disable=not-callable
+
+    kind = target.kind
+    kind = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", kind)
+    kind = re.sub("([a-z0-9])([A-Z])", r"\1_\2", kind).lower()
+
+    try:
+        # Expect the user to create namespaced objects more often
+        kwargs["name"] = target.metadata.name
+        if hasattr(k8s_api, "delete_namespaced_{0}".format(kind)):
+            # Decide which namespace we are going to put the object in, if any
+            kwargs["namespace"] = target.metadata.namespace
+            resp = getattr(k8s_api, "delete_namespaced_{0}".format(kind))(**kwargs)
+        else:
+            kwargs.pop("namespace", None)
+            resp = getattr(k8s_api, "delete_{0}".format(kind))(**kwargs)
+    except kubernetes.client.rest.ApiException:
+        # Object already deleted.
+        pass
+    else:
+        # waiting for delete
+        if wait:
+            start_time = time.time()
+            if hasattr(k8s_api, "read_namespaced_{0}".format(kind)):
+                while True:
+                    try:
+                        getattr(k8s_api, "read_namespaced_{0}".format(kind))(**kwargs)
+                    except kubernetes.client.rest.ApiException as ex:
+                        if ex.status != 404:
+                            logger.error(
+                                "Deleting {0} {1} failed: {2}".format(
+                                    kind, target.metadata.name, str(ex)
+                                )
+                            )
+                        break
+                    else:
+                        time.sleep(1)
+                        if time.time() - start_time > timeout_seconds:
+                            logger.info(
+                                "Deleting {0} {1} timeout".format(
+                                    kind, target.metadata.name
+                                )
+                            )
+        if verbose:
+            msg = "{0}/{1} deleted.".format(kind, target.metadata.name)
+            if hasattr(resp, "status"):
+                msg += " status='{0}'".format(str(resp.status))
+            logger.info(msg)
+        return resp
+
+
+__all__ = [
+    'start_vineyardd',
+    'delete_kubernetes_object',
+    'delete_kubernetes_objects',
+]

--- a/python/vineyard/deploy/local.py
+++ b/python/vineyard/deploy/local.py
@@ -266,7 +266,7 @@ def shutdown():
     """
     global __default_instance_contexts
     if __default_instance_contexts:
-        for ipc_socket in reversed(__default_instance_contexts):
+        for ipc_socket in reversed(__default_instance_contexts.keys()):
             __default_instance_contexts[ipc_socket][0].__exit__(None, None, None)
         # NB. don't pop pre-existing env if we not launch
         os.environ.pop('VINEYARD_IPC_SOCKET', None)

--- a/python/vineyard/deploy/vineyard.yaml.tpl
+++ b/python/vineyard/deploy/vineyard.yaml.tpl
@@ -21,7 +21,8 @@ spec:
         effect: NoSchedule
       containers:
       - name: vineyard
-        image: docker.pkg.github.com/v6d-io/v6d/vineyardd:latest
+        image: vineyardcloudnative/vineyardd:latest
+        command: ["/usr/local/bin/vineyardd"]
         args:
         - "--socket"
         - "{Socket}"
@@ -31,10 +32,10 @@ spec:
         - "{Size}"
         resources:
           limits:
-            memory: 200m
+            memory: 1024Mi
           requests:
             cpu: 100m
-            memory: 200m
+            memory: 512Mi
         volumeMounts:
         - name: varrun
           mountPath: /var/run

--- a/src/common/util/env.h
+++ b/src/common/util/env.h
@@ -30,6 +30,7 @@ has the following license header originally:
 #include <unistd.h>
 
 #include <string>
+#include <thread>
 
 namespace vineyard {
 
@@ -73,6 +74,8 @@ inline std::string get_nodename() {
 }
 
 inline int get_pid() { return static_cast<int>(getpid()); }
+
+inline std::thread::id get_tid() { return std::this_thread::get_id(); }
 
 /**
  * @brief Returns the current resident set size (physical memory use) measured


### PR DESCRIPTION
What do these changes do?
-------------------------

- Revisit the vineyard deployment template to fixes the memory unit error
- Create namespace if the namespace not found
- Add docuementation for deploying using the Python API
- Move the vineyard docker registry to `vineyardcloudnative/vineyardd`

Related issue number
--------------------

Fixes #851 and fixes #852 

