### PR TITLE
Expose the `fetch` argument to python API

### DIFF
--- a/python/vineyard/core/resolver.py
+++ b/python/vineyard/core/resolver.py
@@ -168,7 +168,7 @@ def resolver_context(resolvers=None, base=None):
         _resolver_context_local.default_resolver = current_resolver
 
 
-def get(client, object_id, resolver=None, **kw):
+def get(client, object_id, resolver=None, fetch=False, **kw):
     """Get vineyard object as python value.
 
     .. code:: python
@@ -186,6 +186,9 @@ def get(client, object_id, resolver=None, **kw):
         resolver:
             When retrieving vineyard object, an optional *resolver* can be specified.
             If no resolver given, the default resolver context will be used.
+        fetch:
+            Whether to trigger a migration when the target object is located on remote
+            instances.
         kw:
             User-specific argument that will be passed to the builder.
 
@@ -197,7 +200,7 @@ def get(client, object_id, resolver=None, **kw):
         object_id = ObjectID(object_id)
 
     # run resolver
-    obj = client.get_object(object_id)
+    obj = client.get_object(object_id, fetch=fetch)
     meta = obj.meta
     if not meta.islocal and not meta.isglobal:
         raise ValueError(

--- a/src/client/ds/blob.cc
+++ b/src/client/ds/blob.cc
@@ -39,8 +39,8 @@ const char* Blob::data() const {
   }
   if (size_ > 0 && (buffer_ == nullptr || buffer_->size() == 0)) {
     throw std::invalid_argument(
-        "The object might be a (partially) remote object and the payload data "
-        "is not locally available: " +
+        "Blob::data(): the object might be a (partially) remote object and the "
+        "payload data is not locally available: " +
         ObjectIDToString(id_));
   }
   return reinterpret_cast<const char*>(buffer_->data());
@@ -49,8 +49,8 @@ const char* Blob::data() const {
 const std::shared_ptr<arrow::Buffer>& Blob::Buffer() const {
   if (size_ > 0 && (buffer_ == nullptr || buffer_->size() == 0)) {
     throw std::invalid_argument(
-        "The object might be a (partially) remote object and the payload data "
-        "is not locally available: " +
+        "Blob::Buffer(): the object might be a (partially) remote object and "
+        "the payload data is not locally available: " +
         ObjectIDToString(id_));
   }
   return buffer_;
@@ -76,14 +76,15 @@ void Blob::Construct(ObjectMeta const& meta) {
   if (meta.GetBuffer(meta.GetId(), this->buffer_).ok()) {
     if (this->buffer_ == nullptr) {
       throw std::runtime_error(
-          "Invalid internal state: local blob found bit it is nullptr: " +
+          "Blob::Construct(): Invalid internal state: local blob found bit it "
+          "is nullptr: " +
           ObjectIDToString(meta.GetId()));
     }
     this->size_ = this->buffer_->size();
   } else {
     throw std::runtime_error(
-        "Invalid internal state: failed to construct local blob since payload "
-        "is missing: " +
+        "Blob::Construct(): Invalid internal state: failed to construct local "
+        "blob since payload is missing: " +
         ObjectIDToString(meta.GetId()));
   }
 }

--- a/src/client/ds/remote_blob.cc
+++ b/src/client/ds/remote_blob.cc
@@ -45,8 +45,8 @@ const char* RemoteBlob::data() const {
   }
   if (size_ > 0 && (buffer_ == nullptr || buffer_->size() == 0)) {
     throw std::invalid_argument(
-        "The object might be a (partially) remote object and the payload data "
-        "is not locally available: " +
+        "RemoteBlob::data(): the object might be a (partially) remote object "
+        "and the payload data is not locally available: " +
         ObjectIDToString(id_));
   }
   return reinterpret_cast<const char*>(buffer_->data());
@@ -55,8 +55,8 @@ const char* RemoteBlob::data() const {
 const std::shared_ptr<arrow::Buffer>& RemoteBlob::Buffer() const {
   if (size_ > 0 && (buffer_ == nullptr || buffer_->size() == 0)) {
     throw std::invalid_argument(
-        "The object might be a (partially) remote object and the payload data "
-        "is not locally available: " +
+        "RemoteBlob::Buffer(): the object might be a (partially) remote object "
+        "and the payload data is not locally available: " +
         ObjectIDToString(id_));
   }
   return buffer_;
@@ -95,8 +95,8 @@ char* RemoteBlob::mutable_data() const {
   }
   if (size_ > 0 && (buffer_ == nullptr || buffer_->size() == 0)) {
     throw std::invalid_argument(
-        "The object might be a (partially) remote object and the payload data "
-        "is not locally available: " +
+        "RemoteBlob::mutable_data(): The object might be a (partially) remote "
+        "object and the payload data is not locally available: " +
         ObjectIDToString(id_));
   }
   return reinterpret_cast<char*>(buffer_->mutable_data());

--- a/src/server/memory/usage.h
+++ b/src/server/memory/usage.h
@@ -113,7 +113,7 @@ class DependencyTracker
   Status RemoveDependency(ID const& id, int conn) {
     Status status;
     bool accessed = dependency_.erase_fn(
-        conn, [this, id, &status](ska::flat_hash_set<ID>& objects) -> bool {
+        conn, [id, &status](ska::flat_hash_set<ID>& objects) -> bool {
           if (objects.find(id) == objects.end()) {
             status = Status::ObjectNotExists(
                 "DependencyTracker: failed to find object during remove "

--- a/src/server/util/remote.cc
+++ b/src/server/util/remote.cc
@@ -196,6 +196,9 @@ Status RemoteClient::recreateMetadata(
     json const& metadata, json& target,
     std::map<ObjectID, ObjectID> const& result_blobs) {
   for (auto const& kv : metadata.items()) {
+    if (kv.key() == "id") {
+      continue;
+    }
     if (kv.value().is_object()) {
       json member = kv.value();
       if (member.value("typename", "") == "vineyard::Blob") {
@@ -214,9 +217,9 @@ Status RemoteClient::recreateMetadata(
     } else {
       target[kv.key()] = kv.value();
     }
-    target["instance_id"] = this->server_ptr_->instance_id();
-    target["transient"] = true;
   }
+  target["instance_id"] = this->server_ptr_->instance_id();
+  target["transient"] = true;
   return Status::OK();
 }
 


### PR DESCRIPTION
What do these changes do?
-------------------------

The change will be included in the next release of Python wheels. As a workround, you could do

```python
obj = client.get(client.migrate(object_id))
```

with current version.


Related issue number
--------------------

Fixes N/A

