### PR TITLE
Resolves the data race condition in the destruction of SocketServer.

### DIFF
--- a/src/server/async/ipc_server.h
+++ b/src/server/async/ipc_server.h
@@ -33,7 +33,8 @@ class VineyardServer;
  * @brief The server for inter-process communication (IPC)
  *
  */
-class IPCServer : public SocketServer {
+class IPCServer : public SocketServer,
+                  public std::enable_shared_from_this<IPCServer> {
  public:
   explicit IPCServer(std::shared_ptr<VineyardServer> vs_ptr);
 

--- a/src/server/async/rpc_server.cc
+++ b/src/server/async/rpc_server.cc
@@ -68,21 +68,26 @@ void RPCServer::doAccept() {
   if (!acceptor_.is_open()) {
     return;
   }
-  acceptor_.async_accept(socket_, [this](boost::system::error_code ec) {
+  auto self(shared_from_this());
+  acceptor_.async_accept(socket_, [self](boost::system::error_code ec) {
     if (!ec) {
-      std::shared_ptr<SocketConnection> conn =
-          std::make_shared<SocketConnection>(std::move(this->socket_), vs_ptr_,
-                                             this, next_conn_id_);
-      conn->Start();
       std::lock_guard<std::recursive_mutex> scope_lock(
-          this->connections_mutex_);
-      connections_.emplace(next_conn_id_, conn);
-      ++next_conn_id_;
+          self->connections_mutex_);
+      if (self->stopped_.load() || self->closable_.load()) {
+        return;
+      }
+      std::shared_ptr<SocketConnection> conn =
+          std::make_shared<SocketConnection>(std::move(self->socket_),
+                                             self->vs_ptr_, self,
+                                             self->next_conn_id_);
+      conn->Start();
+      self->connections_.emplace(self->next_conn_id_, conn);
+      ++self->next_conn_id_;
     }
     // don't continue when the iocontext being cancelled.
     if (!ec || ec != boost::system::errc::operation_canceled) {
-      if (!stopped_.load()) {
-        doAccept();
+      if (!self->stopped_.load() || !self->closable_.load()) {
+        self->doAccept();
       }
     }
   });

--- a/src/server/async/rpc_server.h
+++ b/src/server/async/rpc_server.h
@@ -32,7 +32,8 @@ class VineyardServer;
  * @brief A kind of server that supports remote procedure call (RPC)
  *
  */
-class RPCServer : public SocketServer {
+class RPCServer : public SocketServer,
+                  public std::enable_shared_from_this<RPCServer> {
  public:
   explicit RPCServer(std::shared_ptr<VineyardServer> vs_ptr);
 

--- a/src/server/async/socket_server.cc
+++ b/src/server/async/socket_server.cc
@@ -33,9 +33,9 @@ limitations under the License.
 
 namespace vineyard {
 
-SocketConnection::SocketConnection(stream_protocol::socket socket,
-                                   std::shared_ptr<VineyardServer> server_ptr,
-                                   SocketServer* socket_server_ptr, int conn_id)
+SocketConnection::SocketConnection(
+    stream_protocol::socket socket, std::shared_ptr<VineyardServer> server_ptr,
+    std::shared_ptr<SocketServer> socket_server_ptr, int conn_id)
     : socket_(std::move(socket)),
       server_ptr_(server_ptr),
       socket_server_ptr_(socket_server_ptr),

--- a/src/server/server/vineyard_server.cc
+++ b/src/server/server/vineyard_server.cc
@@ -94,13 +94,11 @@ Status VineyardServer::Serve(StoreType const& bulk_store_type) {
 
   // Initialize the ipc/rpc server ptr first to get self endpoints when
   // initializing the metadata service.
-  ipc_server_ptr_ =
-      std::unique_ptr<IPCServer>(new IPCServer(shared_from_this()));
+  ipc_server_ptr_ = std::make_shared<IPCServer>(shared_from_this());
   if (session_id_ == RootSessionID() && spec_["rpc_spec"]["rpc"].get<bool>()) {
     // TODO: the rpc won't be enabled for child sessions as we are unsure
     // about how to select the port.
-    rpc_server_ptr_ =
-        std::unique_ptr<RPCServer>(new RPCServer(shared_from_this()));
+    rpc_server_ptr_ = std::make_shared<RPCServer>(shared_from_this());
   }
 
   this->meta_service_ptr_ = IMetaService::Get(shared_from_this());
@@ -1039,8 +1037,8 @@ void VineyardServer::Stop() {
   }
 
   // cleanup
-  this->ipc_server_ptr_.reset(nullptr);
-  this->rpc_server_ptr_.reset(nullptr);
+  this->ipc_server_ptr_.reset();
+  this->rpc_server_ptr_.reset();
   this->meta_service_ptr_.reset();
   this->stream_store_.reset();
   this->bulk_store_.reset();

--- a/src/server/server/vineyard_server.h
+++ b/src/server/server/vineyard_server.h
@@ -220,8 +220,8 @@ class VineyardServer : public std::enable_shared_from_this<VineyardServer> {
   callback_t<std::string const&> callback_;
 
   std::shared_ptr<IMetaService> meta_service_ptr_;
-  std::unique_ptr<IPCServer> ipc_server_ptr_;
-  std::unique_ptr<RPCServer> rpc_server_ptr_;
+  std::shared_ptr<IPCServer> ipc_server_ptr_;
+  std::shared_ptr<RPCServer> rpc_server_ptr_;
 
   std::list<DeferredReq> deferred_;
 


### PR DESCRIPTION
What do these changes do?
-------------------------

By making sure no longer trying to add new socket connection after the `SocketServer` itself bas been stopped/destructed.

Related issue number
--------------------

Fixes #884.

