### PR TITLE
Add dask repartition operation to pluggable drivers.

### DIFF
--- a/.github/workflows/vineyard-operator.yaml
+++ b/.github/workflows/vineyard-operator.yaml
@@ -228,3 +228,25 @@ jobs:
         uses: apache/skywalking-infra-e2e@afdf1cca0519d65bc480d8680b7a27f9b41fc421 # always prefer to use a revision instead of `main`.
         with:
           e2e-file: k8s/test/e2e/assembly/distributed-assembly-e2e.yaml
+
+  dask-repartition-e2e-tests:
+    name: e2e tests(dask-repartition)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+        id: go
+      - name: Log in to GitHub Docker Registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: docker.pkg.github.com
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+      - name: Run E2E Test(distributed-assembly)
+        uses: apache/skywalking-infra-e2e@afdf1cca0519d65bc480d8680b7a27f9b41fc421 # always prefer to use a revision instead of `main`.
+        with:
+          e2e-file: k8s/test/e2e/repartition/dask-repartition-e2e.yaml

--- a/charts/vineyard-operator/templates/webhooks.yaml
+++ b/charts/vineyard-operator/templates/webhooks.yaml
@@ -31,7 +31,7 @@ webhooks:
   name: mpod.kb.io
   namespaceSelector:
     matchLabels:
-      assembly-injection: enabled
+      operation-injection: enabled
   rules:
   - apiGroups:
     - ""

--- a/k8s/config/rbac/role.yaml
+++ b/k8s/config/rbac/role.yaml
@@ -62,6 +62,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - pods/status
   verbs:
   - create

--- a/k8s/config/webhook/namespace_selector_patch.yaml
+++ b/k8s/config/webhook/namespace_selector_patch.yaml
@@ -11,4 +11,4 @@ webhooks:
   name: mpod.kb.io
   namespaceSelector:
     matchLabels:
-      assembly-injection: enabled
+      operation-injection: enabled

--- a/k8s/controllers/k8s/operation_controller.go
+++ b/k8s/controllers/k8s/operation_controller.go
@@ -53,6 +53,7 @@ type OperationReconciler struct {
 // +kubebuilder:rbac:groups=batch,resources=jobs/status,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="",resources=pods/status,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="",resources=pods/log,verbs=get
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile reconciles the operation
@@ -70,7 +71,7 @@ func (r *OperationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		CR:       &op,
 		GVK:      k8sv1alpha1.GroupVersion.WithKind("Operation"),
 		TmplFunc: map[string]interface{}{"getDistributedAssemblyConfig": operation.GetDistributedAssemblyConfig,
-			"getAssemblyConfig": operation.GetAssemblyConfig},
+			"getAssemblyConfig": operation.GetAssemblyConfig, "getDaskRepartitionConfig": operation.GetDaskRepartitionConfig},
 		Recorder: r.Recorder,
 	}
 

--- a/k8s/pkg/operation/assembly.go
+++ b/k8s/pkg/operation/assembly.go
@@ -222,7 +222,7 @@ func (ao *AssemblyOperation) checkLocalAssemblyJob(ctx context.Context, o *v1alp
 		}
 	}
 
-	if err := UpdateConfigmap(ao.Client, ctx, targetLocalObjects, o, AssemblyPrefix, &map[string]string{}); err != nil {
+	if err := UpdateConfigmap(ctx, ao.Client, targetLocalObjects, o, AssemblyPrefix, &map[string]string{}); err != nil {
 		return false, fmt.Errorf("failed to update the configmap: %v", err)
 	}
 
@@ -366,7 +366,7 @@ func (ao *AssemblyOperation) checkDistributedAssemblyJob(ctx context.Context, o 
 		}
 	}
 
-	if err := UpdateConfigmap(ao.Client, ctx, targetGlobalObjects, o, AssemblyPrefix, &map[string]string{}); err != nil {
+	if err := UpdateConfigmap(ctx, ao.Client, targetGlobalObjects, o, AssemblyPrefix, &map[string]string{}); err != nil {
 		return false, fmt.Errorf("failed to update the configmap: %v", err)
 	}
 
@@ -374,7 +374,7 @@ func (ao *AssemblyOperation) checkDistributedAssemblyJob(ctx context.Context, o 
 }
 
 // UpdateConfigmap will update the configmap when the assembly operation is done
-func UpdateConfigmap(k8sclient client.Client, ctx context.Context, target map[string]bool,
+func UpdateConfigmap(ctx context.Context, k8sclient client.Client, target map[string]bool,
 	o *v1alpha1.Operation, prefix string, data *map[string]string) error {
 	globalObjectList := &v1alpha1.GlobalObjectList{}
 

--- a/k8s/pkg/operation/interface.go
+++ b/k8s/pkg/operation/interface.go
@@ -35,6 +35,8 @@ func NewPluggableOperation(opname string, c client.Client, app *kubernetes.Appli
 	switch opname {
 	case "assembly":
 		return &AssemblyOperation{c, app, false}
+	case "repartition":
+		return &RepartitionOperation{c, app, false}
 	}
 	return nil
 }

--- a/k8s/pkg/operation/repartition.go
+++ b/k8s/pkg/operation/repartition.go
@@ -1,0 +1,327 @@
+/** Copyright 2020-2022 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package operation contains the operation logic
+package operation
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"unicode"
+
+	swckkube "github.com/apache/skywalking-swck/operator/pkg/kubernetes"
+	v1alpha1 "github.com/v6d-io/v6d/k8s/apis/k8s/v1alpha1"
+	"github.com/v6d-io/v6d/k8s/schedulers"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// RepartitionPrefix is the prefix of the assembly job
+	RepartitionPrefix = "repartition-"
+	// NeedInjecteRepartitionKey represents the pod need to be injected with the repartition job
+	NeedInjecteRepartitionKey = "need-injected-repartition"
+)
+
+// RepartitionOperation is the operation for the repartition
+type RepartitionOperation struct {
+	client.Client
+	app  *swckkube.Application
+	done bool
+}
+
+// DaskRepartitionConfig is the config for the dask repartition job
+type DaskRepartitionConfig struct {
+	Name             string
+	Namespace        string
+	GlobalobjectID   string
+	Replicas         string
+	InstanceToWorker string
+	DaskScheduler    string
+	JobName          string
+	TimeoutSeconds   int64
+	VineyardSockPath string
+}
+
+// TmpDaskRepartitionConfig is the template config for the dask repartition job
+var TmpDaskRepartitionConfig DaskRepartitionConfig
+
+// GetDaskRepartitionConfig gets the dask repartition config
+func GetDaskRepartitionConfig() DaskRepartitionConfig {
+	return TmpDaskRepartitionConfig
+}
+
+// CreateJob creates the job for the repartition
+func (ro *RepartitionOperation) CreateJob(ctx context.Context, o *v1alpha1.Operation) error {
+	switch o.Spec.Type {
+	case "dask":
+		if err := ro.applyDaskRepartitionJob(ctx, o); err != nil {
+			return fmt.Errorf("failed to apply dask repartition job: %w", err)
+		}
+		daskRepartitionDone, err := ro.checkDaskRepartitionJob(ctx, o)
+		if err != nil {
+			return fmt.Errorf("failed to check dask repartition job: %w", err)
+		}
+		ro.done = daskRepartitionDone
+	}
+	return nil
+}
+
+// buildDaskRepartitionJob builds the dask repartition job
+func (ro *RepartitionOperation) buildDaskRepartitionJob(ctx context.Context, globalObject *v1alpha1.GlobalObject,
+	pod *corev1.Pod, o *v1alpha1.Operation) error {
+	require := o.Spec.Require
+	podList := &corev1.PodList{}
+	podOpts := []client.ListOption{
+		client.MatchingLabels{
+			schedulers.VineyardJobName: require,
+		},
+	}
+
+	// get all instance's hostname
+	instanceToNode := make(map[int]string)
+	if err := ro.Client.List(ctx, podList, podOpts...); err != nil {
+		return fmt.Errorf("failed to list pods: %w", err)
+	}
+
+	localObjectList := &v1alpha1.LocalObjectList{}
+	if err := ro.Client.List(ctx, localObjectList); err != nil {
+		return fmt.Errorf("failed to list local objects: %w", err)
+	}
+
+	for _, lo := range localObjectList.Items {
+		instanceToNode[lo.Spec.InstanceID] = lo.Spec.Hostname
+	}
+	// get dask workers's hostname and their real name
+	daskHostnameToName := make(map[string]string)
+	// convert the selector to map
+	anno := pod.GetAnnotations()
+	daskWorkerSelector := anno[schedulers.DaskWorkerSelector]
+	allselectors := strings.Split(daskWorkerSelector, ",")
+	selector := map[string]string{}
+	for _, s := range allselectors {
+		str := strings.Split(s, ":")
+		selector[str[0]] = str[1]
+	}
+
+	daskWorkPodList := &corev1.PodList{}
+	daskWorkPodOpts := []client.ListOption{
+		client.MatchingLabels(selector),
+	}
+	if err := ro.Client.List(ctx, daskWorkPodList, daskWorkPodOpts...); err != nil {
+		return fmt.Errorf("failed to list dask workers: %w", err)
+	}
+
+	for i := range daskWorkPodList.Items {
+		workerName, err := ro.getWorkerNameFromPodLogs(&daskWorkPodList.Items[i])
+		if err != nil {
+			return fmt.Errorf("failed to get worker name from pod logs: %w", err)
+		}
+		daskHostnameToName[daskWorkPodList.Items[i].Spec.NodeName] = workerName
+	}
+
+	// build vineyard instance to dask worker name
+	instanceToWorker := "'{"
+	for instance, hostname := range instanceToNode {
+		workerName, ok := daskHostnameToName[hostname]
+		if ok {
+			instanceToWorker = instanceToWorker + `"` + strconv.Itoa(instance) + `"` + ":" + `"` + workerName + `"` + ","
+		}
+	}
+	instanceToWorker = instanceToWorker[:len(instanceToWorker)-1] + `}'`
+	for _, dp := range daskWorkPodList.Items {
+		daskHostnameToName[dp.Spec.NodeName] = dp.Status.PodIP
+	}
+
+	// get target replicas
+	target := o.Spec.Target
+	targetPodList := &corev1.PodList{}
+	targetPodOpts := []client.ListOption{
+		client.MatchingLabels{
+			schedulers.VineyardJobName: target,
+		},
+	}
+
+	if err := ro.Client.List(ctx, targetPodList, targetPodOpts...); err != nil {
+		return fmt.Errorf("failed to list target pods: %w", err)
+	}
+	replicas, ok := targetPodList.Items[0].Labels[schedulers.WorkloadReplicas]
+	if !ok {
+		return fmt.Errorf("failed to get replicas from target jobs")
+	}
+
+	TmpDaskRepartitionConfig.Replicas = "'" + replicas + "'"
+	TmpDaskRepartitionConfig.Name = RepartitionPrefix + globalObject.Name
+	TmpDaskRepartitionConfig.Namespace = pod.Namespace
+	TmpDaskRepartitionConfig.GlobalobjectID = globalObject.Name
+	TmpDaskRepartitionConfig.DaskScheduler = "'" + anno[schedulers.DaskScheduler] + "'"
+	TmpDaskRepartitionConfig.JobName = pod.Labels[schedulers.VineyardJobName]
+	TmpDaskRepartitionConfig.InstanceToWorker = instanceToWorker
+	TmpDaskRepartitionConfig.TimeoutSeconds = o.Spec.TimeoutSeconds
+
+	vineyardd, ok := pod.Labels[schedulers.VineyarddName]
+	if !ok {
+		return fmt.Errorf("failed to get vineyardd name from pod labels")
+	}
+	TmpDaskRepartitionConfig.VineyardSockPath = "/var/run/vineyard-" + globalObject.Namespace + "-" + vineyardd
+	return nil
+}
+
+// findNeedDaskRepartitionPodByGlobalObject finds the pod which needs the dask repartition from global objects
+func (ro *RepartitionOperation) findNeedDaskRepartitionPodByGlobalObject(ctx context.Context, labels *map[string]string) (*corev1.Pod, error) {
+	podName := (*labels)[PodNameLabelKey]
+	podNamespace := (*labels)[PodNameSpaceLabelKey]
+	if podName != "" && podNamespace != "" {
+		pod := &corev1.Pod{}
+		if err := ro.Client.Get(ctx, client.ObjectKey{Name: podName, Namespace: podNamespace}, pod); err != nil {
+			return nil, fmt.Errorf("failed to get the pod: %v", err)
+		}
+		if v, ok := pod.Labels[NeedInjecteRepartitionKey]; ok && strings.ToLower(v) == "true" {
+			return pod, nil
+		}
+	}
+	return nil, nil
+
+}
+
+// applyDaskRepartitionJob applies the dask repartition job
+func (ro *RepartitionOperation) applyDaskRepartitionJob(ctx context.Context, o *v1alpha1.Operation) error {
+	globalObjectList := &v1alpha1.GlobalObjectList{}
+
+	if err := ro.Client.List(ctx, globalObjectList); err != nil {
+		return fmt.Errorf("failed to list global objects: %w", err)
+	}
+
+	for i := range globalObjectList.Items {
+		pod, err := ro.findNeedDaskRepartitionPodByGlobalObject(ctx, &globalObjectList.Items[i].Labels)
+		if err != nil {
+			return fmt.Errorf("failed to find the pod which needs to be injected with the repartition job: %v", err)
+		}
+		if pod != nil {
+			if err := ro.buildDaskRepartitionJob(ctx, &globalObjectList.Items[i], pod, o); err != nil {
+				return fmt.Errorf("failed to build dask repartition job: %v", err)
+			}
+			if _, err := ro.app.Apply(ctx, "operation/dask-repartition.yaml", ctrl.Log, false); err != nil {
+				return fmt.Errorf("failed to apply the dask repartition job: %v", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// checkDaskRepartitionJob checks whether the dask repartition job is ready
+func (ro *RepartitionOperation) checkDaskRepartitionJob(ctx context.Context, o *v1alpha1.Operation) (bool, error) {
+	// get all required pod
+	require := o.Spec.Require
+	allRequiredPods := map[string]bool{}
+	podList := &corev1.PodList{}
+	podOpts := []client.ListOption{
+		client.MatchingLabels{
+			schedulers.VineyardJobName: require,
+		},
+	}
+
+	if err := ro.Client.List(ctx, podList, podOpts...); err != nil {
+		return false, fmt.Errorf("failed to list pods: %w", err)
+	}
+	for i := range podList.Items {
+		allRequiredPods[podList.Items[i].Name] = true
+	}
+
+	// get all globalobjects and check if the repartition job is done
+	globalObjectList := &v1alpha1.GlobalObjectList{}
+	if err := ro.Client.List(ctx, globalObjectList); err != nil {
+		return false, fmt.Errorf("failed to list global objects: %w", err)
+	}
+
+	targetGlobalObjects := map[string]bool{}
+	for i := range globalObjectList.Items {
+		labels := globalObjectList.Items[i].Labels
+		createdPod := labels[PodNameLabelKey]
+		if allRequiredPods[createdPod] {
+			job := &batchv1.Job{}
+			if err := ro.Client.Get(ctx, client.ObjectKey{Name: RepartitionPrefix + globalObjectList.Items[i].Name, Namespace: o.Namespace}, job); err != nil {
+				return false, fmt.Errorf("failed to get the repartition job: %v", err)
+			}
+			targetGlobalObjects[globalObjectList.Items[i].Spec.ObjectID] = true
+			// if the job failed, then the dask repartition job is failed
+			if job.Status.Succeeded == 0 {
+				return false, nil
+			}
+		}
+	}
+
+	data := map[string]string{}
+	data["InstanceToWorker"] = strings.Trim(TmpDaskRepartitionConfig.InstanceToWorker, "'")
+	if err := UpdateConfigmap(ro.Client, ctx, targetGlobalObjects, o, RepartitionPrefix, &data); err != nil {
+		return false, fmt.Errorf("failed to update the configmap: %v", err)
+	}
+	return true, nil
+}
+
+// getWorkerNameFromPodLogs get worker name from pod's logs
+func (ro *RepartitionOperation) getWorkerNameFromPodLogs(pod *corev1.Pod) (string, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return "", fmt.Errorf("failed to get in cluster config: %v", err)
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return "", fmt.Errorf("failed to get clientset: %v", err)
+	}
+	req := clientset.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{})
+	logs, err := req.Stream(context.Background())
+	if err != nil {
+		return "", fmt.Errorf("failed to open stream: %v", err)
+	}
+	defer logs.Close()
+
+	buf := new(bytes.Buffer)
+	_, err = io.Copy(buf, logs)
+	if err != nil {
+		return "", fmt.Errorf("failed to copy logs: %v", err)
+	}
+	log := buf.String()
+
+	// delete useless info
+	workerIndex := strings.Index(log, "Start worker at")
+	log = log[workerIndex:]
+
+	ipPrefix := "tcp://" + pod.Status.PodIP + ":"
+	start := strings.Index(log, ipPrefix)
+	end := start
+	for i := start + len(ipPrefix); i < len(log); i++ {
+		if !unicode.IsDigit(rune(log[i])) {
+			end = i
+			break
+		}
+	}
+
+	return log[start:end], nil
+}
+
+// IsDone checks whether the repartition operation is done
+func (ro *RepartitionOperation) IsDone() bool {
+	return ro.done
+}

--- a/k8s/pkg/operation/repartition.go
+++ b/k8s/pkg/operation/repartition.go
@@ -274,7 +274,7 @@ func (ro *RepartitionOperation) checkDaskRepartitionJob(ctx context.Context, o *
 
 	data := map[string]string{}
 	data["InstanceToWorker"] = strings.Trim(TmpDaskRepartitionConfig.InstanceToWorker, "'")
-	if err := UpdateConfigmap(ro.Client, ctx, targetGlobalObjects, o, RepartitionPrefix, &data); err != nil {
+	if err := UpdateConfigmap(ctx, ro.Client, targetGlobalObjects, o, RepartitionPrefix, &data); err != nil {
 		return false, fmt.Errorf("failed to update the configmap: %v", err)
 	}
 	return true, nil

--- a/k8s/schedulers/scheduling.go
+++ b/k8s/schedulers/scheduling.go
@@ -58,6 +58,12 @@ const (
 	VineyardSystemNamespace = "vineyard-system"
 	// VineyarddName is the name of the vineyardd
 	VineyarddName = "scheduling.k8s.v6d.io/vineyardd"
+	// DaskScheduler is the name of the dask scheduler
+	DaskScheduler = "scheduling.k8s.v6d.io/dask-scheduler"
+	// DaskWorkerSelector is the selector of the dask worker
+	DaskWorkerSelector = "scheduling.k8s.v6d.io/dask-worker-selector"
+	// WorkloadReplicas is the replicas of workload
+	WorkloadReplicas = "scheduling.k8s.v6d.io/replicas"
 )
 
 // VineyardScheduling is a plugin that schedules pods that requires vineyard objects as inputs.

--- a/k8s/templates/operation/dask-repartition.yaml
+++ b/k8s/templates/operation/dask-repartition.yaml
@@ -1,0 +1,57 @@
+# Copyright 2020-2022 Alibaba Group Holding Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+{{- $config := getDaskRepartitionConfig }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $config.Name }}
+  namespace: {{ $config.Namespace }}
+spec:
+  activeDeadlineSeconds: {{ $config.TimeoutSeconds }}
+  template:
+    spec:
+      containers:
+      - name: dask-repartition-operation
+        image: ghcr.io/v6d-io/v6d/dask-repartition
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: GLOBALOBJECT_ID
+          value: {{ $config.GlobalobjectID  }}
+        - name: Replicas
+          value: {{ $config.Replicas  }}
+        - name: InstanceToWorker
+          value: {{ $config.InstanceToWorker  }}
+        - name: DASK_SCHEDULER
+          value: {{ $config.DaskScheduler }}
+        - name: JOB_NAME
+          value: {{ $config.JobName }}
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        volumeMounts:
+        - mountPath: /var/run
+          name: vineyard-sock
+      volumes:
+      - name: vineyard-sock
+        hostPath:
+          # The path should be changed to the path provided by users.
+          path: {{ $config.VineyardSockPath }}
+      restartPolicy: Never

--- a/k8s/test/e2e/assembly/distributed-assembly-e2e.yaml
+++ b/k8s/test/e2e/assembly/distributed-assembly-e2e.yaml
@@ -47,7 +47,7 @@ setup:
     - name: install job1 and job2
       command: |
         kubectl create namespace vineyard-job
-        kubectl label namespace vineyard-job assembly-injection=enabled
+        kubectl label namespace vineyard-job operation-injection=enabled
         sed 's/$job/distributedJob1/' k8s/test/e2e/assembly-job.yaml | gomplate -d config=k8s/test/e2e/assembly-job-config.yaml | kubectl apply -f -
         kubectl wait --for=condition=Ready pod -l app=distributed-assembly-job1 -n vineyard-job --timeout=5m
         while [ -z $(kubectl get po -l app=distributed-assembly-job1 -n vineyard-job -oname | awk -F '/' '{print $2}' | xargs kubectl logs -n vineyard-job) ]; \

--- a/k8s/test/e2e/repartition/dask-repartition-e2e.yaml
+++ b/k8s/test/e2e/repartition/dask-repartition-e2e.yaml
@@ -13,13 +13,30 @@
 # limitations under the License.
 #
 
-# Test assembly operation in the same node
 setup:
   env: kind
   file: ../kind.yaml
   steps:
     - name: prepare e2e.yaml
       command: bash k8s/test/hack/prepare-e2e.sh
+    - name: load docker image
+      command: |
+        docker pull ghcr.io/v6d-io/v6d/dask-worker-with-vineyard
+        docker pull ghcr.io/dask/dask:2022.8.1
+        kind load docker-image ghcr.io/v6d-io/v6d/dask-worker-with-vineyard
+        kind load docker-image ghcr.io/dask/dask:2022.8.1
+    - name: install dask-scheduler and dask-worker
+      command: |
+        helm repo add dask https://helm.dask.org/
+        helm repo update
+        helm install my-release dask/dask -f k8s/test/e2e/repartition/repartition-dask-helm-values.yaml
+      wait:
+        - namespace: default
+          resource: deployment/my-release-dask-scheduler
+          for: condition=Available
+        - namespace: default
+          resource: deployment/my-release-dask-worker
+          for: condition=Available
     - name: install cert-manager
       command: |
         kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.9.1/cert-manager.yaml
@@ -39,7 +56,7 @@ setup:
           for: condition=Available
     - name: install vineyardd
       command: |
-        kubectl apply -f k8s/test/e2e/vineyardd.yaml
+        sed 's/replicas: 2/replicas: 3/' k8s/test/e2e/vineyardd.yaml | kubectl apply -f -
       wait:
         - namespace: vineyard-system
           resource: vineyardd/vineyardd-sample
@@ -48,17 +65,17 @@ setup:
       command: |
         kubectl create namespace vineyard-job
         kubectl label namespace vineyard-job operation-injection=enabled
-        sed 's/$job/job1/' k8s/test/e2e/assembly-job.yaml | gomplate -d config=k8s/test/e2e/assembly-job-config.yaml | kubectl apply -f -
+        sed 's/$job/daskRepartitionJob1/' k8s/test/e2e/repartition/repartition-job.yaml | gomplate -d config=k8s/test/e2e/repartition/repartition-job-config.yaml | kubectl apply -f -
       wait:
         - namespace: vineyard-job
-          resource: deployment/assembly-job1
+          resource: deployment/dask-repartition-job1
           for: condition=Available
     - name: install job2
       command: |
-        sed 's/$job/job2/' k8s/test/e2e/assembly-job.yaml | gomplate -d config=k8s/test/e2e/assembly-job-config.yaml | kubectl apply -f -
+        sed 's/$job/daskRepartitionJob2/' k8s/test/e2e/repartition/repartition-job.yaml | gomplate -d config=k8s/test/e2e/repartition/repartition-job-config.yaml | kubectl apply -f -
       wait:
         - namespace: vineyard-job
-          resource: deployment/assembly-job2
+          resource: deployment/dask-repartition-job2
           for: condition=Available
   timeout: 50m
 
@@ -74,5 +91,7 @@ verify:
     # the interval between two attempts, e.g. 10s, 1m.
     interval: 10s
   cases:
-    - query: 'kubectl get po -l app=assembly-job2 -n vineyard-job -oname | awk -F ''/'' ''{print $2}'' | head -n 1 | xargs kubectl logs -n vineyard-job | yq e ''{"sum": .}'' - | yq e ''to_entries'' -'
-      expected: ../verify/local-assembly-values.yaml
+    - query: |
+        kubectl get po -l app=dask-repartition-job2 -n vineyard-job -o name | awk -F '/' '{print $2}' |  \
+        xargs kubectl logs -n vineyard-job | head -n 1 | yq e '{"partition": .}' - | yq e 'to_entries' -
+      expected: ../verify/partition.yaml

--- a/k8s/test/e2e/repartition/dask-repartition-operation/Dockerfile.repartition
+++ b/k8s/test/e2e/repartition/dask-repartition-operation/Dockerfile.repartition
@@ -1,0 +1,25 @@
+# Copyright 2020-2022 Alibaba Group Holding Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM  docker.pkg.github.com/v6d-io/v6d/vineyard-python-dev:latest
+
+WORKDIR /
+
+COPY ./dask-repartition.py /
+
+RUN pip3 install --no-cache-dir dask
+
+ENTRYPOINT [ "python3" ]
+
+CMD [ "dask-repartition.py" ]

--- a/k8s/test/e2e/repartition/dask-repartition-operation/Makefile
+++ b/k8s/test/e2e/repartition/dask-repartition-operation/Makefile
@@ -1,0 +1,27 @@
+# Copyright 2020-2022 Alibaba Group Holding Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+REGISTRY := docker.pkg.github.com/v6d-io/v6d
+TAG      := latest
+
+all: build-dask-repartition
+
+build-dask-repartition:
+	docker build . -f Dockerfile.repartition -t $(REGISTRY)/dask-repartition:$(TAG)
+.PHONY: build-dask-repartition
+
+docker-push: build-dask-repartition
+	docker push $(REGISTRY)/repartition:$(TAG)
+.PHONY: docker-push

--- a/k8s/test/e2e/repartition/dask-repartition-operation/dask-repartition.py
+++ b/k8s/test/e2e/repartition/dask-repartition-operation/dask-repartition.py
@@ -1,0 +1,60 @@
+#! /usr/bin/env python3 # pylint: disable=missing-module-docstring
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020-2022 Alibaba Group Holding Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import contextlib
+import json
+import os
+
+import vineyard
+from vineyard.contrib.dask.dask import register_dask_types
+from vineyard.core.builder import builder_context
+from vineyard.core.resolver import resolver_context
+
+
+@contextlib.contextmanager
+def vineyard_for_dask():
+    with builder_context() as builder:
+        with resolver_context() as resolver:
+            register_dask_types(builder, resolver)
+            yield builder, resolver
+
+
+env_dist = os.environ
+
+replicas = env_dist['Replicas']
+gid = env_dist['GLOBALOBJECT_ID']
+# map from vineyard instances to dask workers
+allstr = env_dist['InstanceToWorker']
+
+dist = json.loads(allstr)
+
+dask_workers = {}
+for key, value in dist.items():
+    dask_workers[int(key)] = value
+
+dask_scheduler = env_dist['DASK_SCHEDULER']
+
+client = vineyard.connect('/var/run/vineyard.sock')
+with vineyard_for_dask():
+    print('start to get ddf', flush=True)
+    data = client.get(vineyard._C.ObjectID(gid),
+                      dask_scheduler=dask_scheduler, dask_workers=dask_workers)
+    print('get data done', flush=True)
+    new_df = data.repartition(npartitions=int(replicas))
+    print('repartition done', flush=True)
+    obj_id = client.put(new_df, dask_scheduler=dask_scheduler)

--- a/k8s/test/e2e/repartition/repartition-dask-helm-values.yaml
+++ b/k8s/test/e2e/repartition/repartition-dask-helm-values.yaml
@@ -1,0 +1,36 @@
+# Copyright 2020-2022 Alibaba Group Holding Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+scheduler.image.tag: "2022.8.1"
+
+worker:
+  # worker numbers
+  replicas: 3
+  image:
+    repository: ghcr.io/v6d-io/v6d/dask-worker-with-vineyard
+    tag: latest
+  env:
+    - name: VINEYARD_IPC_SOCKET
+      value: /var/run/vineyard.sock
+    - name: VINEYARD_RPC_SOCKET
+      value: vineyardd-sample-rpc.vineyard-system:9600
+  mounts:
+    volumes:
+      - name: vineyard-sock
+        hostPath:
+          path: /var/run/vineyard-vineyard-system-vineyardd-sample
+    volumeMounts:
+      - mountPath: /var/run
+        name: vineyard-sock

--- a/k8s/test/e2e/repartition/repartition-dask-helm-values.yaml
+++ b/k8s/test/e2e/repartition/repartition-dask-helm-values.yaml
@@ -13,7 +13,12 @@
 # limitations under the License.
 #
 
-scheduler.image.tag: "2022.8.1"
+scheduler:
+  image:
+    tag: "2022.8.1"
+
+jupyter:
+  enabled: false
 
 worker:
   # worker numbers

--- a/k8s/test/e2e/repartition/repartition-demo/Dockerfile.dask-worker-with-vineyard
+++ b/k8s/test/e2e/repartition/repartition-demo/Dockerfile.dask-worker-with-vineyard
@@ -1,0 +1,3 @@
+FROM ghcr.io/dask/dask:2022.8.1
+
+RUN pip3 install --no-cache-dir vineyard

--- a/k8s/test/e2e/repartition/repartition-demo/Dockerfile.job1
+++ b/k8s/test/e2e/repartition/repartition-demo/Dockerfile.job1
@@ -1,0 +1,25 @@
+# Copyright 2020-2022 Alibaba Group Holding Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM docker.pkg.github.com/v6d-io/v6d/vineyard-python-dev:latest
+
+WORKDIR /
+
+COPY ./job1.py /
+
+RUN pip3 install --no-cache-dir dask==2022.8.1
+
+ENTRYPOINT [ "python3" ]
+
+CMD [ "job1.py" ]

--- a/k8s/test/e2e/repartition/repartition-demo/Dockerfile.job2
+++ b/k8s/test/e2e/repartition/repartition-demo/Dockerfile.job2
@@ -1,0 +1,25 @@
+# Copyright 2020-2022 Alibaba Group Holding Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM docker.pkg.github.com/v6d-io/v6d/vineyard-python-dev:latest
+
+WORKDIR /
+
+COPY ./job2.py /
+
+RUN pip3 install --no-cache-dir lz4
+
+ENTRYPOINT [ "python3" ]
+
+CMD [ "job2.py" ]

--- a/k8s/test/e2e/repartition/repartition-demo/Makefile
+++ b/k8s/test/e2e/repartition/repartition-demo/Makefile
@@ -1,0 +1,36 @@
+# Copyright 2020-2022 Alibaba Group Holding Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+REGISTRY := docker.pkg.github.com/v6d-io/v6d
+TAG      := latest
+
+all: build-dask-repartition-job1 build-dask-repartition-job2 build-dask-worker-with-vineyard
+	
+build-dask-repartition-job1:
+	docker build . -f Dockerfile.job1 -t $(REGISTRY)/dask-repartition-job1:$(TAG)
+.PHONY: build-dask-repartition-job1
+
+build-dask-repartition-job2:
+	docker build . -f Dockerfile.job2 -t $(REGISTRY)/dask-repartition-job2:$(TAG)
+.PHONY: build-dask-repartition-job2
+
+build-dask-worker-with-vineyard:
+	docker build . -f Dockerfile.dask-worker-with-vineyard -t $(REGISTRY)/dask-worker-with-vineyard:$(TAG)
+
+docker-push: build-dask-repartition-job1 build-dask-repartition-job2 build-dask-worker-with-vineyard
+	docker push $(REGISTRY)/dask-repartition-job1:$(TAG)
+	docker push $(REGISTRY)/dask-repartition-job2:$(TAG)
+	docker push $(REGISTRY)/dask-worker-with-vineyard:$(TAG)
+.PHONY: docker-push

--- a/k8s/test/e2e/repartition/repartition-demo/job1.py
+++ b/k8s/test/e2e/repartition/repartition-demo/job1.py
@@ -1,4 +1,5 @@
-#! /usr/bin/env python3 # pylint: disable=missing-module-docstring
+# pylint: disable=django-not-configured
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # Copyright 2020-2022 Alibaba Group Holding Limited.

--- a/k8s/test/e2e/repartition/repartition-demo/job1.py
+++ b/k8s/test/e2e/repartition/repartition-demo/job1.py
@@ -1,0 +1,50 @@
+#! /usr/bin/env python3 # pylint: disable=missing-module-docstring
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020-2022 Alibaba Group Holding Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import contextlib
+import time
+import os
+
+import dask.array as da
+import dask.dataframe as dd
+
+import vineyard
+from vineyard.contrib.dask.dask import register_dask_types
+from vineyard.core.builder import builder_context
+from vineyard.core.resolver import resolver_context
+
+
+@contextlib.contextmanager
+def vineyard_for_dask():
+    with builder_context() as builder:
+        with resolver_context() as resolver:
+            register_dask_types(builder, resolver)
+            yield builder, resolver
+
+
+env_dist = os.environ
+dask_scheduler = env_dist['DASK_SCHEDULER']
+client = vineyard.connect('/var/run/vineyard.sock')
+
+with vineyard_for_dask():
+    arr = da.ones((1024, 2), chunks=(256, 2))
+    df = dd.from_dask_array(arr, columns=['a', 'b'])
+    obj_id = client.put(df, dask_scheduler=dask_scheduler)
+
+# avoid CrashLoopBackOff
+time.sleep(600)

--- a/k8s/test/e2e/repartition/repartition-demo/job2.py
+++ b/k8s/test/e2e/repartition/repartition-demo/job2.py
@@ -1,0 +1,60 @@
+#! /usr/bin/env python3 # pylint: disable=missing-module-docstring
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020-2022 Alibaba Group Holding Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import json
+import contextlib
+import time
+
+import vineyard
+from vineyard.contrib.dask.dask import register_dask_types
+from vineyard.core.builder import builder_context
+from vineyard.core.resolver import resolver_context
+
+
+@contextlib.contextmanager
+def vineyard_for_dask():
+    with builder_context() as builder:
+        with resolver_context() as resolver:
+            register_dask_types(builder, resolver)
+            yield builder, resolver
+
+
+client = vineyard.connect('/var/run/vineyard.sock')
+env_dist = os.environ
+
+job = env_dist['REQUIRED_JOB_NAME']
+gid = env_dist.get(job)
+# map from vineyard instances to dask workers
+allstr = env_dist['InstanceToWorker']
+
+dist = json.loads(allstr)
+
+dask_workers = {}
+for key, value in dist.items():
+    dask_workers[int(key)] = value
+
+dask_scheduler = env_dist['DASK_SCHEDULER']
+with vineyard_for_dask():
+    ddf = client.get(vineyard._C.ObjectID(gid),
+                     dask_scheduler=dask_scheduler, dask_workers=dask_workers)
+    partitions = ddf.npartitions
+    print(partitions, flush=True)
+
+# avoid CrashLoopBackOff
+time.sleep(600)

--- a/k8s/test/e2e/repartition/repartition-job-config.yaml
+++ b/k8s/test/e2e/repartition/repartition-job-config.yaml
@@ -1,0 +1,42 @@
+# Copyright 2020-2022 Alibaba Group Holding Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+daskRepartitionJob1:
+  jobName: dask-repartition-job1
+  replicas: "1"
+  repartition:
+    enabled: ""
+    type: "dask"
+    dask:
+      daskScheduler: "tcp://my-release-dask-scheduler.default:8786"
+      daskWorkerSelector: "app:dask,component:worker"
+  required:
+    jobName: none
+    dataName: ""
+  schedulerName: "vineyard-scheduler"
+
+daskRepartitionJob2:
+  jobName: dask-repartition-job2
+  replicas: "1"
+  repartition:
+    enabled: "true"
+    type: "dask"
+    dask:
+      daskScheduler: "tcp://my-release-dask-scheduler.default:8786"
+      daskWorkerSelector: "app:dask,component:worker"
+  required:
+    jobName: dask-repartition-job1
+    dataName: dask-repartition-job1
+  schedulerName: vineyard-scheduler

--- a/k8s/test/e2e/repartition/repartition-job.yaml
+++ b/k8s/test/e2e/repartition/repartition-job.yaml
@@ -1,0 +1,78 @@
+# Copyright 2020-2022 Alibaba Group Holding Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# replace the $job with your job name
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ (datasource "config").$job.jobName }}
+  namespace: vineyard-job
+spec:
+  selector:
+    matchLabels:
+      app: {{ (datasource "config").$job.jobName }}
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        scheduling.k8s.v6d.io/required: "{{ (datasource "config").$job.required.jobName }}"
+        {{- if (datasource "config").$job.repartition.dask.daskScheduler }}
+        scheduling.k8s.v6d.io/dask-scheduler: "{{ (datasource "config").$job.repartition.dask.daskScheduler }}"
+        {{- end }}
+        {{- if (datasource "config").$job.repartition.dask.daskWorkerSelector }}
+        # use ',' to separate the different labels here
+        scheduling.k8s.v6d.io/dask-worker-selector: "{{ (datasource "config").$job.repartition.dask.daskWorkerSelector }}"
+        {{- end }}
+      labels:
+        app: {{ (datasource "config").$job.jobName }}
+        {{- if (datasource "config").$job.repartition.enabled }}
+        repartition.v6d.io/enabled: "{{ (datasource "config").$job.repartition.enabled }}"
+        {{- end }}
+        {{- if (datasource "config").$job.repartition.type }}
+        repartition.v6d.io/type: "{{ (datasource "config").$job.repartition.type }}"
+        {{- end }}
+        scheduling.k8s.v6d.io/replicas: "{{ (datasource "config").$job.replicas }}"
+        # this label represents the vineyardd's name that need to be used
+        scheduling.k8s.v6d.io/vineyardd: vineyardd-sample
+        scheduling.k8s.v6d.io/job: {{ (datasource "config").$job.jobName }}
+    spec:
+      schedulerName: vineyard-scheduler
+      containers:
+      - name: {{ (datasource "config").$job.jobName }}
+        image: ghcr.io/v6d-io/v6d/{{ (datasource "config").$job.jobName }}
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: JOB_NAME
+          value: {{ (datasource "config").$job.jobName }}
+        {{- if (datasource "config").$job.repartition.dask.daskScheduler }}
+        - name: DASK_SCHEDULER
+          value: {{ (datasource "config").$job.repartition.dask.daskScheduler }}
+        {{- end }}
+        {{- if (datasource "config").$job.required.dataName }}
+        - name: REQUIRED_JOB_NAME
+          value: {{ (datasource "config").$job.required.dataName }}
+        {{- end }}
+        {{- if (datasource "config").$job.required.dataName }}
+        envFrom:
+        - configMapRef:
+            name: {{ (datasource "config").$job.required.dataName }}
+        {{- end }}
+        volumeMounts:
+        - mountPath: /var/run
+          name: vineyard-sock
+      volumes:
+      - name: vineyard-sock
+        hostPath:
+          path: /var/run/vineyard-vineyard-system-vineyardd-sample

--- a/k8s/test/e2e/verify/partition.yaml
+++ b/k8s/test/e2e/verify/partition.yaml
@@ -1,0 +1,19 @@
+# Copyright 2020-2022 Alibaba Group Holding Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+{{- contains . }}
+- key: partition
+  value: 1
+{{- end }}


### PR DESCRIPTION
The pr mainly do the following things:
* Add dask repartition operation logic.
* Add End-to-End repartition demo based on dask.
* Update webhook NamespaceSelector from `assembly-injection` to `operation-injection`.


