### PR TITLE
Fixes a incorrect of shared_from_this in CRTP

### DIFF
--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -1504,12 +1504,12 @@ Status UsageTracker<ID, P, Der>::OnRelease(ID const& id) {
   // cannot be guaranteed (may trigger spilling in server-side), thus this
   // blob should be regard as not-in-use.
   RETURN_ON_ERROR(DeleteUsage(id));
-  return this->Self().OnRelease(id);
+  return this->self().OnRelease(id);
 }
 
 template <typename ID, typename P, typename Der>
 Status UsageTracker<ID, P, Der>::OnDelete(ID const& id) {
-  return Self().OnDelete(id);
+  return self().OnDelete(id);
 }
 
 }  // namespace detail

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -195,7 +195,7 @@ class UsageTracker : public LifeCycleTracker<ID, P, UsageTracker<ID, P, Der>> {
   Status OnDelete(ID const& id);
 
  private:
-  inline Der& Self() { return static_cast<Der&>(*this); }
+  inline Der& self() { return static_cast<Der&>(*this); }
 
   // Track the objects' usage.
   std::unordered_map<ID, std::shared_ptr<P>> object_in_use_;

--- a/src/common/util/lifecycle.h
+++ b/src/common/util/lifecycle.h
@@ -60,12 +60,12 @@ class LifeCycleTracker {
     }
 
     // If reaches zero, trigger `OnRelease` behavior.
-    auto s = Self().OnRelease(id);
+    auto s = self().OnRelease(id);
 
     // If the object is marked as to be deleted, trigger `OnDelete` behavior.
     if (pending_to_delete_.count(id) > 0) {
       pending_to_delete_.erase(id);
-      s += Self().OnDelete(id);
+      s += self().OnDelete(id);
     }
     return s;
   }
@@ -79,7 +79,7 @@ class LifeCycleTracker {
     if (ref_cnt != 0) {
       pending_to_delete_.emplace(id);
     } else {
-      RETURN_ON_ERROR(Self().OnDelete(id));
+      RETURN_ON_ERROR(self().OnDelete(id));
     }
     return Status::OK();
   }
@@ -87,7 +87,7 @@ class LifeCycleTracker {
   Status ClearCache() {
     Status s;
     for (auto const& id : pending_to_delete_) {
-      s += (Self().OnDelete(id));
+      s += (self().OnDelete(id));
     }
     pending_to_delete_.clear();
     return s;
@@ -95,7 +95,7 @@ class LifeCycleTracker {
 
  protected:
   Status FetchAndModify(ID const& id, int64_t& ref_cnt, int64_t change) {
-    return Self().FetchAndModify(id, ref_cnt, change);
+    return self().FetchAndModify(id, ref_cnt, change);
   }
 
   bool IsInDeletion(ID const& id) {
@@ -103,7 +103,8 @@ class LifeCycleTracker {
   }
 
  private:
-  inline Derived& Self() { return static_cast<Derived&>(*this); }
+  inline Derived& self() { return static_cast<Derived&>(*this); }
+
   /// Cache the objects that client wants to delete but `ref_count > 0`
   /// Race condition should be settled by Der.
   std::unordered_set<ID> pending_to_delete_;

--- a/src/server/async/socket_server.cc
+++ b/src/server/async/socket_server.cc
@@ -90,7 +90,7 @@ bool SocketConnection::Stop() {
 }
 
 void SocketConnection::doReadHeader() {
-  auto self(this->shared_from_this());
+  auto self(shared_from_this());
   asio::async_read(socket_, asio::buffer(&read_msg_header_, sizeof(size_t)),
                    [this, self](boost::system::error_code ec, std::size_t) {
                      if (!ec && running_.load()) {

--- a/src/server/memory/memory.h
+++ b/src/server/memory/memory.h
@@ -190,6 +190,11 @@ class BulkStore
    */
   Status OnDelete(ObjectID const& id);
 
+ private:
+  inline std::shared_ptr<BulkStore> shared_from_self() override {
+    return shared_from_this();
+  }
+
   friend class detail::ColdObjectTracker<ObjectID, Payload, BulkStore>;
   friend class SocketConnection;
   friend class VineyardServer;
@@ -235,6 +240,7 @@ class PlasmaBulkStore
    */
   Status OnDelete(PlasmaID const& id);
 
+ private:
   friend class detail::DependencyTracker<PlasmaID, PlasmaPayload,
                                          PlasmaBulkStore>;
   friend class SocketConnection;

--- a/src/server/util/etcd_launcher.cc
+++ b/src/server/util/etcd_launcher.cc
@@ -185,7 +185,7 @@ Status EtcdLauncher::LaunchEtcdServer(
 
   // use a random etcd data dir
   std::string file_template = "/tmp/vineyard-etcd-XXXXXX";
-  char* data_dir = mktemp(const_cast<char*>(file_template.c_str()));
+  char* data_dir = mkdtemp(const_cast<char*>(file_template.c_str()));
   if (data_dir == nullptr) {
     return Status::EtcdError(
         "Failed to create a temporary directory for etcd data");

--- a/src/server/util/proc.cc
+++ b/src/server/util/proc.cc
@@ -83,7 +83,7 @@ void Process::Start(const std::string& command,
 }
 
 void Process::AsyncWrite(std::string const& content, callback_t<> callback) {
-  auto self(this->shared_from_this());
+  auto self(shared_from_this());
   asio::async_write(
       stdin_pipe_, boost::asio::buffer(content.data(), content.size()),
       [self, callback](const boost::system::error_code& ec, std::size_t) {
@@ -100,7 +100,7 @@ void Process::AsyncRead(boost::process::async_pipe& pipe,
                         asio::streambuf& buffer,
                         callback_t<const std::string&> callback, bool once,
                         bool processed, const char delimeter) {
-  auto self(this->shared_from_this());
+  auto self(shared_from_this());
   asio::async_read_until(
       pipe, buffer, delimeter,
       [self, &pipe, &buffer, callback, delimeter, once, processed](


### PR DESCRIPTION

<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

Calling `shared_from_this()` on a _reference_ of child class is not ok. This pull request renames `Self()` to `self()` as well as it is a private method.

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #953

