### PR TITLE
Delete the Name field in globalobject and localobject's API

### DIFF
--- a/charts/vineyard-operator/templates/crds.yaml
+++ b/charts/vineyard-operator/templates/crds.yaml
@@ -47,9 +47,6 @@ spec:
     - jsonPath: .spec.id
       name: Id
       type: string
-    - jsonPath: .spec.name
-      name: Name
-      type: string
     - jsonPath: .spec.signature
       name: Signature
       type: string
@@ -75,8 +72,6 @@ spec:
                   type: string
                 type: array
               metadata:
-                type: string
-              name:
                 type: string
               signature:
                 type: string
@@ -134,9 +129,6 @@ spec:
     - jsonPath: .spec.id
       name: Id
       type: string
-    - jsonPath: .spec.name
-      name: Name
-      type: string
     - jsonPath: .spec.signature
       name: Signature
       type: string
@@ -169,8 +161,6 @@ spec:
                 type: integer
               metadata:
                 type: string
-              name:
-                type: string
               signature:
                 type: string
               typename:
@@ -182,10 +172,11 @@ spec:
             type: object
           status:
             properties:
+              createdTime:
+                format: date-time
+                type: string
               state:
                 type: string
-            required:
-            - state
             type: object
         type: object
     served: true

--- a/k8s/apis/k8s/v1alpha1/globalobject_types.go
+++ b/k8s/apis/k8s/v1alpha1/globalobject_types.go
@@ -24,8 +24,6 @@ type GlobalObjectSpec struct {
 	// +kubebuilder:validation:Required
 	ObjectID string `json:"id"`
 	// +kubebuilder:validation:Required
-	Name string `json:"name,omitempty"`
-	// +kubebuilder:validation:Required
 	Signature string `json:"signature"`
 	// +kubebuilder:validation:Required
 	Typename string `json:"typename,omitempty"`
@@ -49,7 +47,6 @@ type GlobalObjectStatus struct {
 // +kubebuilder:resource:categories=all,shortName=gobject
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Id",type=string,JSONPath=`.spec.id`
-// +kubebuilder:printcolumn:name="Name",type=string,JSONPath=`.spec.name`
 // +kubebuilder:printcolumn:name="Signature",type=string,JSONPath=`.spec.signature`
 // +kubebuilder:printcolumn:name="Typename",type=string,JSONPath=`.spec.typename`
 // +genclient

--- a/k8s/apis/k8s/v1alpha1/localobject_types.go
+++ b/k8s/apis/k8s/v1alpha1/localobject_types.go
@@ -24,8 +24,6 @@ type LocalObjectSpec struct {
 	// +kubebuilder:validation:Required
 	ObjectID string `json:"id"`
 	// +kubebuilder:validation:Required
-	Name string `json:"name,omitempty"`
-	// +kubebuilder:validation:Required
 	Signature string `json:"signature"`
 	// +kubebuilder:validation:Optional
 	Typename string `json:"typename,omitempty"`
@@ -51,7 +49,6 @@ type LocalObjectStatus struct {
 // +kubebuilder:resource:categories=all,shortName=lobject
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Id",type=string,JSONPath=`.spec.id`
-// +kubebuilder:printcolumn:name="Name",type=string,JSONPath=`.spec.name`
 // +kubebuilder:printcolumn:name="Signature",type=string,JSONPath=`.spec.signature`
 // +kubebuilder:printcolumn:name="Typename",type=string,JSONPath=`.spec.typename`
 // +kubebuilder:printcolumn:name="Instance",type=integer,JSONPath=`.spec.instance_id`

--- a/k8s/config/crd/bases/k8s.v6d.io_globalobjects.yaml
+++ b/k8s/config/crd/bases/k8s.v6d.io_globalobjects.yaml
@@ -23,9 +23,6 @@ spec:
     - jsonPath: .spec.id
       name: Id
       type: string
-    - jsonPath: .spec.name
-      name: Name
-      type: string
     - jsonPath: .spec.signature
       name: Signature
       type: string
@@ -51,8 +48,6 @@ spec:
                   type: string
                 type: array
               metadata:
-                type: string
-              name:
                 type: string
               signature:
                 type: string

--- a/k8s/config/crd/bases/k8s.v6d.io_localobjects.yaml
+++ b/k8s/config/crd/bases/k8s.v6d.io_localobjects.yaml
@@ -23,9 +23,6 @@ spec:
     - jsonPath: .spec.id
       name: Id
       type: string
-    - jsonPath: .spec.name
-      name: Name
-      type: string
     - jsonPath: .spec.signature
       name: Signature
       type: string
@@ -57,8 +54,6 @@ spec:
               instance_id:
                 type: integer
               metadata:
-                type: string
-              name:
                 type: string
               signature:
                 type: string


### PR DESCRIPTION
Delete the Name field as we never use them. E.g.

```shell
kubectl get globalobjects -n vineyard-system
NAME                ID                  NAME   SIGNATURE           TYPENAME
o001c87014cf03c70   o001c87014cf03c70          s001c87014cf03262   vineyard::Sequence
```

```shell
 kubectl get localobjects -n vineyard-system 
NAME                ID                  NAME   SIGNATURE           TYPENAME                  INSTANCE   HOSTNAME
o001c87014ca81924   o001c87014ca81924          s001c87014ca80acc   vineyard::Tensor<int64>   1          kind-worker2
o001c8729e4590626   o001c8729e4590626          s001c8729e458f47a   vineyard::Tensor<int64>   2          kind-worker3
```
