### PR TITLE
Ignore invalid metadata entries in `client.ListData()`.

### DIFF
--- a/src/common/util/status.h
+++ b/src/common/util/status.h
@@ -417,6 +417,11 @@ class VINEYARD_MUST_USE_TYPE Status {
     return Status(StatusCode::kMetaTreeTypeNotExists, "");
   }
 
+  /// Return an error if the "typename" field not exists in metatree.
+  static Status MetaTreeTypeNotExists(std::string const& message) {
+    return Status(StatusCode::kMetaTreeTypeNotExists, message);
+  }
+
   /// Return an error if the "id" field in metatree is invalid.
   static Status MetaTreeNameInvalid() {
     return Status(StatusCode::kMetaTreeNameInvalid, "");


### PR DESCRIPTION
What do these changes do?
-------------------------

as titled. Make sure `client.clear()` must success as well.


Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #936

