### PR TITLE
Cast boolean array to int array.

### DIFF
--- a/modules/basic/ds/arrow_utils.cc
+++ b/modules/basic/ds/arrow_utils.cc
@@ -215,7 +215,10 @@ Status EmptyTableBuilder::Build(const std::shared_ptr<arrow::Schema>& schema,
     std::shared_ptr<arrow::Array> dummy;
     auto type = schema->field(i)->type();
 
-    if (type == arrow::uint64()) {
+    if (type == arrow::boolean()) {
+      arrow::BooleanBuilder builder;
+      RETURN_ON_ARROW_ERROR(builder.Finish(&dummy));
+    } else if (type == arrow::uint64()) {
       arrow::UInt64Builder builder;
       RETURN_ON_ARROW_ERROR(builder.Finish(&dummy));
     } else if (type == arrow::int64()) {

--- a/modules/graph/fragment/property_graph_utils.h
+++ b/modules/graph/fragment/property_graph_utils.h
@@ -90,10 +90,13 @@ inline boost::leaf::result<std::shared_ptr<arrow::Schema>> TypeLoosen(
 
   for (int i = 0; i < field_num; ++i) {
     lossen_fields[i] = fields[i][0];
-    if (fields[i][0]->type() == arrow::null()) {
+    auto res = fields[i][0]->type();
+    if (res == arrow::null()) {
       continue;
     }
-    auto res = fields[i][0]->type();
+    if (res->Equals(arrow::boolean())) {
+      res = arrow::int32();
+    }
     if (res->Equals(arrow::date32())) {
       res = arrow::int32();
     }


### PR DESCRIPTION

What do these changes do?
-------------------------

Cast boolean array to int array, as boolean array is not directly indexable when accessing data from FFI.

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #926 

