### PR TITLE
Add a shared_ptr reference of bulkstore in the SocketConnection

### DIFF
--- a/src/server/memory/memory.h
+++ b/src/server/memory/memory.h
@@ -109,6 +109,7 @@ class BulkStoreBase {
 
 class BulkStore
     : public BulkStoreBase<ObjectID, Payload>,
+      public std::enable_shared_from_this<BulkStore>,
       protected detail::ColdObjectTracker<ObjectID, Payload, BulkStore> {
  public:
   /*
@@ -151,6 +152,7 @@ class BulkStore
  */
 class PlasmaBulkStore
     : public BulkStoreBase<PlasmaID, PlasmaPayload>,
+      public std::enable_shared_from_this<PlasmaBulkStore>,
       protected detail::DependencyTracker<PlasmaID, PlasmaPayload,
                                           PlasmaBulkStore> {
  public:

--- a/src/server/memory/usage.h
+++ b/src/server/memory/usage.h
@@ -169,11 +169,11 @@ class DependencyTracker
  * @brief ColdObjectTracker is a CRTP class record non-in-use object in a list
  * for its derived classes. It requires the derived class to implement the:
  *  - `OnRelease(ID)` method to describe what will happens when `ref_count`
- * reaches zero.
+ *    reaches zero.
  *  - `OnDelete(ID)` method to describe what will happens when `ref_count`
- * reaches zero and the object is marked as to be deleted.
+ *    reaches zero and the object is marked as to be deleted.
  *  - `FetchAndModify(ID, int, int)` method to fetch the current `ref_count` and
- * modify it by the given value.
+ *    modify it by the given value.
  */
 template <typename ID, typename P, typename Der>
 class ColdObjectTracker
@@ -195,8 +195,10 @@ class ColdObjectTracker
     using lru_map_t =
         std::unordered_map<ID, typename std::list<value_t>::iterator>;
     using lru_list_t = std::list<value_t>;
+
     LRU() = default;
     ~LRU() = default;
+
     void Ref(ID id, std::shared_ptr<P> payload) {
       std::unique_lock<decltype(mu_)> locked;
       auto it = map_.find(id);

--- a/src/server/services/etcd_meta_service.cc
+++ b/src/server/services/etcd_meta_service.cc
@@ -131,6 +131,8 @@ void EtcdMetaService::Stop() {
   if (stopped_.exchange(true)) {
     return;
   }
+  // invoke parent's stop method
+  IMetaService::Stop();
   if (backoff_timer_) {
     boost::system::error_code ec;
     backoff_timer_->cancel(ec);

--- a/src/server/services/local_meta_service.cc
+++ b/src/server/services/local_meta_service.cc
@@ -21,6 +21,13 @@ limitations under the License.
 
 namespace vineyard {
 
+inline void LocalMetaService::Stop() {
+  if (stopped_.exchange(true)) {
+    return;
+  }
+  IMetaService::Stop();
+}
+
 void LocalMetaService::requestLock(
     std::string lock_name,
     callback_t<std::shared_ptr<ILock>> callback_after_locked) {

--- a/src/server/services/local_meta_service.h
+++ b/src/server/services/local_meta_service.h
@@ -46,11 +46,9 @@ class LocalLock : public ILock {
  */
 class LocalMetaService : public IMetaService {
  public:
-  inline void Stop() override {
-    if (stopped_.exchange(true)) {
-      return;
-    }
-  }
+  inline void Stop() override;
+
+  ~LocalMetaService() override {}
 
  protected:
   explicit LocalMetaService(vs_ptr_t& server_ptr) : IMetaService(server_ptr) {}

--- a/src/server/services/meta_service.cc
+++ b/src/server/services/meta_service.cc
@@ -40,6 +40,10 @@ std::shared_ptr<IMetaService> IMetaService::Get(vs_ptr_t server_ptr) {
   return nullptr;
 }
 
+IMetaService::~IMetaService() { this->Stop(); }
+
+void IMetaService::Stop() { LOG(INFO) << "meta service is stopping ..."; }
+
 /** Note [Deleting objects and blobs]
  *
  * Blob is special: suppose A -> B and A -> C, where A is an object, B is an

--- a/src/server/services/meta_service.h
+++ b/src/server/services/meta_service.h
@@ -124,11 +124,13 @@ class IMetaService : public std::enable_shared_from_this<IMetaService> {
     callback_t<const json&, const std::string&> watcher;
     std::string tag;
   };
-  virtual ~IMetaService() { LOG(INFO) << "dtor the metadata service"; }
+
   explicit IMetaService(vs_ptr_t& server_ptr)
       : server_ptr_(server_ptr), rev_(0), meta_sync_lock_("/meta_sync_lock") {
     stopped_.store(false);
   }
+
+  virtual ~IMetaService();
 
   static std::shared_ptr<IMetaService> Get(vs_ptr_t);
 
@@ -162,7 +164,7 @@ class IMetaService : public std::enable_shared_from_this<IMetaService> {
     return Status::OK();
   }
 
-  virtual inline void Stop() { LOG(INFO) << "meta service is stopping ..."; }
+  virtual void Stop();
 
  public:
   inline void RequestToBulkUpdate(


### PR DESCRIPTION
What do these changes do?
-------------------------

The `SocketConnection` do something like `Release` on `Stop()`, which requires the blukstore keep alive other wise there will be a data race contention between the `SocketConnection::Stop()` and `BulkStore::~BulkStore()`.

Related issue number
--------------------

Fixes #842 

