### PR TITLE
Catch the json exception, especially inserting using json_pointer

### DIFF
--- a/src/client/client_base.cc
+++ b/src/client/client_base.cc
@@ -442,10 +442,7 @@ Status ClientBase::doRead(json& root) {
     connected_ = false;
     return status;
   }
-  status = CATCH_JSON_ERROR([&]() -> Status {
-    root = json::parse(message_in);
-    return Status::OK();
-  }());
+  CATCH_JSON_ERROR(root, status, json::parse(message_in));
   if (!status.ok()) {
     connected_ = false;
   }

--- a/src/common/util/macros.h
+++ b/src/common/util/macros.h
@@ -34,5 +34,13 @@ namespace vineyard {
 #define VINEYARD_MUST_USE_TYPE
 #endif
 
+#ifndef GET_MACRO
+#define GET_MACRO(_1, _2, NAME, ...) NAME
+#endif
+
+#ifndef GET_MACRO2
+#define GET_MACRO2(_1, _2, _3, NAME, ...) NAME
+#endif
+
 }  // namespace vineyard
 #endif  // SRC_COMMON_UTIL_MACROS_H_

--- a/src/common/util/status.h
+++ b/src/common/util/status.h
@@ -38,8 +38,6 @@
 #include "common/util/json.h"
 #include "common/util/macros.h"
 
-#define GET_MACRO(_1, _2, NAME, ...) NAME
-
 // raise a std::runtime_error (inherits std::exception), don't FATAL
 #ifndef VINEYARD_CHECK_OK
 #define VINEYARD_CHECK_OK(status)                                             \


### PR DESCRIPTION

What do these changes do?
-------------------------

- refactor the `CATCH_JSON_ERROR` macro to avoid creating a lambda function
- catch the possbile `std::invalid_argument` exception (triggerred by `std:: stoull`) in `putVal` with a json pointer
- prevent crash when the given metadata contains invalid keys.

Related issue number
--------------------

Fixes #913 

