### PR TITLE
Use more meaningful message when failed to create the IPC socket

### DIFF
--- a/docs/notes/deploy-locally.rst
+++ b/docs/notes/deploy-locally.rst
@@ -14,7 +14,15 @@ Command-line arguments
 ----------------------
 
 Various command-line arguments are supported to configure the behaviors of the
-vineyard server:
+vineyard server, noteably,
+
+- :code:`--socket <PATH>` to specify the path of UNIX-domain socket that vineyardd will
+  bind to
+- :code:`--size <SIZE>` to specify the upper limit of shared memory, can be in human
+  readable format, e.g. :code:`256M`, :code:`1G`, etc.
+- :code:`--etcd_endpoint <ENDPOINT>` to specify the etcd endpoint to connect
+
+The full list of command-line arguments is as follows:
 
 .. code:: shell
 

--- a/docs/notes/getting-started.rst
+++ b/docs/notes/getting-started.rst
@@ -29,6 +29,21 @@ A vineyard daemon server will be launched on the underlying machine with default
 settings. The default ``socket`` is ``/var/run/vineyard.sock``, and it is
 listened by the server for ipc connections. 
 
+.. tip::
+
+  If you encounter errors like
+  :code:`cannot launch vineyardd on '/var/run/vineyard.sock': Permission denied,`,
+  that means you don't have the permission to create a UNIX-domain socket at
+  :code:`/var/run/vineyard.sock`, you could either
+
+  - run vineyard as root, using :code:`sudo`
+  - or change the socket path to a different one, with the :code:`--socket` command
+    line option, like
+
+    .. code:: console
+     
+       $ python3 -m vineyard --socket /tmp/vineyard.sock
+
 A vineyard daemon server is a vineyard instance in a vineyard cluster. Thus, to
 start a vineyard cluster, we can simply start ``vineyardd`` over all the
 machines in the cluster, and make sure these vineyard instances can register to 

--- a/src/common/util/status.h
+++ b/src/common/util/status.h
@@ -285,6 +285,9 @@ class VINEYARD_MUST_USE_TYPE Status {
   /// Return an error status for failed key lookups (e.g. column name in a
   /// table).
   static Status KeyError() { return Status(StatusCode::kKeyError, ""); }
+  static Status KeyError(std::string const& msg) {
+    return Status(StatusCode::kKeyError, msg);
+  }
 
   /// Return an error status for type errors (such as mismatching data types).
   static Status TypeError() { return Status(StatusCode::kTypeError, ""); }

--- a/src/server/async/socket_server.cc
+++ b/src/server/async/socket_server.cc
@@ -68,9 +68,9 @@ bool SocketConnection::Stop() {
   if (server_ptr_->GetBulkStoreType() == StoreType::kDefault) {
     std::unordered_set<ObjectID> ids;
     auto status = bulk_store_->ReleaseConnection(this->getConnId());
-    if (!status.ok()) {
-      LOG(INFO) << "No dependent objects, conn_id: " << this->getConnId()
-                << ", status: " << status.ToString();
+    if (!status.ok() && !status.IsKeyError()) {
+      LOG(WARNING) << "Failed to release the connction '" << this->getConnId()
+                   << "' from object dependency: " << status.ToString();
     }
   }
 

--- a/src/server/memory/usage.h
+++ b/src/server/memory/usage.h
@@ -116,7 +116,7 @@ class DependencyTracker
   Status RemoveDependency(ID const& id, int conn) {
     typename dependency_map_t::accessor accessor;
     if (!dependency_.find(accessor, conn)) {
-      return Status::Invalid("connection not exist.");
+      return Status::KeyError("connection not exist.");
     } else {
       auto& objects = accessor->second;
       if (objects.find(id) == objects.end()) {
@@ -146,7 +146,7 @@ class DependencyTracker
   Status ReleaseConnection(int conn) {
     typename dependency_map_t::const_accessor accessor;
     if (!dependency_.find(accessor, conn)) {
-      return Status::Invalid("connection not exist.");
+      return Status::KeyError("connection doesn't exist.");
     } else {
       auto& objects = accessor->second;
       for (auto& elem : objects) {


### PR DESCRIPTION

What do these changes do?
-------------------------

Fixes a bug about using `--socket ./socket` on Linux as well.

Related issue number
--------------------

Fixes #883
