### PR TITLE
Use wyhash as the hash function when building the hashmap to reduce memory usage

### DIFF
--- a/modules/basic/ds/hashmap.h
+++ b/modules/basic/ds/hashmap.h
@@ -23,9 +23,7 @@ limitations under the License.
 #include <utility>
 
 #include "flat_hash_map/flat_hash_map.hpp"
-#if defined(USE_WY_HASH)
 #include "wyhash/wyhash.hpp"
-#endif
 
 #include "basic/ds/array.h"
 #include "basic/ds/hashmap.vineyard.h"
@@ -44,7 +42,7 @@ namespace vineyard {
  * @tparam std::hash<K> The hash function for the key.
  * @tparam std::equal_to<K> The compare function for the key.
  */
-template <typename K, typename V, typename H = prime_number_hash<K>,
+template <typename K, typename V, typename H = prime_number_hash_wy<K>,
           typename E = std::equal_to<K>>
 class HashmapBuilder : public HashmapBaseBuilder<K, V, H, E> {
  public:
@@ -99,6 +97,19 @@ class HashmapBuilder : public HashmapBaseBuilder<K, V, H, E> {
    *
    */
   void reserve(size_t size) { hashmap_.reserve(size); }
+
+  /**
+   * @brief Return the maximum possible size of the HashMap, i.e., the number
+   * of elements that can be stored in the HashMap.
+   *
+   */
+  size_t bucket_count() const { return hashmap_.bucket_count(); }
+
+  /**
+   * @brief Return the load factor of the HashMap.
+   *
+   */
+  float load_factor() const { return hashmap_.load_factor(); }
 
   /**
    * @brief Check whether the hashmap is empty.

--- a/modules/basic/ds/hashmap.vineyard-mod
+++ b/modules/basic/ds/hashmap.vineyard-mod
@@ -23,9 +23,7 @@ limitations under the License.
 #include <utility>
 
 #include "flat_hash_map/flat_hash_map.hpp"
-#if defined(USE_WY_HASH)
 #include "wyhash/wyhash.hpp"
-#endif
 
 #include "basic/ds/array.vineyard.h"
 #include "client/ds/blob.h"
@@ -57,17 +55,7 @@ struct prime_hash_policy {
 };
 
 // Using prime_hash_policy in flat_hash_map.
-#if defined(USE_WY_HASH)
-template <typename T>
-struct prime_number_hash : wy::hash<T> {
-  typedef ska::prime_number_hash_policy hash_policy;
-};
 
-template <typename U>
-struct typename_t<prime_number_hash<U>> {
-  inline static const std::string name() { return type_name<wy::hash<U>>(); }
-};
-#else
 template <typename T>
 struct prime_number_hash : std::hash<T> {
   typedef ska::prime_number_hash_policy hash_policy;
@@ -77,7 +65,16 @@ template <typename U>
 struct typename_t<prime_number_hash<U>> {
   inline static const std::string name() { return type_name<std::hash<U>>(); }
 };
-#endif
+
+template <typename T>
+struct prime_number_hash_wy : wy::hash<T> {
+  typedef ska::prime_number_hash_policy hash_policy;
+};
+
+template <typename U>
+struct typename_t<prime_number_hash_wy<U>> {
+  inline static const std::string name() { return type_name<wy::hash<U>>(); }
+};
 
 template <typename K, typename V, typename H, typename E>
 class HashmapBaseBuilder;
@@ -90,14 +87,14 @@ class HashmapBaseBuilder;
  * @tparam std::hash<K> The hash function for the key.
  * @tparam std::equal_to<K> The compare function for the key.
  */
-template <typename K, typename V, typename H = prime_number_hash<K>,
+template <typename K, typename V, typename H = prime_number_hash_wy<K>,
           typename E = std::equal_to<K>>
 class [[vineyard]] Hashmap : public Registered<Hashmap<K, V, H, E>>,
                              public H,
                              public E {
  public:
-  using KeyHash = prime_number_hash<K>;
-  using KeyEqual = typename std::equal_to<K>;
+  using KeyHash = H;
+  using KeyEqual = E;
 
   using T = std::pair<K, V>;
 
@@ -224,6 +221,28 @@ class [[vineyard]] Hashmap : public Registered<Hashmap<K, V, H, E>>,
    *
    */
   size_t size() const { return num_elements_; }
+
+  /**
+   * @brief Return the max size of the HashMap, i.e., the number of allocated
+   * cells for elements stored in the HashMap.
+   *
+   */
+  size_t bucket_count() const {
+    return num_slots_minus_one_ ? num_slots_minus_one_ + 1 : 0;
+  }
+
+  /**
+   * @brief Return the load factor of the HashMap.
+   *
+   */
+  float load_factor() const {
+    size_t bucket_count = num_slots_minus_one_ ? num_slots_minus_one_ + 1 : 0;
+    if (bucket_count) {
+      return static_cast<float>(num_elements_) / bucket_count;
+    } else {
+      return 0.0f;
+    }
+  }
 
   /**
    * @brief Check whether the HashMap is empty.

--- a/modules/graph/vertex_map/arrow_vertex_map_builder.h
+++ b/modules/graph/vertex_map/arrow_vertex_map_builder.h
@@ -152,6 +152,7 @@ ObjectID ArrowVertexMap<OID_T, VID_T>::AddNewVertexLabels(
   new_meta.SetNBytes(nbytes);
   ObjectID ret;
   VINEYARD_CHECK_OK(client.CreateMetaData(new_meta, ret));
+  VLOG(2) << "vertex map memory usage: " << new_meta.MemoryUsage() << " bytes";
   return ret;
 }
 
@@ -229,6 +230,7 @@ ObjectID ArrowVertexMap<arrow::util::string_view, VID_T>::AddNewVertexLabels(
   new_meta.SetNBytes(nbytes);
   ObjectID ret;
   VINEYARD_CHECK_OK(client.CreateMetaData(new_meta, ret));
+  VLOG(2) << "vertex map memory usage: " << new_meta.MemoryUsage() << " bytes";
   return ret;
 }
 
@@ -279,6 +281,9 @@ std::shared_ptr<vineyard::Object> ArrowVertexMapBuilder<OID_T, VID_T>::_Seal(
   vertex_map->meta_.SetNBytes(nbytes);
 
   VINEYARD_CHECK_OK(client.CreateMetaData(vertex_map->meta_, vertex_map->id_));
+  VLOG(2) << "vertex map memory usage: " << vertex_map->meta_.MemoryUsage()
+          << " bytes";
+
   // mark the builder as sealed
   this->set_sealed(true);
 
@@ -326,6 +331,9 @@ ArrowVertexMapBuilder<arrow::util::string_view, VID_T>::_Seal(
 
   vertex_map->meta_.SetNBytes(nbytes);
   VINEYARD_CHECK_OK(client.CreateMetaData(vertex_map->meta_, vertex_map->id_));
+  VLOG(2) << "vertex map memory usage: " << vertex_map->meta_.MemoryUsage()
+          << " bytes";
+
   // mark the builder as sealed
   this->set_sealed(true);
 

--- a/test/hashmap_largefile_test.cc
+++ b/test/hashmap_largefile_test.cc
@@ -1,0 +1,87 @@
+/** Copyright 2020-2022 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "arrow/api.h"
+#include "arrow/io/api.h"
+
+#include "basic/ds/array.h"
+#include "basic/ds/hashmap.h"
+#include "client/client.h"
+#include "client/ds/object_meta.h"
+#include "common/util/logging.h"
+
+using namespace vineyard;  // NOLINT(build/namespaces)
+
+int main(int argc, char** argv) {
+  if (argc < 3) {
+    printf("usage ./hashmap_test <ipc_socket_name> <datafile>");
+    return 1;
+  }
+  std::string ipc_socket = std::string(argv[1]);
+  std::string datafile = std::string(argv[2]);
+
+  Client client;
+  VINEYARD_CHECK_OK(client.Connect(ipc_socket));
+  LOG(INFO) << "Connected to IPCServer: " << ipc_socket;
+
+  std::vector<int64_t> ns;
+  {
+    int64_t n;
+    std::FILE* fp = fopen(datafile.c_str(), "r");
+    while (fscanf(fp, "%ld", &n) != EOF) {
+      ns.emplace_back(n);
+    }
+    fclose(fp);
+  }
+
+  LOG(INFO) << "number size: " << ns.size();
+
+  HashmapBuilder<int64_t, uint64_t> builder(client);
+  for (int64_t n : ns) {
+    builder.emplace(n, n);
+    if (builder.bucket_count() > ns.size() * 16) {
+      LOG(ERROR) << "bucket count exceed limit: " << builder.bucket_count();
+      exit(-1);
+    }
+  }
+
+  LOG(INFO) << "hashmap size: " << builder.size()
+            << ", bucket count: " << builder.bucket_count()
+            << ", load factor: " << builder.load_factor();
+
+  auto sealed_hashmap = std::dynamic_pointer_cast<Hashmap<int64_t, uint64_t>>(
+      builder.Seal(client));
+
+  LOG(INFO) << "sealed hashmap size: " << sealed_hashmap->size()
+            << ", bucket count: " << sealed_hashmap->bucket_count()
+            << ", load factor: " << sealed_hashmap->load_factor()
+            << ", memory usage: " << sealed_hashmap->meta().MemoryUsage();
+
+  for (auto const& kv : *sealed_hashmap) {
+    CHECK_EQ(kv.first, kv.second);
+  }
+
+  LOG(INFO) << "Passed double hashmap tests...";
+
+  client.Disconnect();
+
+  return 0;
+}

--- a/test/typename_test.cc
+++ b/test/typename_test.cc
@@ -61,7 +61,7 @@ int main(int, const char**) {
   {
     const auto type = type_name<Hashmap<int64_t, double>>();
     CHECK_EQ(type,
-             "vineyard::Hashmap<int64,double,std::hash<int64>,std::equal_to<"
+             "vineyard::Hashmap<int64,double,wy::hash<int64>,std::equal_to<"
              "int64>>");
   }
 
@@ -82,7 +82,7 @@ int main(int, const char**) {
   {
     const auto type = type_name<my_hashmap<int64_t, double>>();
     CHECK_EQ(type,
-             "vineyard::Hashmap<int64,double,std::hash<int64>,std::equal_to<"
+             "vineyard::Hashmap<int64,double,wy::hash<int64>,std::equal_to<"
              "int64>>");
   }
   {
@@ -101,6 +101,10 @@ int main(int, const char**) {
   {
     const auto type = type_name<std::hash<int>>();
     CHECK_EQ(type, "std::hash<int>");
+  }
+  {
+    const auto type = type_name<wy::hash<int>>();
+    CHECK_EQ(type, "wy::hash<int>");
   }
   {
     const auto type = type_name<std::equal_to<int64_t>>();


### PR DESCRIPTION


What do these changes do?
-------------------------

LOG the memory usage of vertex map as well.

Related issue number
--------------------

Fixes #973

