### PR TITLE
Enable switch allocator using command line flags.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -570,20 +570,22 @@ if(BUILD_VINEYARD_SERVER)
     find_openssl_libraries(REQUIRED)
     find_etcd_cpp_apiv3()
     find_intel_tbb()
+    find_mimalloc()
     file(GLOB_RECURSE SERVER_SRC_FILES "src/server/*.cc"
                                        "src/common/memory/*.cc"
                                        "src/common/util/*.cc"
     )
     add_executable(vineyardd ${SERVER_SRC_FILES})
     target_compile_options(vineyardd PRIVATE -DBUILD_VINEYARDD)
-    target_link_libraries(vineyardd PUBLIC ${Boost_LIBRARIES}
-                                           ${CPPREST_LIB}
-                                           ${ETCD_CPP_LIBRARIES}
-                                           ${GFLAGS_LIBRARIES}
-                                           ${GLOG_LIBRARIES}
-                                           ${OPENSSL_LIBRARIES}
-                                           nlohmann_json::nlohmann_json
-                                           TBB::tbb
+    target_link_libraries(vineyardd PRIVATE ${Boost_LIBRARIES}
+                                            ${CPPREST_LIB}
+                                            ${ETCD_CPP_LIBRARIES}
+                                            ${GFLAGS_LIBRARIES}
+                                            ${GLOG_LIBRARIES}
+                                            ${OPENSSL_LIBRARIES}
+                                            mimalloc-static
+                                            nlohmann_json::nlohmann_json
+                                            TBB::tbb
     )
     if(ARROW_SHARED_LIB)
         target_link_libraries(vineyardd PUBLIC ${ARROW_SHARED_LIB})
@@ -609,16 +611,16 @@ if(BUILD_VINEYARD_SERVER)
         target_include_directories(vineyardd PRIVATE ${Gperftools_INCLUDE_DIRS})
         target_link_libraries(vineyardd PRIVATE ${Gperftools_LIBRARIES})
     endif()
-    message(STATUS "Vineyard will use '${WITH_ALLOCATOR}' for shared memory allocation")
+
+    message(STATUS "Vineyard will use '${WITH_ALLOCATOR}' by default for shared memory allocation")
+    # bundle dlmalloc and mimalloc at the same time
+    target_compile_options(vineyardd PRIVATE -DWITH_DLMALLOC -DWITH_MIMALLOC)
+
     if(WITH_ALLOCATOR STREQUAL "dlmalloc")
-        # use dlmalloc
-        target_compile_options(vineyardd PRIVATE -DWITH_DLMALLOC)
+        target_compile_options(vineyardd PRIVATE -DDEFAULT_ALLOCATOR=dlmalloc)
     endif()
     if(WITH_ALLOCATOR STREQUAL "mimalloc")
-        # use mimalloc
-        find_mimalloc()
-        target_compile_options(vineyardd PRIVATE -DWITH_MIMALLOC)
-        target_link_libraries(vineyardd PRIVATE mimalloc-static)
+        target_compile_options(vineyardd PRIVATE -DDEFAULT_ALLOCATOR=mimalloc)
     endif()
 
     file(GLOB_RECURSE VINEYARD_CLIENT_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/src"

--- a/src/common/util/protocols.cc
+++ b/src/common/util/protocols.cc
@@ -18,8 +18,6 @@ limitations under the License.
 #include <sstream>
 #include <unordered_set>
 
-#include "boost/algorithm/string.hpp"
-
 #include "common/util/logging.h"
 #include "common/util/uuid.h"
 #include "common/util/version.h"

--- a/src/server/memory/allocator.h
+++ b/src/server/memory/allocator.h
@@ -31,6 +31,9 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <string>
+
+#include "common/util/macros.h"
 
 namespace vineyard {
 
@@ -41,7 +44,13 @@ class MimallocAllocator;
 
 class BulkAllocator {
  public:
-  static void* Init(const size_t size);
+  static void* Init(
+      const size_t size,
+#if defined(DEFAULT_ALLOCATOR)
+      std::string const& allocator = VINEYARD_TO_STRING(DEFAULT_ALLOCATOR));
+#else
+      std::string const& allocator = "mimalloc");
+#endif
 
   /// Allocates size bytes and returns a pointer to the allocated memory. The
   /// memory address will be a multiple of alignment, which must be a power of
@@ -73,15 +82,11 @@ class BulkAllocator {
   /// \return Number of bytes allocated by Plasma so far.
   static int64_t Allocated();
 
-#if defined(WITH_DLMALLOC)
-  using Allocator = vineyard::memory::DLmallocAllocator;
-#endif
-
-#if defined(WITH_MIMALLOC)
-  using Allocator = vineyard::memory::MimallocAllocator;
-#endif
+  using DLmallocAllocator = vineyard::memory::DLmallocAllocator;
+  using MimallocAllocator = vineyard::memory::MimallocAllocator;
 
  private:
+  static bool use_mimalloc_;
   static int64_t allocated_;
   static int64_t footprint_limit_;
 };

--- a/src/server/memory/memory.cc
+++ b/src/server/memory/memory.cc
@@ -334,9 +334,10 @@ Status BulkStoreBase<ID, P>::MakeArena(size_t const size, int& fd,
 }
 
 template <typename ID, typename P>
-Status BulkStoreBase<ID, P>::PreAllocate(const size_t size) {
+Status BulkStoreBase<ID, P>::PreAllocate(const size_t size,
+                                         std::string const& allocator) {
   BulkAllocator::SetFootprintLimit(size);
-  void* pointer = BulkAllocator::Init(size);
+  void* pointer = BulkAllocator::Init(size, allocator);
 
   if (pointer == nullptr) {
     return Status::NotEnoughMemory("mmap failed, size = " +

--- a/src/server/memory/memory.h
+++ b/src/server/memory/memory.h
@@ -34,6 +34,7 @@
 #include <map>
 #include <memory>
 #include <set>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -42,6 +43,7 @@
 
 #include "common/memory/payload.h"
 #include "common/util/logging.h"
+#include "common/util/macros.h"
 #include "common/util/status.h"
 #include "server/memory/usage.h"
 
@@ -84,7 +86,13 @@ class BulkStoreBase {
 
   Status MakeArena(size_t const size, int& fd, uintptr_t& base);
 
-  Status PreAllocate(size_t const size);
+  Status PreAllocate(
+      size_t const size,
+#if defined(DEFAULT_ALLOCATOR)
+      std::string const& allocator = VINEYARD_TO_STRING(DEFAULT_ALLOCATOR));
+#else
+      std::string const& allocator = "mimalloc");
+#endif
 
   Status FinalizeArena(int const fd, std::vector<size_t> const& offsets,
                        std::vector<size_t> const& sizes);

--- a/src/server/server/vineyard_server.cc
+++ b/src/server/server/vineyard_server.cc
@@ -100,26 +100,31 @@ Status VineyardServer::Serve(StoreType const& bulk_store_type) {
   this->meta_service_ptr_ = IMetaService::Get(shared_from_this());
   RETURN_ON_ERROR(this->meta_service_ptr_->Start());
 
+  auto memory_limit = spec_["bulkstore_spec"]["memory_size"].get<size_t>();
+  auto allocator = spec_["bulkstore_spec"]["allocator"].get<std::string>();
+
   if (bulk_store_type_ == StoreType::kPlasma) {
     plasma_bulk_store_ = std::make_shared<PlasmaBulkStore>();
-    RETURN_ON_ERROR(plasma_bulk_store_->PreAllocate(
-        spec_["bulkstore_spec"]["memory_size"].get<size_t>()));
+    RETURN_ON_ERROR(plasma_bulk_store_->PreAllocate(memory_limit, allocator));
 
     // TODO(mengke.mk): Currently we do not allow streamming in plasma
     // bulkstore, anyway, we can templatize stream store to solve this.
     stream_store_ = nullptr;
   } else if (bulk_store_type_ == StoreType::kDefault) {
     bulk_store_ = std::make_shared<BulkStore>();
-    auto mem_limit = spec_["bulkstore_spec"]["memory_size"].get<size_t>();
     auto spill_lower_bound_rate =
         spec_["bulkstore_spec"]["spill_lower_bound_rate"].get<double>();
     auto spill_upper_bound_rate =
         spec_["bulkstore_spec"]["spill_upper_bound_rate"].get<double>();
-    RETURN_ON_ERROR(bulk_store_->PreAllocate(mem_limit));
-    bulk_store_->SetMemSpillUpBound(mem_limit * spill_upper_bound_rate);
-    bulk_store_->SetMemSpillLowBound(mem_limit * spill_lower_bound_rate);
+    RETURN_ON_ERROR(bulk_store_->PreAllocate(memory_limit, allocator));
+
+    // setup spill
+    bulk_store_->SetMemSpillUpBound(memory_limit * spill_upper_bound_rate);
+    bulk_store_->SetMemSpillLowBound(memory_limit * spill_lower_bound_rate);
     bulk_store_->SetSpillPath(
         spec_["bulkstore_spec"]["spill_path"].get<std::string>());
+
+    // setup stream store
     stream_store_ = std::make_shared<StreamStore>(
         shared_from_this(), bulk_store_,
         spec_["bulkstore_spec"]["stream_threshold"].get<size_t>());


### PR DESCRIPTION

What do these changes do?
-------------------------

Build against dlmalloc and mimalloc at the same time, and add a runtime flag to select the allocator at startup.


