### PR TITLE
Etcd launcher: use a temporary directory to data for each launching.

### DIFF
--- a/src/server/services/etcd_meta_service.cc
+++ b/src/server/services/etcd_meta_service.cc
@@ -143,11 +143,8 @@ void EtcdMetaService::Stop() {
       watcher_->Cancel();
     } catch (...) {}
   }
-  if (etcd_proc_) {
-    std::error_code err;
-    etcd_proc_->terminate(err);
-    kill(etcd_proc_->id(), SIGTERM);
-    etcd_proc_->wait(err);
+  if (etcd_launcher_) {
+    etcd_launcher_.reset();
   }
 }
 
@@ -389,8 +386,8 @@ Status EtcdMetaService::probe() {
 }
 
 Status EtcdMetaService::preStart() {
-  auto launcher = EtcdLauncher(etcd_spec_);
-  return launcher.LaunchEtcdServer(etcd_, meta_sync_lock_, etcd_proc_);
+  etcd_launcher_ = std::unique_ptr<EtcdLauncher>(new EtcdLauncher(etcd_spec_));
+  return etcd_launcher_->LaunchEtcdServer(etcd_, meta_sync_lock_);
 }
 
 }  // namespace vineyard

--- a/src/server/services/etcd_meta_service.h
+++ b/src/server/services/etcd_meta_service.h
@@ -27,6 +27,7 @@ limitations under the License.
 #include "etcd/Client.hpp"
 
 #include "server/services/meta_service.h"
+#include "server/util/etcd_launcher.h"
 
 namespace etcd {
 class Client;
@@ -175,7 +176,7 @@ class EtcdMetaService : public IMetaService {
   std::shared_ptr<etcd::Watcher> watcher_;
   std::shared_ptr<EtcdWatchHandler> handler_;
   std::unique_ptr<asio::steady_timer> backoff_timer_;
-  std::unique_ptr<boost::process::child> etcd_proc_;
+  std::unique_ptr<EtcdLauncher> etcd_launcher_;
 
   callback_task_queue_t registered_callbacks_;
   std::atomic<unsigned> handled_rev_;

--- a/src/server/util/etcd_launcher.h
+++ b/src/server/util/etcd_launcher.h
@@ -30,13 +30,14 @@ limitations under the License.
 #include "common/util/status.h"
 
 namespace vineyard {
+
 class EtcdLauncher {
  public:
-  explicit EtcdLauncher(const json& etcd_spec) : etcd_spec_(etcd_spec) {}
+  explicit EtcdLauncher(const json& etcd_spec);
+  ~EtcdLauncher();
 
   Status LaunchEtcdServer(std::unique_ptr<etcd::Client>& etcd_client,
-                          std::string& sync_lock,
-                          std::unique_ptr<boost::process::child>& etcd_proc);
+                          std::string& sync_lock);
 
   // Check if the etcd server available, return True if succeed, otherwise
   // False.
@@ -44,16 +45,20 @@ class EtcdLauncher {
                               std::string const& key);
 
  private:
-  void parseEndpoint();
+  Status parseEndpoint();
 
-  void initHostInfo();
+  Status initHostInfo();
 
   const json etcd_spec_;
   std::string endpoint_host_;
+  std::string etcd_data_dir_;
   int endpoint_port_;
   std::set<std::string> local_hostnames_;
   std::set<std::string> local_ip_addresses_;
+
+  std::unique_ptr<boost::process::child> etcd_proc_;
 };
+
 }  // namespace vineyard
 
 #endif  // SRC_SERVER_UTIL_ETCD_LAUNCHER_H_


### PR DESCRIPTION
What do these changes do?
-------------------------

- Generate a temporary directory for launching etcd from vineyard, as destroy the directory when exit.

Related issue number
--------------------

Fixes #935

