### PR TITLE
Add docker images for vineyard installed and for vineyard developing

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -25,6 +25,17 @@ and the following python packages that can be easily installed using `pip`:
 - libclang
 - parsec
 
+Developing vineyard using Docker
+--------------------------------
+
+To simplify the dependency installation process, we have provided a docker
+image with all requirements installed. The docker image can be found from
+`vineyardcloudnative/vineyard-dev <https://hub.docker.com/r/vineyardcloudnative/vineyard-dev/tags>`_.
+
+.. code:: shell
+
+    docker pull vineyardcloudnative/vineyard-dev:latest 
+
 Build the source
 ----------------
 

--- a/docker/Dockerfile.vineyard-python
+++ b/docker/Dockerfile.vineyard-python
@@ -1,0 +1,9 @@
+ARG PYTHON_VERSION=3.10
+
+FROM python:$PYTHON_VERSION
+
+RUN pip3 install --no-cache-dir \
+    vineyard \
+    vineyard-io \
+    ipython
+

--- a/docker/dev/Dockerfile.dev
+++ b/docker/dev/Dockerfile.dev
@@ -1,0 +1,19 @@
+FROM ubuntu:20.04
+
+RUN chmod 1777 /tmp
+
+RUN mkdir -p /workspace/build_scripts
+
+COPY ./build_scripts/install-deps.sh /workspace/build_scripts
+RUN cd /workspace && bash ./build_scripts/install-deps.sh
+
+COPY ./build_scripts/install-arrow.sh /workspace/build_scripts
+RUN cd /workspace && bash ./build_scripts/install-arrow.sh
+
+COPY ./build_scripts/install-miscs.sh /workspace/build_scripts
+COPY ./build_scripts/requirements.txt /workspace/build_scripts
+RUN cd /workspace && bash ./build_scripts/install-miscs.sh
+
+COPY ./build_scripts/install-libgrape-lite.sh /workspace/build_scripts
+RUN cd /workspace && bash ./build_scripts/install-libgrape-lite.sh
+

--- a/docker/dev/build_scripts/install-arrow.sh
+++ b/docker/dev/build_scripts/install-arrow.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+export DEBIAN_FRONTEND=noninteractive
+export DEBCONF_NONINTERACTIVE_SEEN=true
+
+# install apache-arrow
+wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+apt update
+apt install -y libarrow-dev=6.0.1-1 libparquet-dev=6.0.1-1 libarrow-python-dev=6.0.1-1
+
+# install pyarrow from scratch
+sudo pip3 install --no-binary pyarrow pyarrow==6.0.1
+
+# apt-get cleanup
+apt-get autoclean
+rm -rf ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+

--- a/docker/dev/build_scripts/install-deps.sh
+++ b/docker/dev/build_scripts/install-deps.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+export DEBIAN_FRONTEND=noninteractive
+export DEBCONF_NONINTERACTIVE_SEEN=true
+
+# install deps using apt-get
+apt-get update -y
+apt-get install -y sudo
+
+apt-get install -y \
+  ca-certificates \
+  ccache \
+  cmake \
+  curl \
+  doxygen \
+  fuse3 \
+  git \
+  libboost-all-dev \
+  libcurl4-openssl-dev \
+  libfuse3-dev \
+  libgflags-dev \
+  libgoogle-glog-dev \
+  libgmock-dev \
+  libgrpc-dev \
+  libgrpc++-dev \
+  libgtest-dev \
+  libkrb5-dev \
+  libmpich-dev \
+  libprotobuf-dev \
+  librdkafka-dev \
+  libgsasl7-dev \
+  librdkafka-dev \
+  libssl-dev \
+  libunwind-dev \
+  libxml2-dev \
+  libz-dev \
+  lsb-release \
+  pandoc \
+  protobuf-compiler-grpc \
+  python3-pip \
+  uuid-dev \
+  vim \
+  wget
+
+# apt-get cleanup
+apt-get autoclean
+rm -rf ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+

--- a/docker/dev/build_scripts/install-libgrape-lite.sh
+++ b/docker/dev/build_scripts/install-libgrape-lite.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# install libgrape-lite
+pushd /tmp
+git clone https://github.com/alibaba/libgrape-lite.git
+cd libgrape-lite
+mkdir build
+cd build
+cmake ..
+make -j`nproc`
+sudo make install
+popd
+rm -rf /tmp/libgrape-lite
+

--- a/docker/dev/build_scripts/install-miscs.sh
+++ b/docker/dev/build_scripts/install-miscs.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# install python packages for codegen, and io adaptors
+sudo pip3 install -U "Pygments>=2.4.1"
+sudo pip3 install -r build_scripts/requirements.txt
+
+# install clang-format
+sudo curl -L https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-22538c65/clang-format-8_linux-amd64 --output /usr/bin/clang-format
+sudo chmod +x /usr/bin/clang-format
+

--- a/docker/dev/build_scripts/requirements.txt
+++ b/docker/dev/build_scripts/requirements.txt
@@ -1,0 +1,33 @@
+argcomplete
+black
+breathe
+docutils==0.16
+etcd-distro
+flake8
+furo        # sphinx theme
+isort
+jinja2>=3.0.0
+libclang
+nbsphinx
+numpy>=1.18.5
+parsec
+pandas<1.0.0; python_version<"3.6"
+pandas<1.2.0; python_version<"3.7"
+pandas>=1.0.0; python_version>="3.7"
+pickle5; python_version<="3.7"
+pygments>=2.4.1
+psutil
+pytest
+pytest-benchmark
+pytest-datafiles
+setuptools
+shared-memory38; python_version<="3.7"
+sortedcontainers
+sphinx>=3.0.2
+sphinx-copybutton
+sphinx-panels
+sphinxemoji
+sphinxext-opengraph
+treelib
+wheel
+


### PR DESCRIPTION
What do these changes do?
-------------------------

- Add docker image: vineyardcloudnative/vineyard-python
- Add docker image: vineyardcloudnative/vineyard-dev

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

N/A

