### PR TITLE
Fix the error in Dockerfile.vineyard-python-dev

### DIFF
--- a/docker/Dockerfile.vineyard-python-dev
+++ b/docker/Dockerfile.vineyard-python-dev
@@ -22,8 +22,6 @@ RUN cd /work/v6d && \
     sed -i 's/Boost::regex//g' thirdparty/cpprestsdk/Release/cmake/cpprest_find_boost.cmake && \
     sed -i 's/regex//g' thirdparty/cpprestsdk/Release/cmake/cpprest_find_boost.cmake
 
-COPY thirdparty /work/v6d/thirdparty
-
 COPY cmake /work/v6d/cmake
 COPY python/vineyard/core/codegen /work/v6d/python/vineyard/core/codegen
 COPY python/vineyard/version.py.in /work/v6d/python/vineyard/version.py.in


### PR DESCRIPTION
What do these changes do?
-------------------------

When I run `make -C docker build-python-dev`, get the following error.

```shell
-- Found ZLIB: /usr/local/lib/libz.a (found version "1.2.12") 
CMake Error at /usr/local/lib/cmake/Boost-1.75.0/BoostConfig.cmake:141 (find_package):
  Could not find a package configuration file provided by "boost_regex"
  (requested version 1.75.0) with any of the following names:

    boost_regexConfig.cmake
    boost_regex-config.cmake

  Add the installation prefix of "boost_regex" to CMAKE_PREFIX_PATH or set
  "boost_regex_DIR" to a directory containing one of the above files.  If
  "boost_regex" provides a separate development package or SDK, be sure it
  has been installed.
Call Stack (most recent call first):
  /usr/local/lib/cmake/Boost-1.75.0/BoostConfig.cmake:258 (boost_find_component)
  /usr/share/cmake-3.19/Modules/FindBoost.cmake:460 (find_package)
  thirdparty/cpprestsdk/Release/cmake/cpprest_find_boost.cmake:49 (find_package)
  thirdparty/cpprestsdk/Release/src/CMakeLists.txt:129 (cpprest_find_boost)


-- Configuring incomplete, errors occurred!
See also "/work/v6d/build/CMakeFiles/CMakeOutput.log".
See also "/work/v6d/build/CMakeFiles/CMakeError.log".
```

It should be a mistake to add two commands `COPY thirdparty /work/v6d/thirdparty`.

