### PR TITLE
String tensors requires arrow.vineyard.h to work.

### DIFF
--- a/modules/basic/ds/tensor.vineyard-mod
+++ b/modules/basic/ds/tensor.vineyard-mod
@@ -30,6 +30,7 @@ limitations under the License.
 #include "arrow/io/api.h"
 
 #include "basic/ds/array.vineyard.h"
+#include "basic/ds/arrow.vineyard.h"
 #include "basic/ds/arrow.h"
 #include "basic/ds/types.h"
 #include "client/client.h"


### PR DESCRIPTION

What do these changes do?
-------------------------

as titled.

Related issue number
--------------------

N/A