### PR TITLE
Avoid print too much logs

### DIFF
--- a/src/server/async/ipc_server.cc
+++ b/src/server/async/ipc_server.cc
@@ -59,7 +59,7 @@ void IPCServer::Close() {
   boost::system::error_code ec;
   acceptor_.cancel(ec);
   if (ec) {
-    LOG(ERROR) << "Failed to close session : " << ec.message();
+    LOG(ERROR) << "Failed to close the IPC server: " << ec.message();
   }
 }
 

--- a/src/server/memory/gpu/gpuallocator.cc
+++ b/src/server/memory/gpu/gpuallocator.cc
@@ -48,8 +48,7 @@ void* GPUBulkAllocator::Memalign(const size_t bytes, const size_t alignment) {
 #ifdef ENABLE_GPU
   cudaError_t result = cudaMalloc(&mem, bytes);
   if (result != cudaSuccess) {
-    LOG(ERROR) << "cudaMalloc Error: " << cudaGetErrorString(result)
-               << std::endl;
+    DVLOG(10) << "cudaMalloc Error: " << cudaGetErrorString(result);
     return nullptr;
   }
   gpu_allocated_ += bytes;
@@ -61,7 +60,7 @@ void GPUBulkAllocator::Free(void* mem, size_t bytes) {
 #ifdef ENABLE_GPU
   cudaError_t result = cudaFree(mem);
   if (result != cudaSuccess) {
-    LOG(ERROR) << "cudaFree Error: " << cudaGetErrorString(result) << "\n";
+    DVLOG(10) << "cudaFree Error: " << cudaGetErrorString(result);
   }
   gpu_allocated_ -= bytes;
 #endif

--- a/src/server/memory/memory.cc
+++ b/src/server/memory/memory.cc
@@ -166,7 +166,7 @@ uint8_t* BulkStoreBase<ID, P>::AllocateMemoryGPU(size_t size) {
   pointer = reinterpret_cast<uint8_t*>(
       GPUBulkAllocator::Memalign(size, gpukBlockSize));
   if (pointer == nullptr) {
-    LOG(ERROR) << "Failed to allocate GPU memory......" << std::endl;
+    DVLOG(10) << "Failed to allocate GPU memory of size '" << size << "'";
   }
   return pointer;
 }

--- a/src/server/memory/usage.h
+++ b/src/server/memory/usage.h
@@ -261,7 +261,7 @@ class ColdObjectTracker
       while (it != list_.rend()) {
         st = bulk_store_ptr->SpillPayload(it->second);
         if (!st.ok()) {
-          LOG(ERROR) << st.ToString();
+          VLOG(100) << "Error: failed to spill payload: " << st.ToString();
           break;
         }
         spilled_sz += it->second->data_size;
@@ -462,7 +462,7 @@ class ColdObjectTracker
   void SetSpillPath(const std::string& spill_path) {
     spill_path_ = spill_path;
     if (spill_path.empty()) {
-      LOG(INFO) << "No spill path set, disable spill...";
+      LOG(INFO) << "No spill path set, spill has been disabled ...";
       return;
     }
     if (spill_path.back() != '/') {

--- a/src/server/server/vineyard_runner.cc
+++ b/src/server/server/vineyard_runner.cc
@@ -108,7 +108,7 @@ Status VineyardRunner::CreateNewSession(
       spec, session_id, shared_from_this(), context_, meta_context_,
       io_context_, callback);
   sessions_.emplace(session_id, vs_ptr);
-  LOG(INFO) << "Vineyard creates a new session with '"
+  LOG(INFO) << "Vineyard creates a new session with ID '"
             << SessionIDToString(session_id) << "'";
   return vs_ptr->Serve(bulk_store_type);
 }
@@ -121,7 +121,7 @@ Status VineyardRunner::Delete(SessionID const& sid) {
   accessor->second->Stop();
   sessions_.erase(accessor);
   if (unlikely(sid != RootSessionID())) {
-    LOG(INFO) << "Deleting session : " << SessionIDToString(sid);
+    LOG(INFO) << "Deleting session: '" << SessionIDToString(sid) << "'";
   }
   return Status::OK();
 }

--- a/src/server/server/vineyard_server.cc
+++ b/src/server/server/vineyard_server.cc
@@ -301,7 +301,7 @@ Status VineyardServer::GetData(const std::vector<ObjectID>& ids,
             return Status::OK();
           }
         } else {
-          LOG(ERROR) << status.ToString();
+          VLOG(100) << "Error: " << status.ToString();
           return status;
         }
       });
@@ -360,7 +360,7 @@ Status VineyardServer::ListData(std::string const& pattern, bool const regex,
           }
           return callback(status, sub_tree_group);
         } else {
-          LOG(ERROR) << status.ToString();
+          VLOG(100) << "Error: " << status.ToString();
           return callback(status, json{});
         }
       });
@@ -386,7 +386,7 @@ Status VineyardServer::ListAllData(
           }
           return callback(status, objects);
         } else {
-          LOG(ERROR) << status.ToString();
+          VLOG(100) << "Error: " << status.ToString();
           return callback(status, {});
         }
       });
@@ -443,7 +443,7 @@ Status VineyardServer::CreateData(
                                                     computed_instance_id));
           return s;
         } else {
-          LOG(ERROR) << status.ToString();
+          VLOG(100) << "Error: " << status.ToString();
           return status;
         }
       },
@@ -476,7 +476,7 @@ Status VineyardServer::Persist(const ObjectID id, callback_t<> callback) {
           }
           return s;
         } else {
-          LOG(ERROR) << status.ToString();
+          VLOG(100) << "Error: " << status.ToString();
           return status;
         }
       },
@@ -509,7 +509,7 @@ Status VineyardServer::IfPersist(const ObjectID id,
           CATCH_JSON_ERROR(s, meta_tree::IfPersist(meta, id, persist));
           return callback(s, persist);
         } else {
-          LOG(ERROR) << status.ToString();
+          VLOG(100) << "Error: " << status.ToString();
           return status;
         }
       });
@@ -533,7 +533,7 @@ Status VineyardServer::Exists(const ObjectID id,
           CATCH_JSON_ERROR(s, meta_tree::Exists(meta, id, exists));
           return callback(s, exists);
         } else {
-          LOG(ERROR) << status.ToString();
+          VLOG(100) << "Error: " << status.ToString();
           return status;
         }
       });
@@ -558,7 +558,7 @@ Status VineyardServer::ShallowCopy(const ObjectID id,
                                            ops, transient));
           return s;
         } else {
-          LOG(ERROR) << status.ToString();
+          VLOG(100) << "Error: " << status.ToString();
           return status;
         }
       },
@@ -610,7 +610,7 @@ Status VineyardServer::DelData(
           }
           return s;
         } else {
-          LOG(ERROR) << status.ToString();
+          VLOG(100) << "Error: " << status.ToString();
           return status;
         }
       },
@@ -635,8 +635,8 @@ Status VineyardServer::DeleteAllAt(const json& meta,
   return this->DelData(objects_to_cleanup, true, true, false /* fastpath */,
                        [](Status const& status) -> Status {
                          if (!status.ok()) {
-                           LOG(ERROR) << "Error happens on cleanup: "
-                                      << status.ToString();
+                           VLOG(100) << "Error: failed during cleanup: "
+                                     << status.ToString();
                          }
                          return Status::OK();
                        });
@@ -687,7 +687,7 @@ Status VineyardServer::PutName(const ObjectID object_id,
               meta_tree::EncodeValue(name)));
           return Status::OK();
         } else {
-          LOG(ERROR) << status.ToString();
+          VLOG(100) << "Error: " << status.ToString();
           return status;
         }
       },
@@ -728,7 +728,7 @@ Status VineyardServer::GetName(const std::string& name, const bool wait,
         return Status::OK();
       }
     } else {
-      LOG(ERROR) << status.ToString();
+      VLOG(100) << "Error: " << status.ToString();
       return status;
     }
   });
@@ -764,7 +764,7 @@ Status VineyardServer::DropName(const std::string& name,
           }
           return Status::OK();
         } else {
-          LOG(ERROR) << status.ToString();
+          VLOG(100) << "Error: " << status.ToString();
           return status;
         }
       },
@@ -779,7 +779,7 @@ Status VineyardServer::ClusterInfo(callback_t<const json&> callback) {
         if (status.ok()) {
           return callback(status, meta["instances"]);
         } else {
-          LOG(ERROR) << status.ToString();
+          VLOG(100) << "Error: " << status.ToString();
           return status;
         }
       });

--- a/src/server/services/meta_service.h
+++ b/src/server/services/meta_service.h
@@ -147,7 +147,8 @@ class IMetaService : public std::enable_shared_from_this<IMetaService> {
 #endif
         self->metaUpdate(ops, false);
       } else {
-        LOG(ERROR) << status.ToString();
+        VLOG(100) << "Error: failed to generated ops to update metadata: "
+                  << status.ToString();
       }
       VINEYARD_SUPPRESS(callback_after_finish(status, computed_instance_id));
     });
@@ -204,7 +205,8 @@ class IMetaService : public std::enable_shared_from_this<IMetaService> {
                 });
             return Status::OK();
           } else {
-            LOG(ERROR) << status.ToString();
+            VLOG(100) << "Error: failed to request metadata lock: "
+                      << status.ToString();
             return callback_after_finish(status);  // propogate the error
           }
         });
@@ -301,7 +303,8 @@ class IMetaService : public std::enable_shared_from_this<IMetaService> {
                   });
               return Status::OK();
             } else {
-              LOG(ERROR) << status.ToString();
+              VLOG(100) << "Error: failed to request metadata lock: "
+                        << status.ToString();
               return callback_after_finish(status, {});  // propogate the error.
             }
           });
@@ -340,11 +343,12 @@ class IMetaService : public std::enable_shared_from_this<IMetaService> {
             return Status::OK();
           }
         } else {
-          LOG(ERROR) << status.ToString();
+          VLOG(100) << "Error: failed to generated ops to update metadata: "
+                    << status.ToString();
           return callback_after_finish(status);
         }
       } else {
-        LOG(ERROR) << "request values failed: " << status.ToString();
+        VLOG(100) << "Error: request values failed: " << status.ToString();
         return callback_after_finish(status);
       }
     });


### PR DESCRIPTION


What do these changes do?
-------------------------

Print user errors, print log only when a high verbosity has been enabled.


Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1008

