### PR TITLE
Use the annotation to replace label for vineyard job

### DIFF
--- a/k8s/schedulers/scheduling.go
+++ b/k8s/schedulers/scheduling.go
@@ -299,7 +299,7 @@ func (vs *VineyardScheduling) Less(pod1, pod2 *framework.PodInfo) bool {
 func (vs *VineyardScheduling) Score(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) (int64, *framework.Status) {
 	klog.V(5).Infof("scoring for pod %v on node %v", GetNamespacedName(pod), nodeName)
 
-	job, replica, requires, vineyardd, err := vs.GetVineyardLabels(pod)
+	job, replica, requires, vineyardd, err := vs.GetJobInfo(pod)
 	if err != nil {
 		return 0, framework.NewStatus(framework.Unschedulable, err.Error())
 	}
@@ -434,7 +434,7 @@ func (vs *VineyardScheduling) GetAllWorkerNodes(vineyardd string) []string {
 
 // get all required jobs name that separated by '.'
 func (vs *VineyardScheduling) getRequiredJob(pod *v1.Pod) ([]string, error) {
-	objects, exists := pod.Labels[VineyardJobRequired]
+	objects, exists := pod.Annotations[VineyardJobRequired]
 	if !exists {
 		return []string{}, fmt.Errorf("Failed to get the required jobs, please set none if there is no required job")
 	}
@@ -446,8 +446,8 @@ func (vs *VineyardScheduling) getRequiredJob(pod *v1.Pod) ([]string, error) {
 	return strings.Split(objects, "."), nil
 }
 
-// GetVineyardLabels requires (job, replica, requires, vineyardd) information of a pod.
-func (vs *VineyardScheduling) GetVineyardLabels(pod *v1.Pod) (string, int64, []string, string, error) {
+// GetJobInfo requires (job, replica, requires, vineyardd) information of a pod.
+func (vs *VineyardScheduling) GetJobInfo(pod *v1.Pod) (string, int64, []string, string, error) {
 	job, err := vs.getJobName(pod)
 	if err != nil {
 		return "", 0, nil, "", err

--- a/k8s/test/e2e/serialize-demo.yaml
+++ b/k8s/test/e2e/serialize-demo.yaml
@@ -27,11 +27,12 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        scheduling.k8s.v6d.io/required: none
       labels:
         app: serialize-demo
         # this label represents the vineyardd's name that need to be used
         scheduling.k8s.v6d.io/vineyardd: vineyardd-sample
-        scheduling.k8s.v6d.io/required: none
         scheduling.k8s.v6d.io/job: serialize-demo
     spec:
       schedulerName: vineyard-scheduler

--- a/k8s/test/e2e/spill-demo.yaml
+++ b/k8s/test/e2e/spill-demo.yaml
@@ -27,11 +27,12 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        scheduling.k8s.v6d.io/required: none
       labels:
         app: spill-demo
         # this label represents the vineyardd's name that need to be used
         scheduling.k8s.v6d.io/vineyardd: vineyardd-sample
-        scheduling.k8s.v6d.io/required: none
         scheduling.k8s.v6d.io/job: spill-demo
     spec:
       schedulerName: vineyard-scheduler

--- a/k8s/test/e2e/workflow-job1.yaml
+++ b/k8s/test/e2e/workflow-job1.yaml
@@ -25,11 +25,12 @@ spec:
   replicas: 2
   template:
     metadata:
+      annotations:
+        scheduling.k8s.v6d.io/required: none
       labels:
         app: v6d-workflow-demo-job1
         # this label represents the vineyardd's name that need to be used
         scheduling.k8s.v6d.io/vineyardd: vineyardd-sample
-        scheduling.k8s.v6d.io/required: none
         scheduling.k8s.v6d.io/job: v6d-workflow-demo-job1
     spec:
       schedulerName: vineyard-scheduler

--- a/k8s/test/e2e/workflow-job2.yaml
+++ b/k8s/test/e2e/workflow-job2.yaml
@@ -25,11 +25,13 @@ spec:
   replicas: 3
   template:
     metadata:
+      annotations:
+        # The label is limited to 63 characters, so we need to use the annotation here
+        scheduling.k8s.v6d.io/required: v6d-workflow-demo-job1
       labels:
         app: v6d-workflow-demo-job2
         # this label represents the vineyardd's name that need to be used
         scheduling.k8s.v6d.io/vineyardd: vineyardd-sample
-        scheduling.k8s.v6d.io/required: v6d-workflow-demo-job1
         scheduling.k8s.v6d.io/job: v6d-workflow-demo-job2
     spec:
       schedulerName: vineyard-scheduler


### PR DESCRIPTION
What do these changes do?
-------------------------

Use annotation to replace the label for the required vineyard jobs as the jobs could be larger than 63 characters(the labels' max length).

