### PR TITLE
Unify the implementation of "mmap/munmap" in different allocators to avoid duplication

### DIFF
--- a/src/common/memory/mimalloc.h
+++ b/src/common/memory/mimalloc.h
@@ -45,20 +45,18 @@ class Mimalloc {
   /**
    * @brief Manages a particular memory arena.
    */
-  static void* Init(void* addr, const size_t size) {
-    // no committed area (mmaped area)
-    bool is_committed = true;
+  static void* Init(void* addr, const size_t size,
+                    const bool is_committed = false,
+                    const bool is_zero = true) {
     // does't consist of large OS pages
     bool is_large = false;
-    // does't consist of zero's
-    bool is_zero = false;
     // no associated numa node
     int numa_node = -1;
 
     void* new_addr = addr;
     size_t new_size = size;
 
-    // the addr must be 64MB aligned(required by mimalloc)
+    // the addr must be 64MB aligned (required by mimalloc)
     if ((reinterpret_cast<uintptr_t>(addr) % MIMALLOC_SEGMENT_ALIGNED_SIZE) !=
         0) {
       new_addr = reinterpret_cast<void*>((reinterpret_cast<uintptr_t>(addr) +

--- a/src/server/memory/malloc.h
+++ b/src/server/memory/malloc.h
@@ -59,6 +59,12 @@ extern std::unordered_map<void*, MmapRecord> mmap_records;
 // Returns a fd as expected.
 int create_buffer(int64_t size);
 
+// Create a buffer, and mmap the buffer as the shared memory space.
+void* mmap_buffer(int64_t size, bool* is_committed, bool* is_zero);
+
+// Unmap the buffer.
+int munmap_buffer(void* addr, int64_t size);
+
 }  // namespace memory
 
 }  // namespace vineyard

--- a/src/server/memory/mimalloc.cc
+++ b/src/server/memory/mimalloc.cc
@@ -15,8 +15,6 @@ limitations under the License.
 
 #include "server/memory/mimalloc.h"
 
-#include <sys/mman.h>
-
 #include <stdio.h>
 
 #include "common/util/status.h"
@@ -30,24 +28,13 @@ namespace memory {
 
 void* MimallocAllocator::Init(const size_t size) {
   // create memory using mmap
-  int fd = create_buffer(size);
-  void* space = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+  bool is_committed = false;
+  bool is_zero = true;
+  void* space = mmap_buffer(size, &is_committed, &is_zero);
   if (space == nullptr) {
     return space;
   }
-
-  // the addr must be 64MB aligned(required by mimalloc)
-  // this will cause some loss of memory, and the maximum does not exceed 64MB
-  void* addr = reinterpret_cast<void*>(
-      (reinterpret_cast<uintptr_t>(space) + MIMALLOC_SEGMENT_ALIGNED_SIZE - 1) &
-      ~(MIMALLOC_SEGMENT_ALIGNED_SIZE - 1));
-  size_t real_size = size - ((size_t) addr - (size_t) space);
-
-  MmapRecord& record = mmap_records[space];
-  record.fd = fd;
-  record.size = size;
-
-  return Mimalloc::Init(addr, real_size);
+  return Mimalloc::Init(space, size, is_committed, is_zero);
 }
 
 }  // namespace memory


### PR DESCRIPTION

What do these changes do?
-------------------------

as titled.  Move the `mmap` operation to the common place.

Related issue number
--------------------

N/A

