### PR TITLE
Source more rf-files and use bash -lc when starting IO drivers

### DIFF
--- a/modules/io/python/drivers/io/kube_ssh.sh
+++ b/modules/io/python/drivers/io/kube_ssh.sh
@@ -7,13 +7,21 @@ if [[ "$POD_NAME" =~ ":" ]]; then
     KUBE_NS=${POD_NAME%%:*}
     KUBE_POD_NAME=${POD_NAME#*:}
 
-    kubectl -n ${KUBE_NS} exec ${KUBE_POD_NAME} -c engine -- /bin/bash -c "cat /etc/hosts > /dev/null || true && \
-                                                                           source ~/.bashrc || true && \
-                                                                           shopt -s huponexit 2>/dev/null || true && \
-                                                                           $*"
+    kubectl -n ${KUBE_NS} exec ${KUBE_POD_NAME} -c engine -- /bin/bash -lc "
+        cat /etc/hosts > /dev/null || true && \
+        source /etc/profile || true && \
+        source /etc/bash.bashrc || true && \
+        source ~/.profile || true && \
+        source ~/.bashrc || true && \
+        shopt -s huponexit 2>/dev/null || true && \
+        $*"
 else
-    kubectl exec ${POD_NAME} -c engine -- /bin/bash -c "cat /etc/hosts > /dev/null || true && \
-                                                        source ~/.bashrc || true && \
-                                                        shopt -s huponexit 2>/dev/null || true && \
-                                                        $*"
+    kubectl exec ${POD_NAME} -c engine -- /bin/bash -lc "
+        cat /etc/hosts > /dev/null || true && \
+        source /etc/profile || true && \
+        source /etc/bash.bashrc || true && \
+        source ~/.profile || true && \
+        source ~/.bashrc || true && \
+        shopt -s huponexit 2>/dev/null || true && \
+        $*"
 fi

--- a/modules/io/python/drivers/io/ssh.sh
+++ b/modules/io/python/drivers/io/ssh.sh
@@ -8,10 +8,13 @@ then
     shopt -s huponexit 2>/dev/null || true;
     bash -c "$*"
 else
-    ssh ${HOST_NAME} -- "/bin/bash -c 'cat /etc/hosts > /dev/null || true && \
-                                       source /etc/bash.bashrc || true && \
-                                       source ~/.bashrc || true && \
-                                       source ~/.bash_profile || true && \
-                                       shopt -s huponexit 2>/dev/null || true && \
-                                       $*'"
+    ssh ${HOST_NAME} -- "/bin/bash -lc '\
+        cat /etc/hosts > /dev/null || true && \
+        source /etc/profile || true && \
+        source /etc/bash.bashrc || true && \
+        source ~/.profile || true && \
+        source ~/.bashrc || true && \
+        source ~/.bash_profile || true && \
+        shopt -s huponexit 2>/dev/null || true && \
+        $*'"
 fi


### PR DESCRIPTION
What do these changes do?
-------------------------

Use `bash -lc` to load rc files.

Related issue number
--------------------

N/A

