### PR TITLE
RPC server for sessions: share the same port and switch to child session when needed

### DIFF
--- a/src/client/rpc_client.h
+++ b/src/client/rpc_client.h
@@ -57,6 +57,17 @@ class RPCClient final : public ClientBase {
   Status Connect(const std::string& rpc_endpoint);
 
   /**
+   * @brief Connect to vineyardd using the given TCP endpoint `rpc_endpoint`.
+   *
+   * @param rpc_endpoint The TPC endpoint of vineyard server, in the format of
+   * `host:port`.
+   * @param session_id Connect to specified session.
+   *
+   * @return Status that indicates whether the connect has succeeded.
+   */
+  Status Connect(const std::string& rpc_endpoint, const SessionID session_id);
+
+  /**
    * @brief Connect to vineyardd using the given TCP `host` and `port`.
    *
    * @param host The host of vineyard server.
@@ -65,6 +76,18 @@ class RPCClient final : public ClientBase {
    * @return Status that indicates whether the connect has succeeded.
    */
   Status Connect(const std::string& host, uint32_t port);
+
+  /**
+   * @brief Connect to vineyardd using the given TCP `host` and `port`.
+   *
+   * @param host The host of vineyard server.
+   * @param port The TCP port of vineyard server's RPC service.
+   * @param session_id Connect to specified session.
+   *
+   * @return Status that indicates whether the connect has succeeded.
+   */
+  Status Connect(const std::string& host, uint32_t port,
+                 const SessionID session_id);
 
   /**
    * @brief Create a new client using self endpoint.

--- a/src/common/util/protocols.cc
+++ b/src/common/util/protocols.cc
@@ -159,21 +159,29 @@ void WriteErrorReply(Status const& status, std::string& msg) {
 }
 
 void WriteRegisterRequest(std::string& msg, StoreType const& store_type) {
+  WriteRegisterRequest(msg, store_type, RootSessionID());
+}
+
+void WriteRegisterRequest(std::string& msg, StoreType const& store_type,
+                          const ObjectID& session_id) {
   json root;
   root["type"] = "register_request";
   root["version"] = vineyard_version();
   root["store_type"] = store_type;
+  root["session_id"] = session_id;
 
   encode_msg(root, msg);
 }
 
 Status ReadRegisterRequest(const json& root, std::string& version,
-                           StoreType& store_type) {
+                           StoreType& store_type, SessionID& session_id) {
   RETURN_ON_ASSERT(root["type"] == "register_request");
 
   // When the "version" field is missing from the client, we treat it
   // as default unknown version number: 0.0.0.
-  version = root.value<std::string>("version", std::string("0.0.0"));
+  version =
+      root.value<std::string>("version", /* default */ std::string("0.0.0"));
+  session_id = root.value("session_id", /* default */ RootSessionID());
 
   // Keep backwards compatibility.
   if (root.contains("store_type")) {

--- a/src/common/util/protocols.h
+++ b/src/common/util/protocols.h
@@ -103,8 +103,11 @@ void WriteErrorReply(Status const& status, std::string& msg);
 
 void WriteRegisterRequest(std::string& msg, StoreType const& bulk_store_type);
 
+void WriteRegisterRequest(std::string& msg, StoreType const& bulk_store_type,
+                          const ObjectID& session_id);
+
 Status ReadRegisterRequest(const json& msg, std::string& version,
-                           StoreType& bulk_store_type);
+                           StoreType& bulk_store_type, SessionID& session_id);
 
 void WriteRegisterReply(const std::string& ipc_socket,
                         const std::string& rpc_endpoint,

--- a/src/server/async/ipc_server.cc
+++ b/src/server/async/ipc_server.cc
@@ -118,6 +118,11 @@ asio::local::stream_protocol::endpoint IPCServer::getEndpoint(
   return endpoint;
 }
 
+Status IPCServer::Register(std::shared_ptr<SocketConnection> conn,
+                           const SessionID session_id) {
+  return Status::OK();
+}
+
 void IPCServer::doAccept() {
   if (!acceptor_.is_open()) {
     return;

--- a/src/server/async/ipc_server.h
+++ b/src/server/async/ipc_server.h
@@ -47,6 +47,9 @@ class IPCServer : public SocketServer,
     return ipc_spec_["socket"].get_ref<std::string const&>();
   }
 
+  Status Register(std::shared_ptr<SocketConnection> conn,
+                  const SessionID session_id) override;
+
  private:
   asio::local::stream_protocol::endpoint getEndpoint(asio::io_context&);
 

--- a/src/server/async/rpc_server.cc
+++ b/src/server/async/rpc_server.cc
@@ -60,6 +60,20 @@ asio::ip::tcp::endpoint RPCServer::getEndpoint(asio::io_context&) {
   return asio::ip::tcp::endpoint(asio::ip::tcp::v4(), port);
 }
 
+Status RPCServer::Register(std::shared_ptr<SocketConnection> conn,
+                           const SessionID session_id) {
+  if (session_id == RootSessionID()) {
+    return Status::OK();
+  }
+  std::shared_ptr<VineyardServer> session;
+  auto status = this->vs_ptr_->GetRunner()->Get(session_id, session);
+  if (status.ok()) {
+    conn->switchSession(session);
+    return status;
+  }
+  return status;
+}
+
 void RPCServer::doAccept() {
   if (!acceptor_.is_open()) {
     return;

--- a/src/server/async/rpc_server.h
+++ b/src/server/async/rpc_server.h
@@ -44,6 +44,9 @@ class RPCServer : public SocketServer,
     return get_hostname() + ":" + json_to_string(rpc_spec_["port"]);
   }
 
+  Status Register(std::shared_ptr<SocketConnection> conn,
+                  const SessionID session_id) override;
+
  private:
   asio::ip::tcp::endpoint getEndpoint(asio::io_context&);
 

--- a/src/server/server/vineyard_server.cc
+++ b/src/server/server/vineyard_server.cc
@@ -94,8 +94,9 @@ Status VineyardServer::Serve(StoreType const& bulk_store_type) {
   // initializing the metadata service.
   ipc_server_ptr_ = std::make_shared<IPCServer>(shared_from_this());
   if (session_id_ == RootSessionID() && spec_["rpc_spec"]["rpc"].get<bool>()) {
-    // TODO: the rpc won't be enabled for child sessions as we are unsure
-    // about how to select the port.
+    // N.B: the rpc won't be enabled for child sessions. In the handler
+    // of "Register" request in RPC server the session will be set as the
+    // request session as expected.
     rpc_server_ptr_ = std::make_shared<RPCServer>(shared_from_this());
   }
 
@@ -109,7 +110,7 @@ Status VineyardServer::Serve(StoreType const& bulk_store_type) {
     plasma_bulk_store_ = std::make_shared<PlasmaBulkStore>();
     RETURN_ON_ERROR(plasma_bulk_store_->PreAllocate(memory_limit, allocator));
 
-    // TODO(mengke.mk): Currently we do not allow streamming in plasma
+    // TODO(mengke.mk): Currently we do not allow streaming in plasma
     // bulkstore, anyway, we can templatize stream store to solve this.
     stream_store_ = nullptr;
   } else if (bulk_store_type_ == StoreType::kDefault) {
@@ -399,8 +400,8 @@ Status VineyardServer::ListName(
     callback_t<const std::map<std::string, ObjectID>&> callback) {
   ENSURE_VINEYARDD_READY();
   meta_service_ptr_->RequestToGetData(
-      true, [this, pattern, regex, limit, callback](const Status& status,
-                                                    const json& meta) {
+      true, [pattern, regex, limit, callback](const Status& status,
+                                              const json& meta) {
         if (status.ok()) {
           std::map<std::string, ObjectID> names;
           Status s;


### PR DESCRIPTION

What do these changes do?
-------------------------

Resolves the leaving TODO in the RPC part when initializing a new session.

Related issue number
--------------------

N/A