### PR TITLE
Fixes parsing flags when using higher version of apache-arrow

### DIFF
--- a/modules/basic/ds/arrow_shim/concatenate.cc
+++ b/modules/basic/ds/arrow_shim/concatenate.cc
@@ -49,8 +49,13 @@
 #include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_ops.h"
 #include "arrow/util/checked_cast.h"
+#include "arrow/util/config.h"
 #include "arrow/util/int_util.h"
+#if defined(ARROW_VERSION) && ARROW_VERSION < 9000000
+#include "arrow/util/int_util_internal.h"
+#else
 #include "arrow/util/int_util_overflow.h"
+#endif
 #include "arrow/util/logging.h"
 #include "arrow/visit_type_inline.h"
 

--- a/python/vineyard/core/codegen/parsing.py
+++ b/python/vineyard/core/codegen/parsing.py
@@ -625,7 +625,7 @@ def generate_parsing_flags(
     base_flags = [
         '-x',
         'c++',
-        '-std=c++14',
+        '-std=c++17',
         '-nostdinc',
         '-nostdinc++',
         '-D__VPP=1',

--- a/python/vineyard/data/arrow.py
+++ b/python/vineyard/data/arrow.py
@@ -28,6 +28,8 @@ from .utils import normalize_dtype
 def buffer_builder(client, buffer, builder):
     if buffer is None:
         return client.create_empty_blob()
+    if len(buffer) == 0:
+        return client.create_empty_blob()
     existing = client.find_shared_memory(buffer.address)
     if existing is not None:
         return client.get_meta(existing)


### PR DESCRIPTION
What do these changes do?
-------------------------

Fixes a include error with arrow 6.0 as well.
