### PR TITLE
Use a CSR generation implementation with less memory footprint

### DIFF
--- a/modules/graph/fragment/arrow_fragment_builder_impl.h
+++ b/modules/graph/fragment/arrow_fragment_builder_impl.h
@@ -361,17 +361,18 @@ ArrowFragment<OID_T, VID_T, VERTEX_MAP_T>::AddNewVertexEdgeLabels(
       if (directed_) {
         // Process 0...total_v_num  X  e_num...total_e_num  part.
         generate_directed_csr<vid_t, eid_t>(
-            client, vid_parser_, edge_src[cur_label_index],
-            edge_dst[cur_label_index], tvnums, total_vertex_label_num,
-            concurrency, sub_oe_lists, sub_oe_offset_lists, is_multigraph_);
-        generate_directed_csr<vid_t, eid_t>(
-            client, vid_parser_, std::move(edge_dst[cur_label_index]),
-            std::move(edge_src[cur_label_index]), tvnums,
-            total_vertex_label_num, concurrency, sub_ie_lists,
+            client, vid_parser_, std::move(edge_src[cur_label_index]),
+            std::move(edge_dst[cur_label_index]), tvnums,
+            total_vertex_label_num, concurrency, sub_oe_lists,
+            sub_oe_offset_lists, is_multigraph_);
+        generate_directed_csc<vid_t, eid_t>(
+            client, vid_parser_, this->fid_, tvnums, total_vertex_label_num,
+            concurrency, sub_oe_lists, sub_oe_offset_lists, sub_ie_lists,
             sub_ie_offset_lists, is_multigraph_);
       } else {
         generate_undirected_csr<vid_t, eid_t>(
-            client, vid_parser_, std::move(edge_src[cur_label_index]),
+            client, vid_parser_, this->fid_,
+            std::move(edge_src[cur_label_index]),
             std::move(edge_dst[cur_label_index]), tvnums,
             total_vertex_label_num, concurrency, sub_oe_lists,
             sub_oe_offset_lists, is_multigraph_);
@@ -849,16 +850,16 @@ ArrowFragment<OID_T, VID_T, VERTEX_MAP_T>::AddNewEdgeLabels(
         vertex_label_num_);
     if (directed_) {
       generate_directed_csr<vid_t, eid_t>(
-          client, vid_parser_, edge_src[e_label], edge_dst[e_label], tvnums,
-          vertex_label_num_, concurrency, sub_oe_lists, sub_oe_offset_lists,
-          is_multigraph_);
-      generate_directed_csr<vid_t, eid_t>(
-          client, vid_parser_, std::move(edge_dst[e_label]),
-          std::move(edge_src[e_label]), tvnums, vertex_label_num_, concurrency,
-          sub_ie_lists, sub_ie_offset_lists, is_multigraph_);
+          client, vid_parser_, std::move(edge_src[e_label]),
+          std::move(edge_dst[e_label]), tvnums, vertex_label_num_, concurrency,
+          sub_oe_lists, sub_oe_offset_lists, is_multigraph_);
+      generate_directed_csc<vid_t, eid_t>(
+          client, vid_parser_, this->fid_, tvnums, vertex_label_num_,
+          concurrency, sub_oe_lists, sub_oe_offset_lists, sub_ie_lists,
+          sub_ie_offset_lists, is_multigraph_);
     } else {
       generate_undirected_csr<vid_t, eid_t>(
-          client, vid_parser_, std::move(edge_src[e_label]),
+          client, vid_parser_, this->fid_, std::move(edge_src[e_label]),
           std::move(edge_dst[e_label]), tvnums, vertex_label_num_, concurrency,
           sub_oe_lists, sub_oe_offset_lists, is_multigraph_);
     }
@@ -1246,16 +1247,16 @@ BasicArrowFragmentBuilder<OID_T, VID_T, VERTEX_MAP_T>::initEdges(
         this->vertex_label_num_);
     if (this->directed_) {
       generate_directed_csr<vid_t, eid_t>(
-          client_, vid_parser_, edge_src[e_label], edge_dst[e_label], tvnums_,
-          this->vertex_label_num_, concurrency, sub_oe_lists,
-          sub_oe_offset_lists, this->is_multigraph_);
-      generate_directed_csr<vid_t, eid_t>(
-          client_, vid_parser_, std::move(edge_dst[e_label]),
-          std::move(edge_src[e_label]), tvnums_, this->vertex_label_num_,
-          concurrency, sub_ie_lists, sub_ie_offset_lists, this->is_multigraph_);
+          client_, vid_parser_, std::move(edge_src[e_label]),
+          std::move(edge_dst[e_label]), tvnums_, this->vertex_label_num_,
+          concurrency, sub_oe_lists, sub_oe_offset_lists, this->is_multigraph_);
+      generate_directed_csc<vid_t, eid_t>(
+          client_, vid_parser_, this->fid_, tvnums_, this->vertex_label_num_,
+          concurrency, sub_oe_lists, sub_oe_offset_lists, sub_ie_lists,
+          sub_ie_offset_lists, this->is_multigraph_);
     } else {
       generate_undirected_csr<vid_t, eid_t>(
-          client_, vid_parser_, std::move(edge_src[e_label]),
+          client_, vid_parser_, this->fid_, std::move(edge_src[e_label]),
           std::move(edge_dst[e_label]), tvnums_, this->vertex_label_num_,
           concurrency, sub_oe_lists, sub_oe_offset_lists, this->is_multigraph_);
     }

--- a/modules/graph/fragment/property_graph_utils.h
+++ b/modules/graph/fragment/property_graph_utils.h
@@ -107,6 +107,9 @@ void check_is_multigraph(
     std::shared_ptr<arrow::Int64Array> offsets, VID_T tvnum, int concurrency,
     bool& is_multigraph);
 
+/**
+ * @brief Generate CSR from given COO.
+ */
 template <typename VID_T, typename EID_T>
 boost::leaf::result<void> generate_directed_csr(
     Client& client, IdParser<VID_T>& parser,
@@ -118,9 +121,43 @@ boost::leaf::result<void> generate_directed_csr(
     std::vector<std::shared_ptr<arrow::Int64Array>>& edge_offsets,
     bool& is_multigraph);
 
+/**
+ * @brief Generate CSC from given CSR.
+ */
+template <typename VID_T, typename EID_T>
+boost::leaf::result<void> generate_directed_csc(
+    Client& client, IdParser<VID_T>& parser, fid_t fid,
+    std::vector<VID_T> tvnums, int vertex_label_num, int concurrency,
+    std::vector<std::shared_ptr<
+        PodArrayBuilder<property_graph_utils::NbrUnit<VID_T, EID_T>>>>& oedges,
+    std::vector<std::shared_ptr<arrow::Int64Array>>& oedge_offsets,
+    std::vector<std::shared_ptr<
+        PodArrayBuilder<property_graph_utils::NbrUnit<VID_T, EID_T>>>>& iedges,
+    std::vector<std::shared_ptr<arrow::Int64Array>>& iedge_offsets,
+    bool& is_multigraph);
+
+/**
+ * @brief Generate CSR and CSC from given COO, scan once, and generate both
+ * direction at the same time.
+ */
 template <typename VID_T, typename EID_T>
 boost::leaf::result<void> generate_undirected_csr(
     Client& client, IdParser<VID_T>& parser,
+    std::vector<std::shared_ptr<ArrowArrayType<VID_T>>> src_chunks,
+    std::vector<std::shared_ptr<ArrowArrayType<VID_T>>> dst_chunks,
+    std::vector<VID_T> tvnums, int vertex_label_num, int concurrency,
+    std::vector<std::shared_ptr<
+        PodArrayBuilder<property_graph_utils::NbrUnit<VID_T, EID_T>>>>& edges,
+    std::vector<std::shared_ptr<arrow::Int64Array>>& edge_offsets,
+    bool& is_multigraph);
+
+/**
+ * @brief Generate CSR and CSC from given COO, scan twice, generate CSR from
+ * COO, and then generate CSC from CSR.
+ */
+template <typename VID_T, typename EID_T>
+boost::leaf::result<void> generate_undirected_csr(
+    Client& client, IdParser<VID_T>& parser, fid_t fid,
     std::vector<std::shared_ptr<ArrowArrayType<VID_T>>> src_chunks,
     std::vector<std::shared_ptr<ArrowArrayType<VID_T>>> dst_chunks,
     std::vector<VID_T> tvnums, int vertex_label_num, int concurrency,

--- a/modules/graph/fragment/property_graph_utils_uint32.cc
+++ b/modules/graph/fragment/property_graph_utils_uint32.cc
@@ -62,8 +62,32 @@ template boost::leaf::result<void> generate_directed_csr<uint32_t, uint64_t>(
     std::vector<std::shared_ptr<arrow::Int64Array>>& edge_offsets,
     bool& is_multigraph);
 
+template boost::leaf::result<void> generate_directed_csc<uint32_t, uint64_t>(
+    Client& client, IdParser<uint32_t>& parser, fid_t fid,
+    std::vector<uint32_t> tvnums, int vertex_label_num, int concurrency,
+    std::vector<std::shared_ptr<
+        PodArrayBuilder<property_graph_utils::NbrUnit<uint32_t, uint64_t>>>>&
+        oedges,
+    std::vector<std::shared_ptr<arrow::Int64Array>>& oedge_offsets,
+    std::vector<std::shared_ptr<
+        PodArrayBuilder<property_graph_utils::NbrUnit<uint32_t, uint64_t>>>>&
+        iedges,
+    std::vector<std::shared_ptr<arrow::Int64Array>>& iedge_offsets,
+    bool& is_multigraph);
+
 template boost::leaf::result<void> generate_undirected_csr<uint32_t, uint64_t>(
     Client& client, IdParser<uint32_t>& parser,
+    std::vector<std::shared_ptr<ArrowArrayType<uint32_t>>> src_chunks,
+    std::vector<std::shared_ptr<ArrowArrayType<uint32_t>>> dst_chunks,
+    std::vector<uint32_t> tvnums, int vertex_label_num, int concurrency,
+    std::vector<std::shared_ptr<
+        PodArrayBuilder<property_graph_utils::NbrUnit<uint32_t, uint64_t>>>>&
+        edges,
+    std::vector<std::shared_ptr<arrow::Int64Array>>& edge_offsets,
+    bool& is_multigraph);
+
+template boost::leaf::result<void> generate_undirected_csr<uint32_t, uint64_t>(
+    Client& client, IdParser<uint32_t>& parser, fid_t fid,
     std::vector<std::shared_ptr<ArrowArrayType<uint32_t>>> src_chunks,
     std::vector<std::shared_ptr<ArrowArrayType<uint32_t>>> dst_chunks,
     std::vector<uint32_t> tvnums, int vertex_label_num, int concurrency,

--- a/modules/graph/fragment/property_graph_utils_uint64.cc
+++ b/modules/graph/fragment/property_graph_utils_uint64.cc
@@ -62,8 +62,32 @@ template boost::leaf::result<void> generate_directed_csr<uint64_t, uint64_t>(
     std::vector<std::shared_ptr<arrow::Int64Array>>& edge_offsets,
     bool& is_multigraph);
 
+template boost::leaf::result<void> generate_directed_csc<uint64_t, uint64_t>(
+    Client& client, IdParser<uint64_t>& parser, fid_t fid,
+    std::vector<uint64_t> tvnums, int vertex_label_num, int concurrency,
+    std::vector<std::shared_ptr<
+        PodArrayBuilder<property_graph_utils::NbrUnit<uint64_t, uint64_t>>>>&
+        oedges,
+    std::vector<std::shared_ptr<arrow::Int64Array>>& oedge_offsets,
+    std::vector<std::shared_ptr<
+        PodArrayBuilder<property_graph_utils::NbrUnit<uint64_t, uint64_t>>>>&
+        iedges,
+    std::vector<std::shared_ptr<arrow::Int64Array>>& iedge_offsets,
+    bool& is_multigraph);
+
 template boost::leaf::result<void> generate_undirected_csr<uint64_t, uint64_t>(
     Client& client, IdParser<uint64_t>& parser,
+    std::vector<std::shared_ptr<ArrowArrayType<uint64_t>>> src_chunks,
+    std::vector<std::shared_ptr<ArrowArrayType<uint64_t>>> dst_chunks,
+    std::vector<uint64_t> tvnums, int vertex_label_num, int concurrency,
+    std::vector<std::shared_ptr<
+        PodArrayBuilder<property_graph_utils::NbrUnit<uint64_t, uint64_t>>>>&
+        edges,
+    std::vector<std::shared_ptr<arrow::Int64Array>>& edge_offsets,
+    bool& is_multigraph);
+
+template boost::leaf::result<void> generate_undirected_csr<uint64_t, uint64_t>(
+    Client& client, IdParser<uint64_t>& parser, fid_t fid,
     std::vector<std::shared_ptr<ArrowArrayType<uint64_t>>> src_chunks,
     std::vector<std::shared_ptr<ArrowArrayType<uint64_t>>> dst_chunks,
     std::vector<uint64_t> tvnums, int vertex_label_num, int concurrency,


### PR DESCRIPTION
What do these changes do?
-------------------------

Avoid keeping both COO, CSR and CSC in memory at the same time.

Further optimization over #1102 and address #974.

