### PR TITLE
Add debuginfo only for vineyard components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,11 +191,9 @@ if(W_NO_NOEXCEPT_TYPE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-noexcept-type")
 endif()
 
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -g")
 if(BUILD_VINEYARD_COVERAGE)
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fprofile-arcs -ftest-coverage")
 endif()
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -g")
 
 if(APPLE)
     set(CMAKE_MACOSX_RPATH ON)
@@ -542,6 +540,10 @@ macro(target_enable_sanitizer target visibility)
     endif()
 endmacro()
 
+macro(target_add_debuginfo target)
+    target_compile_options(${target} PRIVATE -g)
+endmacro()
+
 macro(install_vineyard_target target)
     install(TARGETS ${target}
         EXPORT vineyard-targets
@@ -633,6 +635,7 @@ if(BUILD_VINEYARD_SERVER)
         list(APPEND SERVER_SRC_FILES "thirdparty/redis-plus-plus-shim/recipes/redlock.cpp")
     endif()
     add_executable(vineyardd ${SERVER_SRC_FILES})
+    target_add_debuginfo(vineyardd)
     target_compile_options(vineyardd PRIVATE -DBUILD_VINEYARDD)
     target_link_libraries(vineyardd PRIVATE ${Boost_LIBRARIES}
                                             ${CPPREST_LIB}
@@ -748,6 +751,7 @@ if(BUILD_VINEYARD_CLIENT)
     # the vineyard_client can only be a shared library, since the ObjectFactory
     # is a singleton.
     add_library(vineyard_client ${CLIENT_SRC_FILES})
+    target_add_debuginfo(vineyard_client)
     if(USE_GPU)
         find_package(CUDA REQUIRED)
         target_link_libraries(vineyard_client PUBLIC ${CUDA_LIBRARIES})
@@ -803,6 +807,7 @@ if(BUILD_VINEYARD_PYTHON_BINDINGS)
                           "python/pybind11_utils.cc"
                           "python/vineyard.cc")
     pybind11_add_module(_C MODULE ${PYTHON_BIND_FILES})
+    target_add_debuginfo(_C)
     target_link_libraries(_C PRIVATE vineyard_client)
     target_include_directories(_C PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
                                          thirdparty/pybind11/include)

--- a/modules/basic/CMakeLists.txt
+++ b/modules/basic/CMakeLists.txt
@@ -41,6 +41,7 @@ add_custom_target(vineyard_basic_gen_java
 file(GLOB_RECURSE BASIC_SRC_FILES "${CMAKE_CURRENT_SOURCE_DIR}" "*.cc")
 
 add_library(vineyard_basic ${BASIC_SRC_FILES})
+target_add_debuginfo(vineyard_basic)
 target_link_libraries(vineyard_basic PUBLIC vineyard_client
                                             ${ARROW_SHARED_LIB}
                                             ${GLOG_LIBRARIES}

--- a/modules/graph/CMakeLists.txt
+++ b/modules/graph/CMakeLists.txt
@@ -47,6 +47,7 @@ file(GLOB_RECURSE GRAPH_SRC_FILES "${CMAKE_CURRENT_SOURCE_DIR}" "fragment/*.cc"
 )
 
 add_library(vineyard_graph ${GRAPH_SRC_FILES})
+target_add_debuginfo(vineyard_graph)
 target_include_directories(vineyard_graph PUBLIC
                                           ${MPI_CXX_INCLUDE_PATH}
 )

--- a/modules/hosseinmoein-dataframe/CMakeLists.txt
+++ b/modules/hosseinmoein-dataframe/CMakeLists.txt
@@ -8,6 +8,7 @@ set(HMDF_BENCHMARKS OFF CACHE BOOL "Build benchmarks of hosseinmoein/dataframe")
 add_subdirectory_static(thirdparty/DataFrame EXCLUDE_FROM_ALL)
 
 add_library(vineyard_hosseinmoein_dataframe ${DATAFRAME_SRC_FILES})
+target_add_debuginfo(vineyard_hosseinmoein_dataframe)
 set_property(TARGET vineyard_hosseinmoein_dataframe PROPERTY CXX_STANDARD 17)
 target_link_libraries(vineyard_hosseinmoein_dataframe PUBLIC vineyard_client
                                                              vineyard_basic)

--- a/modules/io/CMakeLists.txt
+++ b/modules/io/CMakeLists.txt
@@ -14,6 +14,7 @@ set(BUILD_SHARED_LIBS_SAVED "${BUILD_SHARED_LIBS}")
 set(BUILD_SHARED_LIBS "${BUILD_SHARED_LIBS_SAVED}" CACHE BOOL "Restore the default value" FORCE)
 
 add_library(vineyard_io ${IO_SRC_FILES})
+target_add_debuginfo(vineyard_io)
 target_include_directories(vineyard_io PRIVATE ${MPI_CXX_INCLUDE_PATH}
 )
 target_link_libraries(vineyard_io PUBLIC vineyard_client

--- a/modules/malloc/CMakeLists.txt
+++ b/modules/malloc/CMakeLists.txt
@@ -3,6 +3,7 @@
 file(GLOB_RECURSE BASIC_SRC_FILES "${CMAKE_CURRENT_SOURCE_DIR}" "*.cc")
 
 add_library(vineyard_malloc ${BASIC_SRC_FILES})
+target_add_debuginfo(vineyard_malloc)
 target_link_libraries(vineyard_malloc PUBLIC vineyard_client)
 
 # requires mimalloc


### PR DESCRIPTION
What do these changes do?
-------------------------

This will help to reduce the binary artifact size, while keep the ability of debugging if error/crash occurs.

Vineyardd size comparison:

- RelWithDebInfo: 131+M
- Release: 11M
- RelWithDebInfo for vineyardd: 78M

Related issue number
--------------------

N/A
