### PR TITLE
Ensure no resize() operation happens at the same time between different worker threads

### DIFF
--- a/modules/graph/fragment/arrow_fragment.h
+++ b/modules/graph/fragment/arrow_fragment.h
@@ -88,6 +88,9 @@ class BasicArrowFragmentBuilder
       tg.AddTask(fn, &client);
     }
 
+    this->vertex_tables_.resize(this->vertex_label_num_);
+    this->ovgid_lists_.resize(this->vertex_label_num_);
+    this->ovg2l_maps_.resize(this->vertex_label_num_);
     for (label_id_t i = 0; i < this->vertex_label_num_; ++i) {
       auto fn = [this, i](Client* client) {
         vineyard::TableBuilder vt(*client, vertex_tables_[i]);
@@ -110,6 +113,7 @@ class BasicArrowFragmentBuilder
       tg.AddTask(fn, &client);
     }
 
+    this->edge_tables_.resize(this->edge_label_num_);
     for (label_id_t i = 0; i < this->edge_label_num_; ++i) {
       auto fn = [this, i](Client* client) {
         vineyard::TableBuilder et(*client, edge_tables_[i]);
@@ -120,7 +124,19 @@ class BasicArrowFragmentBuilder
       tg.AddTask(fn, &client);
     }
 
+    if (this->directed_) {
+      this->ie_lists_.resize(this->vertex_label_num_);
+      this->ie_offsets_lists_.resize(this->vertex_label_num_);
+    }
+    this->oe_lists_.resize(this->vertex_label_num_);
+    this->oe_offsets_lists_.resize(this->vertex_label_num_);
     for (label_id_t i = 0; i < this->vertex_label_num_; ++i) {
+      if (this->directed_) {
+        this->ie_lists_[i].resize(this->edge_label_num_);
+        this->ie_offsets_lists_[i].resize(this->edge_label_num_);
+      }
+      this->oe_lists_[i].resize(this->edge_label_num_);
+      this->oe_offsets_lists_[i].resize(this->edge_label_num_);
       for (label_id_t j = 0; j < this->edge_label_num_; ++j) {
         auto fn = [this, i, j](Client* client) {
           if (this->directed_) {

--- a/modules/graph/fragment/arrow_fragment_modifier.h
+++ b/modules/graph/fragment/arrow_fragment_modifier.h
@@ -501,6 +501,8 @@ ArrowFragment<OID_T, VID_T>::AddNewVertexEdgeLabels(
       ovg2l_maps[i].clear();
     }
   }
+  builder.ovgid_lists_.resize(total_vertex_label_num);
+  builder.ovg2l_maps_.resize(total_vertex_label_num);
   for (label_id_t i = 0; i < total_vertex_label_num; ++i) {
     auto fn = [this, &builder, i, &ovgid_lists, &ovg2l_maps](Client* client) {
       if (i >= vertex_label_num_ || ovgid_lists[i]->length() != 0) {
@@ -520,7 +522,19 @@ ArrowFragment<OID_T, VID_T>::AddNewVertexEdgeLabels(
   }
 
   // Extra ie_list, oe_list, ie_offset_list, oe_offset_list
+  if (directed_) {
+    builder.ie_lists_.resize(total_vertex_label_num);
+    builder.ie_offsets_lists_.resize(total_vertex_label_num);
+  }
+  builder.oe_lists_.resize(total_vertex_label_num);
+  builder.oe_offsets_lists_.resize(total_vertex_label_num);
   for (label_id_t i = 0; i < total_vertex_label_num; ++i) {
+    if (directed_) {
+      builder.ie_lists_[i].resize(total_edge_label_num);
+      builder.ie_offsets_lists_[i].resize(total_edge_label_num);
+    }
+    builder.oe_lists_[i].resize(total_edge_label_num);
+    builder.oe_offsets_lists_[i].resize(total_edge_label_num);
     for (label_id_t j = 0; j < total_edge_label_num; ++j) {
       auto fn = [this, &builder, i, j, &ie_lists, &oe_lists, &ie_offsets_lists,
                  &oe_offsets_lists](Client* client) {
@@ -935,6 +949,8 @@ boost::leaf::result<ObjectID> ArrowFragment<OID_T, VID_T>::AddNewEdgeLabels(
       ovg2l_maps[i].clear();
     }
   }
+  builder.ovgid_lists_.resize(vertex_label_num_);
+  builder.ovg2l_maps_.resize(vertex_label_num_);
   for (label_id_t i = 0; i < vertex_label_num_; ++i) {
     auto fn = [this, &builder, i, &ovgid_lists, &ovg2l_maps](Client* client) {
       if (ovgid_lists[i]->length() != 0) {
@@ -954,7 +970,20 @@ boost::leaf::result<ObjectID> ArrowFragment<OID_T, VID_T>::AddNewEdgeLabels(
   }
 
   // Extra ie_list, oe_list, ie_offset_list, oe_offset_list
+  if (directed_) {
+    builder.ie_lists_.resize(vertex_label_num_);
+    builder.ie_offsets_lists_.resize(vertex_label_num_);
+  }
+  builder.oe_lists_.resize(vertex_label_num_);
+  builder.oe_offsets_lists_.resize(vertex_label_num_);
   for (label_id_t i = 0; i < vertex_label_num_; ++i) {
+    if (directed_) {
+      builder.ie_lists_[i].resize(edge_label_num_ + extra_edge_label_num);
+      builder.ie_offsets_lists_[i].resize(edge_label_num_ +
+                                          extra_edge_label_num);
+    }
+    builder.oe_lists_[i].resize(edge_label_num_ + extra_edge_label_num);
+    builder.oe_offsets_lists_[i].resize(edge_label_num_ + extra_edge_label_num);
     for (label_id_t j = 0; j < extra_edge_label_num; ++j) {
       auto fn = [this, &builder, i, j, &ie_lists, &oe_lists, &ie_offsets_lists,
                  &oe_offsets_lists](Client* client) {

--- a/modules/graph/vertex_map/arrow_vertex_map.h
+++ b/modules/graph/vertex_map/arrow_vertex_map.h
@@ -42,6 +42,9 @@ template <typename OID_T, typename VID_T>
 class ArrowVertexMapBuilder;
 
 template <typename OID_T, typename VID_T>
+class BasicArrowVertexMapBuilder;
+
+template <typename OID_T, typename VID_T>
 class ArrowVertexMap
     : public vineyard::Registered<ArrowVertexMap<OID_T, VID_T>> {
   using oid_t = OID_T;
@@ -187,6 +190,7 @@ class ArrowVertexMap
   std::vector<std::vector<vineyard::Hashmap<oid_t, vid_t>>> o2g_;
 
   friend class ArrowVertexMapBuilder<OID_T, VID_T>;
+  friend class BasicArrowVertexMapBuilder<OID_T, VID_T>;
 
   friend class gs::ArrowProjectedVertexMap<OID_T, VID_T>;
 };
@@ -350,6 +354,7 @@ class ArrowVertexMap<arrow::util::string_view, VID_T>
   std::vector<std::vector<ska::flat_hash_map<oid_t, vid_t>>> o2g_;
 
   friend class ArrowVertexMapBuilder<arrow::util::string_view, VID_T>;
+  friend class BasicArrowVertexMapBuilder<arrow::util::string_view, VID_T>;
 
   friend class gs::ArrowProjectedVertexMap<arrow::util::string_view, VID_T>;
 };

--- a/modules/graph/vertex_map/arrow_vertex_map_builder.h
+++ b/modules/graph/vertex_map/arrow_vertex_map_builder.h
@@ -446,7 +446,6 @@ BasicArrowVertexMapBuilder<arrow::util::string_view, VID_T>::Build(
   this->set_fnum_label_num(fnum_, label_num_);
 
   ThreadGroup tg;
-
   auto builder_fn = [this, &client](fid_t const fid,
                                     label_id_t const vlabel_id) -> Status {
     auto& array = oid_arrays_[vlabel_id][fid];


### PR DESCRIPTION
What do these changes do?
-------------------------

Resizing the vectors in builder before setitem to ensure the "resize()" operation won't happen at the same time, to prevent data race in #1004.

Related issue number
--------------------

Fixes #1004

