### PR TITLE
Keeps compatible with apache-arrow 9.0.0.

### DIFF
--- a/.github/workflows/build-compatibility.yml
+++ b/.github/workflows/build-compatibility.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-10.15]
+        os: [ubuntu-18.04, macos-11]
         arrow: [none, 1.0.1-1, 2.0.0-1, 3.0.0-1]
         exclude:
           - os: ubuntu-18.04

--- a/docker/vineyardd/Dockerfile.alpine-builder
+++ b/docker/vineyardd/Dockerfile.alpine-builder
@@ -54,7 +54,7 @@ RUN cd /tmp && \
     mkdir build && \
     cd build && \
     cmake ../cpp \
-        -DARROW_COMPUTE=OFF \
+        -DARROW_COMPUTE=ON \
         -DARROW_WITH_UTF8PROC=OFF \
         -DARROW_CSV=ON \
         -DARROW_CUDA=OFF \

--- a/modules/basic/ds/arrow_utils.cc
+++ b/modules/basic/ds/arrow_utils.cc
@@ -83,8 +83,13 @@ Status SerializeRecordBatch(std::shared_ptr<arrow::RecordBatch>& batch,
   std::shared_ptr<arrow::io::BufferOutputStream> out_stream;
   RETURN_ON_ARROW_ERROR_AND_ASSIGN(out_stream,
                                    arrow::io::BufferOutputStream::Create(1024));
+#if defined(ARROW_VERSION) && ARROW_VERSION < 9000000
   RETURN_ON_ARROW_ERROR(arrow::ipc::WriteRecordBatchStream(
       {batch}, arrow::ipc::IpcOptions::Defaults(), out_stream.get()));
+#else
+  RETURN_ON_ARROW_ERROR(arrow::ipc::WriteRecordBatchStream(
+      {batch}, arrow::ipc::IpcWriteOptions::Defaults(), out_stream.get()));
+#endif
   RETURN_ON_ARROW_ERROR_AND_ASSIGN(*buffer, out_stream->Finish());
   return Status::OK();
 }
@@ -107,8 +112,13 @@ Status SerializeRecordBatchesToAllocatedBuffer(
     const std::vector<std::shared_ptr<arrow::RecordBatch>>& batches,
     std::shared_ptr<arrow::Buffer>* buffer) {
   arrow::io::FixedSizeBufferWriter stream(*buffer);
+#if defined(ARROW_VERSION) && ARROW_VERSION < 9000000
   RETURN_ON_ARROW_ERROR(arrow::ipc::WriteRecordBatchStream(
       batches, arrow::ipc::IpcOptions::Defaults(), &stream));
+#else
+  RETURN_ON_ARROW_ERROR(arrow::ipc::WriteRecordBatchStream(
+      batches, arrow::ipc::IpcWriteOptions::Defaults(), &stream));
+#endif
   return Status::OK();
 }
 
@@ -118,8 +128,13 @@ Status SerializeRecordBatches(
   std::shared_ptr<arrow::io::BufferOutputStream> out_stream;
   RETURN_ON_ARROW_ERROR_AND_ASSIGN(out_stream,
                                    arrow::io::BufferOutputStream::Create(1024));
+#if defined(ARROW_VERSION) && ARROW_VERSION < 9000000
   RETURN_ON_ARROW_ERROR(arrow::ipc::WriteRecordBatchStream(
       batches, arrow::ipc::IpcOptions::Defaults(), out_stream.get()));
+#else
+  RETURN_ON_ARROW_ERROR(arrow::ipc::WriteRecordBatchStream(
+      batches, arrow::ipc::IpcWriteOptions::Defaults(), out_stream.get()));
+#endif
   RETURN_ON_ARROW_ERROR_AND_ASSIGN(*buffer, out_stream->Finish());
   return Status::OK();
 }


### PR DESCRIPTION

What do these changes do?
-------------------------

Compiling with apache-arrow 9.0.0.

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #894 

