### PR TITLE
Disable the lru_test if tbb is not found

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,7 +31,11 @@ foreach(testfile ${TEST_FILES})
     set(testname ${CMAKE_MATCH_1})
 
     if(${testname} STREQUAL "gpumalloc_test" AND NOT USE_GPU)
-      continue()
+        continue()
+    endif()
+
+    if(${testname} STREQUAL "lru_test" AND NOT (TARGET TBB::tbb))
+        continue()
     endif()
 
     message(STATUS "Found unit_test - " ${testname})


### PR DESCRIPTION

What do these changes do?
-------------------------

Avoid building failure if tbb is not found (tbb is only required for building vineyardd).

Related issue number
--------------------

N/A, credit to @doudoubobo

