### PR TITLE
Move to ubuntu 20.04 and give up ubuntu 18.04 support

### DIFF
--- a/.github/workflows/build-compatibility.yml
+++ b/.github/workflows/build-compatibility.yml
@@ -25,10 +25,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-11]
+        os: [ubuntu-20.04, macos-11]
         arrow: [none, 1.0.1-1, 6.0.1-1, 9.0.0-1]
         exclude:
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             arrow: none
           - os: macos-11
             arrow: 1.0.1-1


### PR DESCRIPTION
What do these changes do?
-------------------------

as titled. The ubuntu 18.04 runner will be removed in the near future.

Related issue number
--------------------

N/A
