### PR TITLE
[WIP] Add scheduler outside k8s cluster

### DIFF
--- a/k8s/cmd/main.go
+++ b/k8s/cmd/main.go
@@ -1,0 +1,186 @@
+/** Copyright 2020-2022 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/* Pakcage cmd is used for simplify the operator usage. */
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+
+	"github.com/v6d-io/v6d/k8s/apis/k8s/v1alpha1"
+	vineyardV1alpha1 "github.com/v6d-io/v6d/k8s/apis/k8s/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientgoScheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	scheme = runtime.NewScheme()
+)
+
+// add k8s apis scheme and apiextensions scheme
+func init() {
+	_ = clientgoScheme.AddToScheme(scheme)
+
+	_ = vineyardV1alpha1.AddToScheme(scheme)
+}
+
+func main() {
+	args := os.Args
+	if len(args) < 3 {
+		fmt.Println("Usage: go run main.go scheduler.go [kubeconfig path] [workflow path]")
+		os.Exit(1)
+	}
+	kubeconfig := args[1]
+	workflow := args[2]
+
+	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		panic(err)
+	}
+
+	client, _ := client.New(cfg, client.Options{Scheme: scheme})
+	//read file from path
+	contents, err := ioutil.ReadFile(workflow)
+	if err != nil {
+		fmt.Println("Error reading file:", err)
+	}
+
+	// parse the workflow yaml file
+	parseManifests(client, contents, kubeconfig)
+}
+
+func parseManifests(c client.Client, manifests []byte, kubeconfig string) {
+	// parse the workflow yaml file
+	resources := bytes.Split(manifests, []byte("---"))
+	for i := range resources {
+		// parse each resource
+		if resources[i][0] == '\r' {
+			resources[i] = resources[i][1:]
+		}
+		decode := clientgoScheme.Codecs.UniversalDeserializer().Decode
+		obj, gvk, err := decode(resources[i], nil, nil)
+		if err != nil {
+			fmt.Println("failed to decode resource", err)
+			os.Exit(1)
+		}
+		if success := SchedulingWorkload(c, gvk, obj, kubeconfig); !success {
+			fmt.Println("failed to wait resource", err)
+			os.Exit(1)
+		}
+	}
+}
+
+func scheduling(c client.Client, manifestsQueue []interface{}) {
+	// scheduling
+	vineyarddList := v1alpha1.VineyarddList{}
+	//podList := v1.PodList{}
+	if err := c.List(context.TODO(), &vineyarddList); err != nil {
+		fmt.Println("failed to list vineyardd", err)
+		os.Exit(1)
+	}
+
+	deploymentList := appsv1.DeploymentList{}
+	if err := c.List(context.TODO(), &deploymentList); err != nil {
+		fmt.Println("failed to list deployment", err)
+		os.Exit(1)
+	}
+	fmt.Println("vineyarddList: ", vineyarddList)
+	for _, q := range manifestsQueue {
+		deployment := q.(*appsv1.Deployment)
+		anno := deployment.Spec.Template.Annotations
+		if anno["scheduling.k8s.v6d.io/required"] == "none" {
+			if err := c.Create(context.TODO(), deployment); err != nil {
+				fmt.Println("failed to create deployment", err)
+				os.Exit(1)
+			}
+		}
+
+		fmt.Println("deployment: ", deployment)
+
+	}
+}
+
+// SchedulingWorkload is used to schedule the workload
+func SchedulingWorkload(c client.Client, gvk *schema.GroupVersionKind, obj interface{}, kubeconfig string) bool {
+	command := ""
+	switch gvk.Kind {
+	case "Deployment":
+		deployment := obj.(*appsv1.Deployment)
+		annotations := deployment.Spec.Template.Annotations
+		labels := deployment.Spec.Template.Labels
+		str := Scheduling(c, annotations, labels, int(*deployment.Spec.Replicas), deployment.Namespace)
+		annotations["scheduledOrder"] = str
+		labels["scheduling.v6d.io/enabled"] = "true"
+		if err := c.Create(context.TODO(), deployment); err != nil {
+			fmt.Println("failed to create deployment", err)
+			os.Exit(1)
+		}
+		command = "kubectl wait --for=condition=available --timeout=60s deployment.apps/" + deployment.Name +
+			" -n " + deployment.Namespace + " --kubeconfig=" + kubeconfig
+	case "StatefulSet":
+		statefulset := obj.(*appsv1.StatefulSet)
+		command = "kubectl wait --for=condition=available --timeout=60s statefulset.apps/" + statefulset.Name +
+			" -n " + statefulset.Namespace + " --kubeconfig=" + kubeconfig
+	case "Job":
+		job := obj.(*batchv1.Job)
+		annotations := job.Spec.Template.Annotations
+		labels := job.Spec.Template.Labels
+		str := Scheduling(c, annotations, labels, int(*job.Spec.Parallelism), job.Namespace)
+		annotations["scheduledOrder"] = str
+		labels["scheduling.v6d.io/enabled"] = "true"
+		if err := c.Create(context.TODO(), job); err != nil {
+			fmt.Println("failed to create job", err)
+			os.Exit(1)
+		}
+		command = "kubectl wait --for=condition=complete --timeout=60s job.batch/" + job.Name +
+			" -n " + job.Namespace + " --kubeconfig=" + kubeconfig
+	case "DaemonSet":
+		daemonset := obj.(*appsv1.DaemonSet)
+		command = "kubectl wait --for=condition=available --timeout=60s daemonset.apps/" + daemonset.Name +
+			" -n " + daemonset.Namespace + " --kubeconfig=" + kubeconfig
+	case "ReplicaSet":
+		replicaset := obj.(*appsv1.ReplicaSet)
+		command = "kubectl wait --for=condition=available --timeout=60s replicaset.apps/" + replicaset.Name +
+			" -n " + replicaset.Namespace + " --kubeconfig=" + kubeconfig
+	case "CronJob":
+		cronjob := obj.(*batchv1.CronJob)
+		command = "kubectl wait --for=condition=complete --timeout=60s cronjob.batch/" + cronjob.Name +
+			" -n " + cronjob.Namespace + " --kubeconfig=" + kubeconfig
+	default:
+		fmt.Println("unsupported workload kind: ", gvk.Kind)
+		os.Exit(1)
+		return false
+	}
+
+	// run kubectl wait command
+	cmd := exec.Command("bash", "-c", command)
+
+	err := cmd.Run()
+	if err != nil {
+		fmt.Println("failed to run kubectl wait, please check", err)
+		os.Exit(1)
+	}
+	return true
+}

--- a/k8s/cmd/scheduler.go
+++ b/k8s/cmd/scheduler.go
@@ -1,0 +1,215 @@
+/** Copyright 2020-2022 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/v6d-io/v6d/k8s/apis/k8s/v1alpha1"
+	"github.com/v6d-io/v6d/k8s/pkg/config/annotations"
+	"github.com/v6d-io/v6d/k8s/pkg/config/labels"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apilabels "k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func Scheduling(c client.Client, a, l map[string]string, replica int, namespace string) string {
+	scheduledOrder := ""
+	ctx := context.Background()
+	jobToNode := make(map[string]int)
+	// get all nodes that have vineyardd
+	nodes := []string{}
+
+	vineyarddName := l[labels.VineyarddName]
+	vineyarddNamespace := l[labels.VineyarddNamespace]
+
+	podList := v1.PodList{}
+	option := &client.ListOptions{
+		LabelSelector: apilabels.SelectorFromSet(apilabels.Set{
+			"app.kubernetes.io/name":     vineyarddName,
+			"app.kubernetes.io/instance": "vineyardd",
+		}),
+		Namespace: vineyarddNamespace,
+	}
+	if err := c.List(ctx, &podList, option); err != nil {
+		fmt.Println("Failed to list all pods with the specific label: %v", err)
+	}
+
+	for _, pod := range podList.Items {
+		nodes = append(nodes, pod.Spec.NodeName)
+	}
+
+	if a["scheduling.k8s.v6d.io/required"] == "none" {
+		l := len(nodes)
+		for i := 0; i < replica; i++ {
+			jobToNode[nodes[i%l]]++
+		}
+
+		s := make([]string, 0)
+		for n, v := range jobToNode {
+			s = append(s, n+"="+strconv.Itoa(v))
+		}
+		scheduledOrder = strings.Join(s, ",")
+		return scheduledOrder
+	}
+
+	// get required jobs
+	required := []string{}
+	jobs, exists := a[annotations.VineyardJobRequired]
+	if !exists {
+		fmt.Println("Failed to get the required jobs, please set none if there is no required job")
+	}
+	fmt.Println(" jobs: ", jobs)
+	required = strings.Split(jobs, ".")
+	fmt.Println("required jobs: ", required)
+	// get all global objects
+	requiredJobs := make(map[string]bool)
+	for _, n := range required {
+		requiredJobs[n] = true
+	}
+	objects := []*v1alpha1.GlobalObject{}
+	globalObjects := &v1alpha1.GlobalObjectList{}
+	if err := c.List(ctx, globalObjects); err != nil {
+		fmt.Println("client.List failed to get global objects, error: %v", err)
+	}
+	for i := range globalObjects.Items {
+		if jobname, exist := globalObjects.Items[i].Labels["k8s.v6d.io/job"]; exist && requiredJobs[jobname] {
+			objects = append(objects, &globalObjects.Items[i])
+			fmt.Println("global objects name: ", globalObjects.Items[i].Name)
+		}
+	}
+
+	fmt.Println("all global objects: ", objects)
+	localsigs := make([]string, 0)
+	for _, globalObject := range objects {
+		fmt.Println("all global objects: ", globalObject.Name)
+		localsigs = append(localsigs, globalObject.Spec.Members...)
+	}
+
+	lobjects := make([]*v1alpha1.LocalObject, 0)
+	for _, sig := range localsigs {
+		localObjects := &v1alpha1.LocalObjectList{}
+		if err := c.List(ctx, localObjects, client.MatchingLabels{
+			"k8s.v6d.io/signature": sig,
+		}); err != nil {
+			fmt.Println("client.List failed to get local objects, error: %v", err)
+		}
+		for _, localObject := range localObjects.Items {
+			lobjects = append(lobjects, &localObject)
+		}
+	}
+
+	locations := make(map[string][]string)
+	for _, localObject := range lobjects {
+		host := localObject.Spec.Hostname
+		if _, ok := locations[host]; !ok {
+			locations[host] = make([]string, 0)
+		}
+		locations[host] = append(locations[host], localObject.Spec.ObjectID)
+	}
+	fmt.Println("locations: ", locations)
+
+	// total frags
+	totalfrags := int(len(lobjects))
+	// frags for per pod
+	nchunks := totalfrags / replica
+	if totalfrags%replica != 0 {
+		nchunks++
+	}
+
+	// find the node
+	objNodes := make([]string, 0)
+	for k := range locations {
+		objNodes = append(objNodes, k)
+	}
+	sort.Strings(objNodes)
+
+	var cnt int
+	//jobToNode := make(map[string]int)
+
+	for i := 0; i < replica; i++ {
+		rank := i
+		for _, node := range nodes {
+			localfrags := len(locations[node])
+			if cnt+localfrags >= (nchunks*rank + (nchunks+1)/2) {
+				jobToNode[node]++
+				break
+			}
+			cnt += localfrags
+		}
+	}
+
+	fmt.Println("nodes: ", nodes)
+	fmt.Println("locations: ", locations)
+	fmt.Println("replica: ", replica)
+	fmt.Println("jobToNode: ", jobToNode)
+
+	s := make([]string, 0)
+	for n, v := range jobToNode {
+		s = append(s, n+"="+strconv.Itoa(v))
+	}
+	scheduledOrder = strings.Join(s, ",")
+
+	for i := range required {
+		configmap := &v1.ConfigMap{}
+		err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: required[i]}, configmap)
+		if err != nil && !apierrors.IsNotFound(err) {
+			fmt.Println("client.Get failed to get configmap, error: %v", err)
+		}
+		// the configmap doesn't exist
+		if apierrors.IsNotFound(err) {
+			data := make(map[string]string)
+			// get all local objects produced by the required job
+			// hostname -> localobject id
+			// TODO: if there are lots of localobjects in the same node
+			for _, o := range lobjects {
+				if (*o).Labels["k8s.v6d.io/job"] == required[i] {
+					data[(*o).Spec.Hostname] = (*o).Spec.ObjectID
+				}
+			}
+			// get all global objects produced by the required job
+			// jobname -> globalobject id
+			// TODO: if there are lots of globalobjects produced by the same job
+			for _, o := range objects {
+				if (*o).Labels["k8s.v6d.io/job"] == required[i] {
+					data[required[i]] = (*o).Spec.ObjectID
+				}
+			}
+			cm := v1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ConfigMap",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      required[i],
+					Namespace: namespace,
+				},
+				Data: data,
+			}
+			if err := c.Create(ctx, &cm); err != nil {
+				fmt.Println("create configmap error: %v", err)
+			}
+		}
+	}
+
+	return scheduledOrder
+}

--- a/k8s/cmd/test.yaml
+++ b/k8s/cmd/test.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: v6d-workflow-demo-job1
+  namespace: vineyard-job
+spec:
+  parallelism: 2
+  template:
+    metadata:
+      annotations:
+        scheduling.k8s.v6d.io/required: none
+        workloadSelector: app=v6d-workflow-demo-job1
+      labels:
+        app: v6d-workflow-demo-job1
+        # this label represents the vineyardd's name that need to be used
+        scheduling.k8s.v6d.io/vineyardd-namespace: vineyard-system
+        scheduling.k8s.v6d.io/vineyardd: vineyardd-sample
+        scheduling.k8s.v6d.io/job: v6d-workflow-demo-job1
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: job1
+        image: docker.pkg.github.com/v6d-io/v6d/job1-with-scheduler
+        env:
+        - name: JOB_NAME
+          value: v6d-workflow-demo-job1
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - mountPath: /var/run
+          name: vineyard-sock
+      volumes:
+      - name: vineyard-sock
+        hostPath:
+          path: /var/run/vineyard-kubernetes/vineyard-system/vineyardd-sample
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: v6d-workflow-demo-job2
+  namespace: vineyard-job
+spec:
+  parallelism: 3
+  template:
+    metadata:
+      annotations:
+        # The label is limited to 63 characters, so we need to use the annotation here
+        scheduling.k8s.v6d.io/required: v6d-workflow-demo-job1
+        workloadSelector: app=v6d-workflow-demo-job2
+      labels:
+        app: v6d-workflow-demo-job2
+        # this label represents the vineyardd's name that need to be used
+        scheduling.k8s.v6d.io/vineyardd-namespace: vineyard-system
+        scheduling.k8s.v6d.io/vineyardd: vineyardd-sample
+        scheduling.k8s.v6d.io/job: v6d-workflow-demo-job2
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: job2
+        image: docker.pkg.github.com/v6d-io/v6d/job2-with-scheduler
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: JOB_NAME
+          value: v6d-workflow-demo-job2
+        # pass node name to the environment
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        # TODO: could we make it more native?
+        envFrom:
+          - configMapRef:
+              name: v6d-workflow-demo-job1
+        volumeMounts:
+        - mountPath: /var/run
+          name: vineyard-sock
+      volumes:
+      - name: vineyard-sock
+        hostPath:
+          path: /var/run/vineyard-kubernetes/vineyard-system/vineyardd-sample

--- a/k8s/config/webhook/kustomization.yaml
+++ b/k8s/config/webhook/kustomization.yaml
@@ -8,3 +8,4 @@ configurations:
 patchesStrategicMerge:
 - operation_namespace_selector_patch.yaml
 - sidecar_selector_patch.yaml
+- scheduling_selector_patch.yaml

--- a/k8s/config/webhook/manifests.yaml
+++ b/k8s/config/webhook/manifests.yaml
@@ -111,6 +111,26 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /mutate-v1-pod-scheduling
+  failurePolicy: Fail
+  name: mpod.scheduling.kb.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /mutate-v1-pod
   failurePolicy: Fail
   name: mpod.kb.io

--- a/k8s/config/webhook/scheduling_selector_patch.yaml
+++ b/k8s/config/webhook/scheduling_selector_patch.yaml
@@ -1,0 +1,14 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+webhooks:
+- clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-v1-pod-scheduling
+  name: mpod.scheduling.kb.io
+  objectSelector:
+    matchLabels:
+      scheduling.v6d.io/enabled: "true"

--- a/k8s/pkg/scheduling/scheduling-webhook.go
+++ b/k8s/pkg/scheduling/scheduling-webhook.go
@@ -1,0 +1,102 @@
+/** Copyright 2020-2022 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package scheduling contains the logic for the scheduling
+package scheduling
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// nolint: lll
+// +kubebuilder:webhook:admissionReviewVersions=v1,sideEffects=None,path=/mutate-v1-pod-scheduling,mutating=true,failurePolicy=fail,groups="",resources=pods,verbs=create;update,versions=v1,name=mpod.scheduling.kb.io
+
+// SchedulingInjector injects assembly operation container into Pods
+type SchedulingInjector struct {
+	Client  client.Client
+	decoder *admission.Decoder
+}
+
+const (
+	// NeedSchedulingLabel is the label for scheduling
+	NeedSchedulingLabel = "scheduling.v6d.io/enabled"
+)
+
+// Handle handles admission requests.
+func (r *SchedulingInjector) Handle(ctx context.Context, req admission.Request) admission.Response {
+	logger := log.FromContext(ctx).WithName("injector").WithName("Assembly")
+
+	pod := &corev1.Pod{}
+	if err := r.decoder.Decode(req, pod); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+	anno := pod.GetAnnotations()
+	selector := anno["workloadSelector"]
+	order := anno["scheduledOrder"]
+
+	jobToNodes := make(map[string]int)
+
+	for _, o := range strings.Split(order, ",") {
+		n := strings.Split(o, "=")
+		i, _ := strconv.Atoi(n[1])
+		jobToNodes[n[0]] = i
+	}
+
+	kv := strings.Split(selector, "=")
+
+	podList := &corev1.PodList{}
+	if err := r.Client.List(ctx, podList, client.MatchingLabels{kv[0]: kv[1]}); err != nil {
+		fmt.Println("faled to list pod", err)
+	}
+
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		node := pod.Spec.NodeName
+		if node != "" {
+			jobToNodes[node]--
+		}
+	}
+
+	for i := range jobToNodes {
+		if jobToNodes[i] > 0 {
+			pod.Spec.NodeName = i
+			break
+		}
+	}
+
+	marshaledPod, err := json.Marshal(pod)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	logger.Info("Injecting the nodeselector!")
+	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledPod)
+}
+
+// InjectDecoder injects the decoder.
+func (r *SchedulingInjector) InjectDecoder(d *admission.Decoder) error {
+	r.decoder = d
+	return nil
+}

--- a/k8s/test/e2e/scheduling-outside-cluster/e2e.yaml
+++ b/k8s/test/e2e/scheduling-outside-cluster/e2e.yaml
@@ -1,0 +1,73 @@
+# Copyright 2020-2022 Alibaba Group Holding Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+setup:
+  env: kind
+  file: ../kind.yaml
+  steps:
+    - name: install cert-manager
+      command: |
+        kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.9.1/cert-manager.yaml
+      wait:
+        - namespace: cert-manager
+          resource: pod
+          for: condition=Ready
+    - name: install vineyard operator
+      command: |
+        kind load docker-image docker.pkg.github.com/v6d-io/v6d/job1-with-scheduler
+        kind load docker-image docker.pkg.github.com/v6d-io/v6d/job2-with-scheduler
+        kind load docker-image vineyardcloudnative/vineyard-operator:latest
+        make -C k8s deploy
+      wait:
+        - namespace: vineyard-system
+          resource: deployment/vineyard-controller-manager
+          for: condition=Available
+    - name: install vineyardd
+      command: |
+        kubectl apply -f k8s/test/e2e/vineyardd.yaml
+      wait:
+        - namespace: vineyard-system
+          resource: vineyardd/vineyardd-sample
+          for: condition=Available
+    - name: scheduling workload
+      command: |
+        kubectl create ns vineyard-job
+        go run k8s/cmd/main.go k8s/cmd/scheduler.go /tmp/e2e-k8s.config k8s/cmd/test.yaml
+    - name: wait job completed
+      command: |
+        kubectl wait --for=condition=complete --timeout=5m job/v6d-workflow-demo-job2 -n vineyard-job
+  timeout: 20m
+
+cleanup:
+  # always never success failure
+  on: always
+
+verify:
+  # verify with retry strategy
+  retry:
+    # max retry count
+    count: 10
+    # the interval between two attempts, e.g. 10s, 1m.
+    interval: 10s
+  cases:
+    - query: 'kubectl get pod -l app=v6d-workflow-demo-job2 -n vineyard-job -oname | awk -F ''/'' ''{print $2}'' | head -n 1 | xargs kubectl logs -n vineyard-job | yq e ''{"sum": .}'' - | yq e ''to_entries'' -'
+      expected: ../verify/values.yaml
+    # test the job can only be scheduled on the nodes with the vineyardd
+    - query: |
+        export job1_nodes=$(kubectl get pod -l app=v6d-workflow-demo-job1 -nvineyard-job -o=custom-columns=NODE:.spec.nodeName | awk 'NR != 1' | sort | tr '\n' ' ')
+        export job2_nodes=$(kubectl get pod -l app=v6d-workflow-demo-job2 -nvineyard-job -o=custom-columns=NODE:.spec.nodeName | awk 'NR != 1' | sort | tr '\n' ' ')
+        export vineyardd_nodes=$(kubectl get pod -l app.kubernetes.io/instance=vineyardd -n vineyard-system -o=custom-columns=NODE:.spec.nodeName | awk 'NR != 1' | sort | tr '\n' ' ')
+        if [ $job1_nodes = $vineyardd_nodes ] && [ $job2_nodes = $vineyardd_nodes ]; then echo '{"AllJobInVineyarddNodes":"true"}' | yq e 'to_entries' -; fi
+      expected: ../verify/nodes.yaml


### PR DESCRIPTION
The core strategy is to check the status of intermediate variables before deploying a certain workload, record the nodes that need to be deployed, and finally inject the node information into the nodeName of the pod through webhook.

The version is WIP as the scheduling code has a lot of duplication.