### PR TITLE
Delete the vineyard controller image

### DIFF
--- a/.github/workflows/vineyard-operator.yaml
+++ b/.github/workflows/vineyard-operator.yaml
@@ -36,7 +36,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     env:
-      IMG: docker.pkg.github.com/v6d-io/v6d/vineyard-controller
+      IMG: docker.pkg.github.com/v6d-io/v6d/vineyard-operator
     strategy:
       matrix:
         os: [ubuntu-20.04]

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -27,7 +27,7 @@ endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
 # Image URL to use all building/pushing image targets
-IMG ?= registry-vpc.cn-hongkong.aliyuncs.com/libvineyard/vineyard-controller:latest
+IMG ?= registry-vpc.cn-hongkong.aliyuncs.com/libvineyard/vineyard-operator:latest
 
 temp=$(shell mktemp -d)
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)

--- a/k8s/config/manager/kustomization.yaml
+++ b/k8s/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: registry-vpc.cn-hongkong.aliyuncs.com/libvineyard/vineyard-controller
+  newName: registry-vpc.cn-hongkong.aliyuncs.com/libvineyard/vineyard-operator
   newTag: latest

--- a/k8s/test/e2e/serialize/e2e.yaml
+++ b/k8s/test/e2e/serialize/e2e.yaml
@@ -38,7 +38,7 @@ setup:
     - name: install scheduler-plugin and operator
       command: |
         make -C k8s docker-build
-        kind load docker-image registry-vpc.cn-hongkong.aliyuncs.com/libvineyard/vineyard-controller:latest
+        kind load docker-image registry-vpc.cn-hongkong.aliyuncs.com/libvineyard/vineyard-operator:latest
         make -C k8s predeploy
         make -C k8s deploy
       wait:

--- a/k8s/test/e2e/spill/e2e.yaml
+++ b/k8s/test/e2e/spill/e2e.yaml
@@ -38,7 +38,7 @@ setup:
     - name: install scheduler-plugin and operator
       command: |
         make -C k8s docker-build
-        kind load docker-image registry-vpc.cn-hongkong.aliyuncs.com/libvineyard/vineyard-controller:latest
+        kind load docker-image registry-vpc.cn-hongkong.aliyuncs.com/libvineyard/vineyard-operator:latest
         make -C k8s predeploy
         make -C k8s deploy
       wait:

--- a/k8s/test/e2e/vineyardd/e2e.yaml
+++ b/k8s/test/e2e/vineyardd/e2e.yaml
@@ -37,7 +37,7 @@ setup:
     - name: install scheduler-plugin and operator
       command: |
         make -C k8s docker-build
-        kind load docker-image registry-vpc.cn-hongkong.aliyuncs.com/libvineyard/vineyard-controller:latest
+        kind load docker-image registry-vpc.cn-hongkong.aliyuncs.com/libvineyard/vineyard-operator:latest
         make -C k8s predeploy
         make -C k8s deploy
       wait:

--- a/misc/release-docker.sh
+++ b/misc/release-docker.sh
@@ -13,12 +13,12 @@ fi
 
 docker pull docker.pkg.github.com/v6d-io/v6d/vineyardd:$version
 docker pull docker.pkg.github.com/v6d-io/v6d/vineyardd:latest
-docker pull docker.pkg.github.com/v6d-io/v6d/vineyard-controller:nightly
+docker pull docker.pkg.github.com/v6d-io/v6d/vineyard-operator:nightly
 
 docker tag docker.pkg.github.com/v6d-io/v6d/vineyardd:$version vineyardcloudnative/vineyardd:$version
 docker tag docker.pkg.github.com/v6d-io/v6d/vineyardd:latest vineyardcloudnative/vineyardd:latest
-docker tag docker.pkg.github.com/v6d-io/v6d/vineyard-controller:nightly vineyardcloudnative/vineyard-controller:nightly
+docker tag docker.pkg.github.com/v6d-io/v6d/vineyard-operator:nightly vineyardcloudnative/vineyard-operator:nightly
 
 docker push vineyardcloudnative/vineyardd:$version
 docker push vineyardcloudnative/vineyardd:latest
-docker push vineyardcloudnative/vineyard-controller:nightly
+docker push vineyardcloudnative/vineyard-operator:nightly


### PR DESCRIPTION
As titled. We have two images now, namely `vineyard-operator` and `vineyard-controller`, which may confuse users. Based on this, we decide to reserve the `vineyard-operator` image and delete the `vineyard-controller` image.