### PR TITLE
Address a missing import error in Python 3.8.

### DIFF
--- a/test/runner.py
+++ b/test/runner.py
@@ -3,6 +3,7 @@
 
 import contextlib
 import importlib
+import importlib.util
 import os
 import platform
 import socket


### PR DESCRIPTION

What do these changes do?
-------------------------

as titled.
