### PR TITLE
Allow customized image when deploying to Kubernetes from Python

### DIFF
--- a/python/vineyard/deploy/vineyard.yaml.tpl
+++ b/python/vineyard/deploy/vineyard.yaml.tpl
@@ -21,7 +21,10 @@ spec:
         effect: NoSchedule
       containers:
       - name: vineyard
-        image: vineyardcloudnative/vineyardd:latest
+        image: {Image}
+        imagePullPolicy: {ImagePullPolicy}
+        imagePullSecrets:
+        - name: {ImagePullSecrets}
         command: ["/usr/local/bin/vineyardd"]
         args:
         - "--socket"


### PR DESCRIPTION

What do these changes do?
-------------------------

Add the following arguments to `start_vineyardd`:

- `vineyard_image`
- `vineyard_image_pull_policy`
- `vineyard_image_pull_secrets`

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #859 

