### PR TITLE
Leave spaces for jemalloc's arena metadata and internal padding

### DIFF
--- a/src/server/memory/allocator.cc
+++ b/src/server/memory/allocator.cc
@@ -92,7 +92,10 @@ void* BulkAllocator::Init(const size_t size) {
   return Allocator::Init(size);
 #endif
 #if defined(WITH_JEMALLOC)
-  return allocator_.Init(size);
+  // jemalloc requires some memory for its internal use (arena metadata and
+  // padding).
+  size_t arena_metadata_size = 16 * 1024 * 1024;
+  return allocator_.Init(size + arena_metadata_size);
 #endif
 }
 
@@ -107,7 +110,9 @@ void* BulkAllocator::Memalign(const size_t bytes, const size_t alignment) {
 #if defined(WITH_JEMALLOC)
   void* mem = allocator_.Allocate(bytes, alignment);
 #endif
-  allocated_ += bytes;
+  if (mem != nullptr) {
+    allocated_ += bytes;
+  }
   return mem;
 }
 

--- a/src/server/memory/malloc.cc
+++ b/src/server/memory/malloc.cc
@@ -104,8 +104,8 @@ void GetMallocMapinfo(void* addr, int* fd, int64_t* map_size,
       return;
     }
   }
-  LOG(INFO) << "fd not found... for  " << addr
-            << ", size = " << mmap_records.size();
+  LOG(INFO) << "fd not found for " << addr
+            << ", mmap records size = " << mmap_records.size();
   *fd = -1;
   *map_size = 0;
   *offset = 0;


### PR DESCRIPTION
What do these changes do?
-------------------------

Jemalloc's arean saves internal metadata inside the arena as well.

Related issue number
--------------------

Fixes #862

