### PR TITLE
MarkAsCold: exclude "unsealed" blobs.

### DIFF
--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -1443,7 +1443,7 @@ Status UsageTracker<ID, P, Der>::DeleteUsage(ID const& id) {
 
 template <typename ID, typename P, typename Der>
 void UsageTracker<ID, P, Der>::ClearCache() {
-  base_t::ClearCache();
+  VINEYARD_DISCARD(base_t::ClearCache());
   object_in_use_.clear();
 }
 

--- a/src/common/util/protocols.cc
+++ b/src/common/util/protocols.cc
@@ -416,7 +416,7 @@ Status ReadGetBuffersReply(const json& root, std::vector<Payload>& objects,
                            std::vector<int>& fd_sent) {
   CHECK_IPC_ERROR(root, "get_buffers_reply");
 
-  for (size_t i = 0; i < root.value("num", 0); ++i) {
+  for (size_t i = 0; i < root.value("num", static_cast<size_t>(0)); ++i) {
     json tree = root[std::to_string(i)];
     Payload object;
     object.FromJSON(tree);

--- a/src/common/util/status.cc
+++ b/src/common/util/status.cc
@@ -55,6 +55,25 @@ void Status::CopyFrom(const Status& s) {
   }
 }
 
+void Status::MoveFrom(Status& s) {
+  delete state_;
+  state_ = s.state_;
+  s.state_ = nullptr;
+}
+
+void Status::MergeFrom(const Status& s) {
+  delete state_;
+  if (state_ == nullptr) {
+    if (s.state_ != nullptr) {
+      state_ = new State(*s.state_);
+    }
+  } else {
+    if (s.state_ != nullptr) {
+      state_->msg += "; " + s.state_->msg;
+    }
+  }
+}
+
 std::string Status::CodeAsString() const {
   if (state_ == nullptr) {
     return "OK";

--- a/src/common/util/status.h
+++ b/src/common/util/status.h
@@ -314,6 +314,7 @@ class VINEYARD_MUST_USE_TYPE Status {
   inline Status operator&(Status&& s) const noexcept;
   inline Status& operator&=(const Status& s) noexcept;
   inline Status& operator&=(Status&& s) noexcept;
+  inline Status& operator+=(const Status& s) noexcept;
 
   /// Return a success status
   inline static Status OK() { return Status(); }
@@ -680,7 +681,8 @@ class VINEYARD_MUST_USE_TYPE Status {
     state_ = nullptr;
   }
   void CopyFrom(const Status& s);
-  inline void MoveFrom(Status& s);
+  void MoveFrom(Status& s);
+  void MergeFrom(const Status& s);
 };
 
 static inline std::ostream& operator<<(std::ostream& os, const Status& x) {
@@ -708,12 +710,6 @@ Status& Status::operator<<(const T& s) {
   tmp << s;
   state_->msg.append(tmp.str());
   return *this;
-}
-
-void Status::MoveFrom(Status& s) {
-  delete state_;
-  state_ = s.state_;
-  s.state_ = nullptr;
 }
 
 Status::Status(const Status& s)
@@ -767,6 +763,14 @@ Status& Status::operator&=(Status&& s) noexcept {
   }
   return *this;
 }
+
+Status& Status::operator+=(const Status& s) noexcept {
+  if (!s.ok()) {
+    MergeFrom(s);
+  }
+  return *this;
+}
+
 /// \endcond
 
 }  // namespace vineyard

--- a/src/server/memory/usage.h
+++ b/src/server/memory/usage.h
@@ -354,11 +354,10 @@ class ColdObjectTracker
   Status MarkAsCold(ID const& id, std::shared_ptr<P> payload) {
     if (payload->IsSealed()) {
       cold_obj_lru_.Ref(id, payload);
-      return Status::OK();
     }
-    std::string err_msg = "Not Sealed, Object ID: " + std::to_string(id);
-    LOG(WARNING) << err_msg;
-    return Status::ObjectNotSealed(err_msg);
+    // n.b.: unseal blobs shouldn't be spilled, as will be re-get by clients
+    // with a "unsafe" argument.
+    return Status::OK();
   }
 
   /**


### PR DESCRIPTION
What do these changes do?
-------------------------

- Add `+=` operator to `Status`
- Skip unsealed blobs in `MarkAsCold` to avoid possible crash.

Resolves #932

