### PR TITLE
Implements accmulate support for vineyard.io.open()

### DIFF
--- a/k8s/test/e2e/assembly-demo/assembly-distributed.py
+++ b/k8s/test/e2e/assembly-demo/assembly-distributed.py
@@ -33,13 +33,13 @@ new_meta_size = 0
 new_id_size = 0
 new_meta['typename'] = 'vineyard::GlobalSequence'
 new_meta.set_global(True)
-old_meta = vineyard_client.get_meta(vineyard._C.ObjectID(
+old_meta = vineyard_client.get_meta(vineyard.ObjectID(
     globalobject_id))  # pylint: disable=no-member
 for i in range(0, old_meta['__elements_-size']):
-    member_meta = vineyard_client.get_meta(vineyard._C.ObjectID(
+    member_meta = vineyard_client.get_meta(vineyard.ObjectID(
         old_meta['__elements_-{}'.format(i)].id))  # pylint: disable=no-member
     if member_meta['id'] in dist:
-        id = vineyard._C.ObjectID(dist[member_meta['id']])
+        id = vineyard.ObjectID(dist[member_meta['id']])
         local_meta = vineyard_client.get_meta(id)  # pylint: disable=no-member
         for j in range(0, local_meta['__elements_-size']):
             md = local_meta['__elements_-{}'.format(j)]

--- a/k8s/test/e2e/assembly-demo/assembly-job2.py
+++ b/k8s/test/e2e/assembly-demo/assembly-job2.py
@@ -27,12 +27,12 @@ job = env_dist['REQUIRED_JOB_NAME']
 metaid = env_dist.get(job)
 sum = 0
 top_meta = vineyard_client.get_meta(
-    vineyard._C.ObjectID(metaid))  # pylint: disable=no-member
+    vineyard.ObjectID(metaid))  # pylint: disable=no-member
 for i in range(0, top_meta['__elements_-size']):
-    second_meta = vineyard_client.get_meta(vineyard._C.ObjectID(
+    second_meta = vineyard_client.get_meta(vineyard.ObjectID(
         top_meta['__elements_-{}'.format(i)].id))  # pylint: disable=no-member
     for i in range(0, second_meta['__elements_-size']):
-        meta = vineyard_client.get_meta(vineyard._C.ObjectID(
+        meta = vineyard_client.get_meta(vineyard.ObjectID(
             second_meta['__elements_-{}'.format(i)].id))
         value = vineyard_client.get(meta.id)
         sum += (value['a'].sum() + value['b'].sum())

--- a/k8s/test/e2e/assembly-demo/distributed-job2.py
+++ b/k8s/test/e2e/assembly-demo/distributed-job2.py
@@ -35,7 +35,7 @@ vineyard_client = vineyard.connect('/var/run/vineyard.sock')
 stream = RecordBatchStream.new(vineyard_client)
 vineyard_client.persist(stream.id)
 meta1 = vineyard_client.get_meta(stream.id)
-meta2 = vineyard_client.get_meta(vineyard._C.ObjectID(metaid))
+meta2 = vineyard_client.get_meta(vineyard.ObjectID(metaid))
 
 meta = vineyard.ObjectMeta()
 meta['__elements_-size'] = 2

--- a/k8s/test/e2e/assembly-demo/distributed-job3.py
+++ b/k8s/test/e2e/assembly-demo/distributed-job3.py
@@ -26,13 +26,13 @@ env_dist = os.environ
 job = env_dist['REQUIRED_JOB_NAME']
 metaid = env_dist.get(job)
 sum = 0
-top_meta = vineyard_client.get_meta(vineyard._C.ObjectID(metaid))  # pylint: disable=no-member
+top_meta = vineyard_client.get_meta(vineyard.ObjectID(metaid))  # pylint: disable=no-member
 for i in range(0, top_meta['__global_id_-size']):
-    second_meta = vineyard_client.get_meta(vineyard._C.ObjectID(top_meta['__global_id_-{}'.format(i)]))  # pylint: disable=no-member
+    second_meta = vineyard_client.get_meta(vineyard.ObjectID(top_meta['__global_id_-{}'.format(i)]))  # pylint: disable=no-member
     for j in range(0, second_meta['__elements_-size']):
-        third_meta = vineyard_client.get_meta(vineyard._C.ObjectID(second_meta['__elements_-{}'.format(j)].id))  # pylint: disable=no-member
+        third_meta = vineyard_client.get_meta(vineyard.ObjectID(second_meta['__elements_-{}'.format(j)].id))  # pylint: disable=no-member
         for k in range(0, third_meta['__elements_-size']):
-            meta = vineyard_client.get_meta(vineyard._C.ObjectID(third_meta['__elements_-{}'.format(k)].id),True,True)
+            meta = vineyard_client.get_meta(vineyard.ObjectID(third_meta['__elements_-{}'.format(k)].id),True,True)
             value = vineyard_client.get(meta.id)
             sum += (value['a'].sum() + value['b'].sum())
 print(sum, flush=True)

--- a/k8s/test/e2e/failover-demo/build-distributed-object-step2.py
+++ b/k8s/test/e2e/failover-demo/build-distributed-object-step2.py
@@ -33,7 +33,7 @@ obj = client.put(df)
 client.persist(obj)
 
 meta1 = client.get_meta(obj)
-meta2 = client.get_meta(vineyard._C.ObjectID(objid))
+meta2 = client.get_meta(vineyard.ObjectID(objid))
 
 meta = vineyard.ObjectMeta()
 meta['__elements_-size'] = 2

--- a/k8s/test/e2e/failover-demo/get-distributed-object.py
+++ b/k8s/test/e2e/failover-demo/get-distributed-object.py
@@ -24,7 +24,7 @@ env_dist = os.environ
 
 objid = env_dist['OBJECT_ID']
 
-meta = vineyard_client.get_meta(vineyard._C.ObjectID(objid))  # pylint: disable=no-member
+meta = vineyard_client.get_meta(vineyard.ObjectID(objid))  # pylint: disable=no-member
 verified = True
 for i in range(0, meta['__elements_-size']):
     oid = meta['__elements_-{}'.format(i)].id

--- a/k8s/test/e2e/failover-demo/get-local-object.py
+++ b/k8s/test/e2e/failover-demo/get-local-object.py
@@ -27,7 +27,7 @@ env_dist = os.environ
 
 objid = env_dist['OBJECT_ID']
 
-value = client.get(vineyard._C.ObjectID(objid))
+value = client.get(vineyard.ObjectID(objid))
 
 sum = np.sum(value)
 print(sum,flush=True)

--- a/k8s/test/e2e/repartition-demo/dask-repartition.py
+++ b/k8s/test/e2e/repartition-demo/dask-repartition.py
@@ -52,7 +52,7 @@ dask_scheduler = env_dist['DASK_SCHEDULER']
 client = vineyard.connect('/var/run/vineyard.sock')
 with vineyard_for_dask():
     print('start to get ddf', flush=True)
-    data = client.get(vineyard._C.ObjectID(gid),
+    data = client.get(vineyard.ObjectID(gid),
                       dask_scheduler=dask_scheduler, dask_workers=dask_workers)
     print('get data done', flush=True)
     new_df = data.repartition(npartitions=int(replicas))

--- a/k8s/test/e2e/repartition-demo/job2.py
+++ b/k8s/test/e2e/repartition-demo/job2.py
@@ -51,7 +51,7 @@ for key, value in dist.items():
 
 dask_scheduler = env_dist['DASK_SCHEDULER']
 with vineyard_for_dask():
-    ddf = client.get(vineyard._C.ObjectID(gid),
+    ddf = client.get(vineyard.ObjectID(gid),
                      dask_scheduler=dask_scheduler, dask_workers=dask_workers)
     partitions = ddf.npartitions
     print(partitions, flush=True)

--- a/k8s/test/e2e/workflow-demo/job2.py
+++ b/k8s/test/e2e/workflow-demo/job2.py
@@ -27,7 +27,7 @@ env_dist = os.environ
 
 hostname = env_dist['NODENAME']
 metaid = env_dist.get(hostname)
-meta = client.get_meta(vineyard._C.ObjectID(metaid)) # pylint: disable=no-member
+meta = client.get_meta(vineyard.ObjectID(metaid)) # pylint: disable=no-member
 value = client.get(meta['buffer_'].id)
 
 sum = np.sum(value)

--- a/modules/io/python/drivers/io/adaptors/read_parquet.py
+++ b/modules/io/python/drivers/io/adaptors/read_parquet.py
@@ -28,6 +28,7 @@ import fsspec.implementations.arrow
 from fsspec.core import split_protocol
 
 import vineyard
+from vineyard.data.utils import str_to_bool
 from vineyard.io.dataframe import DataframeStream
 from vineyard.io.utils import expand_full_path
 from vineyard.io.utils import report_error
@@ -50,7 +51,9 @@ def make_empty_batch(schema):
     return pyarrow.RecordBatch.from_arrays(colmuns, schema.names)
 
 
-def read_parquet_blocks(fs, path, read_options, proc_num, proc_index, writer):
+def read_parquet_blocks(
+    client, fs, path, read_options, proc_num, proc_index, writer, chunks
+):
     import pyarrow.parquet
 
     columns = read_options.get('columns', None)
@@ -75,9 +78,16 @@ def read_parquet_blocks(fs, path, read_options, proc_num, proc_index, writer):
                 use_threads=False,
                 **kwargs,
             ):
-                writer.write(batch)
+                if writer is not None:
+                    writer.write(batch)
+                else:
+                    chunks.append(client.put(batch))
         else:
-            writer.write(make_empty_batch(reader.schema_arrow))
+            batch = make_empty_batch(reader.schema_arrow)
+            if writer is not None:
+                writer.write(batch)
+            else:
+                chunks.append(client.put(batch))
 
 
 def read_bytes(  # noqa: C901, pylint: disable=too-many-statements
@@ -87,6 +97,7 @@ def read_bytes(  # noqa: C901, pylint: disable=too-many-statements
     read_options: Dict,
     proc_num: int,
     proc_index: int,
+    accumulate: bool = False,
 ):
     """Read bytes from external storage and produce a ByteStream,
     which will later be assembled into a ParallelStream.
@@ -136,18 +147,28 @@ def read_bytes(  # noqa: C901, pylint: disable=too-many-statements
             sys.exit(-1)
     files = sorted(files)
 
-    stream, writer = None, None
+    stream, writer, chunks = None, None, []
     try:
         for index, file_path in enumerate(files):
-            if index == 0:
+            if index == 0 and not accumulate:
                 stream = DataframeStream.new(client, {})
                 client.persist(stream.id)
                 report_success(stream.id)
                 writer = stream.open_writer(client)
             read_parquet_blocks(
-                fs, file_path, read_options, proc_num, proc_index, writer
+                client,
+                fs,
+                file_path,
+                read_options,
+                proc_num,
+                proc_index,
+                writer,
+                chunks,
             )
-        writer.finish()
+        if writer is not None:
+            writer.finish()
+        else:
+            report_success(json.dumps([repr(vineyard.ObjectID(k)) for k in chunks]))
     except Exception:  # pylint: disable=broad-except
         report_exception()
         if writer is not None:
@@ -159,7 +180,7 @@ def main():
     if len(sys.argv) < 7:
         print(
             "usage: ./read_parquet <ipc_socket> <path> <storage_options> "
-            "<read_options> <proc_num> <proc_index>"
+            "<read_options> <accumulate> <proc_num> <proc_index>"
         )
         sys.exit(1)
     ipc_socket = sys.argv[1]
@@ -170,9 +191,18 @@ def main():
     read_options = json.loads(
         base64.b64decode(sys.argv[4].encode("utf-8")).decode("utf-8")
     )
-    proc_num = int(sys.argv[5])
-    proc_index = int(sys.argv[6])
-    read_bytes(ipc_socket, path, storage_options, read_options, proc_num, proc_index)
+    accumulate = str_to_bool(sys.argv[5])
+    proc_num = int(sys.argv[6])
+    proc_index = int(sys.argv[7])
+    read_bytes(
+        ipc_socket,
+        path,
+        storage_options,
+        read_options,
+        proc_num,
+        proc_index,
+        accumulate=accumulate,
+    )
 
 
 if __name__ == "__main__":

--- a/modules/io/python/drivers/io/adaptors/read_vineyard_dataframe.py
+++ b/modules/io/python/drivers/io/adaptors/read_vineyard_dataframe.py
@@ -52,12 +52,15 @@ def read_vineyard_dataframe(
     except Exception:  # pylint: disable=broad-except
         df_id = vineyard.ObjectID(name)
     dataframes = client.get(df_id)
+    if not isinstance(dataframes, (tuple, list)):
+        dataframes = [dataframes]
 
     writer: DataframeStream.Writer = stream.open_writer(client)
 
     try:
-        for df in dataframes:
-            batch = pa.RecordBatch.from_pandas(df)
+        for batch in dataframes:
+            if not isinstance(batch, pa.RecordBatch):
+                batch = pa.RecordBatch.from_pandas(batch)
             writer.write(batch)
         writer.finish()
     except Exception:  # pylint: disable=broad-except

--- a/modules/io/python/drivers/io/tests/test_open.py
+++ b/modules/io/python/drivers/io/tests/test_open.py
@@ -71,6 +71,47 @@ def test_local_csv_with_header(
             mode="w",
             vineyard_ipc_socket=vineyard_ipc_socket,
             vineyard_endpoint=vineyard_endpoint,
+            write_options={"header_row": True, "delimiter": " "},
+            handlers=handlers,
+        )
+
+    e.print()
+    _ = [handler.join() for handler in handlers]
+    e.check()
+
+    assert filecmp.cmp(
+        "%s/p2p-31.e" % test_dataset, "%s/p2p-31.out_0" % test_dataset_tmp
+    )
+
+
+def test_local_csv_with_header_accumulate(
+    vineyard_ipc_socket, vineyard_endpoint, test_dataset, test_dataset_tmp
+):
+    handlers = []
+    dataframe = vineyard.io.open(
+        "file://%s/p2p-31.e" % test_dataset,
+        vineyard_ipc_socket=vineyard_ipc_socket,
+        vineyard_endpoint=vineyard_endpoint,
+        read_options={"header_row": True, "delimiter": " "},
+        handlers=handlers,
+        accumulate=True,
+    )
+    if isinstance(dataframe, vineyard.ObjectMeta):
+        dataframe = dataframe.id
+    stream = vineyard.io.open(
+        "vineyard://%s" % repr(dataframe),
+        vineyard_ipc_socket=vineyard_ipc_socket,
+        vineyard_endpoint=vineyard_endpoint,
+        handlers=handlers,
+    )
+    with capture_exception() as e:
+        vineyard.io.open(
+            "file://%s/p2p-31.out" % test_dataset_tmp,
+            stream,
+            mode="w",
+            vineyard_ipc_socket=vineyard_ipc_socket,
+            vineyard_endpoint=vineyard_endpoint,
+            write_options={"header_row": True, "delimiter": " "},
             handlers=handlers,
         )
 
@@ -101,6 +142,47 @@ def test_local_csv_without_header(
             mode="w",
             vineyard_ipc_socket=vineyard_ipc_socket,
             vineyard_endpoint=vineyard_endpoint,
+            write_options={"header_row": False, "delimiter": " "},
+            handlers=handlers,
+        )
+
+    e.print()
+    _ = [handler.join() for handler in handlers]
+    e.check()
+
+    assert filecmp.cmp(
+        "%s/p2p-31.e" % test_dataset, "%s/p2p-31.out_0" % test_dataset_tmp
+    )
+
+
+def test_local_csv_without_header_accumulate(
+    vineyard_ipc_socket, vineyard_endpoint, test_dataset, test_dataset_tmp
+):
+    handlers = []
+    dataframe = vineyard.io.open(
+        "file://%s/p2p-31.e" % test_dataset,
+        vineyard_ipc_socket=vineyard_ipc_socket,
+        vineyard_endpoint=vineyard_endpoint,
+        read_options={"header_row": False, "delimiter": " "},
+        handlers=handlers,
+        accumulate=True,
+    )
+    if isinstance(dataframe, vineyard.ObjectMeta):
+        dataframe = dataframe.id
+    stream = vineyard.io.open(
+        "vineyard://%s" % repr(dataframe),
+        vineyard_ipc_socket=vineyard_ipc_socket,
+        vineyard_endpoint=vineyard_endpoint,
+        handlers=handlers,
+    )
+    with capture_exception() as e:
+        vineyard.io.open(
+            "file://%s/p2p-31.out" % test_dataset_tmp,
+            stream,
+            mode="w",
+            vineyard_ipc_socket=vineyard_ipc_socket,
+            vineyard_endpoint=vineyard_endpoint,
+            write_options={"header_row": False, "delimiter": " "},
             handlers=handlers,
         )
 
@@ -144,12 +226,91 @@ def test_local_parquet_to_csv(
     )
 
 
+def test_local_parquet_to_csv_accumulate(
+    vineyard_ipc_socket, vineyard_endpoint, test_dataset, test_dataset_tmp
+):
+    handlers = []
+    dataframe = vineyard.io.open(
+        "file://%s/p2p-31.e.parquet" % test_dataset,
+        vineyard_ipc_socket=vineyard_ipc_socket,
+        vineyard_endpoint=vineyard_endpoint,
+        handlers=handlers,
+        accumulate=True,
+    )
+    if isinstance(dataframe, vineyard.ObjectMeta):
+        dataframe = dataframe.id
+    stream = vineyard.io.open(
+        "vineyard://%s" % repr(dataframe),
+        vineyard_ipc_socket=vineyard_ipc_socket,
+        vineyard_endpoint=vineyard_endpoint,
+        handlers=handlers,
+    )
+    with capture_exception() as e:
+        vineyard.io.open(
+            "file://%s/p2p-31.out" % test_dataset_tmp,
+            stream,
+            mode="w",
+            vineyard_ipc_socket=vineyard_ipc_socket,
+            vineyard_endpoint=vineyard_endpoint,
+            write_options={"header_row": False, "delimiter": " "},
+            handlers=handlers,
+        )
+
+    e.print()
+    _ = [handler.join() for handler in handlers]
+    e.check()
+
+    print('finish joined: ', flush=True)
+    assert filecmp.cmp(
+        "%s/p2p-31.e" % test_dataset, "%s/p2p-31.out_0" % test_dataset_tmp
+    )
+
+
 def test_local_orc_to_csv(
     vineyard_ipc_socket, vineyard_endpoint, test_dataset, test_dataset_tmp
 ):
     handlers = []
     stream = vineyard.io.open(
         "file://%s/p2p-31.e.orc" % test_dataset,
+        vineyard_ipc_socket=vineyard_ipc_socket,
+        vineyard_endpoint=vineyard_endpoint,
+        handlers=handlers,
+    )
+    with capture_exception() as e:
+        vineyard.io.open(
+            "file://%s/p2p-31.out" % test_dataset_tmp,
+            stream,
+            mode="w",
+            vineyard_ipc_socket=vineyard_ipc_socket,
+            vineyard_endpoint=vineyard_endpoint,
+            write_options={"header_row": False, "delimiter": " "},
+            handlers=handlers,
+        )
+
+    e.print()
+    _ = [handler.join() for handler in handlers]
+    e.check()
+
+    assert filecmp.cmp(
+        "%s/p2p-31.e" % test_dataset, "%s/p2p-31.out_0" % test_dataset_tmp
+    )
+
+
+def test_local_orc_to_csv_accumulate(
+    vineyard_ipc_socket, vineyard_endpoint, test_dataset, test_dataset_tmp
+):
+    handlers = []
+    dataframe = vineyard.io.open(
+        "file://%s/p2p-31.e.orc" % test_dataset,
+        vineyard_ipc_socket=vineyard_ipc_socket,
+        vineyard_endpoint=vineyard_endpoint,
+        handlers=handlers,
+        accumulate=True,
+    )
+    if isinstance(dataframe, vineyard.ObjectMeta):
+        dataframe = dataframe.id
+    stream = vineyard.io.open(
+        "vineyard://%s" % repr(dataframe),
         vineyard_ipc_socket=vineyard_ipc_socket,
         vineyard_endpoint=vineyard_endpoint,
         handlers=handlers,

--- a/python/vineyard/cli.py
+++ b/python/vineyard/cli.py
@@ -747,7 +747,7 @@ def get_tree(meta, tree, memory=False, memory_dict=None, parent=None):
     tree.create_node(node, node, parent=parent)
     parent = node
     for key in meta:
-        if isinstance(meta[key], vineyard._C.ObjectMeta):
+        if isinstance(meta[key], vineyard.ObjectMeta):
             get_tree(meta[key], tree, memory, memory_dict, parent)
 
 
@@ -755,7 +755,7 @@ def get_memory_used(meta):
     """Utility to get the memory used by the vineyard object."""
     total_bytes = 0
     for key in meta:
-        if isinstance(meta[key], vineyard._C.ObjectMeta):
+        if isinstance(meta[key], vineyard.ObjectMeta):
             if str(meta[key]['typename']) == 'vineyard::Blob':
                 size = meta[key]['length']
                 total_bytes += size

--- a/python/vineyard/data/dataframe.py
+++ b/python/vineyard/data/dataframe.py
@@ -189,7 +189,8 @@ def global_dataframe_resolver(obj, resolver):
         df = meta.get_member('partitions_-%d' % i)
         if df.meta.islocal:
             dataframes.append(resolver.run(df))
-            orders.append(df.meta["row_batch_index_"])
+            if 'row_batch_index_' in df.meta:
+                orders.append(df.meta["row_batch_index_"])
     if orders != sorted(orders):
         raise ValueError("Bad dataframe orders:", orders)
     return dataframes

--- a/python/vineyard/io/stream.py
+++ b/python/vineyard/io/stream.py
@@ -33,7 +33,7 @@ logger = logging.getLogger('vineyard')
 
 
 @registerize
-def read(path, *args, handlers=None, **kwargs):
+def read(path, *args, handlers=None, accumulate=False, **kwargs):
     """Open a path and read it as a single stream.
 
     Parameters
@@ -41,6 +41,13 @@ def read(path, *args, handlers=None, **kwargs):
     path: str
         Path to read, the last reader registered for the scheme of
         the path will be used.
+    handlers: list, optional
+        If handlers is not None, launched worker processes will be
+        emplaced into the list for further customized job lifecycle
+        management. Default is None.
+    accumulate: bool, optional
+        If :code:`accumulate` is True, it will return a data frame,
+        rather than dataframe stream. Default is False.
     vineyard_ipc_socket: str
         The local or remote vineyard's IPC socket location that the
         remote readers will use to establish connections with the
@@ -63,6 +70,7 @@ def read(path, *args, handlers=None, **kwargs):
                     proc_kwargs.pop('vineyard_ipc_socket'),
                     *args,
                     handlers=handlers,
+                    accumulate=accumulate,
                     **proc_kwargs
                 )
                 if r is not None:
@@ -88,6 +96,10 @@ def write(path, stream, *args, handlers=None, **kwargs):
         will be used.
     stream: vineyard stream
         Stream that produces the data to write.
+    handlers: list, optional
+        If handlers is not None, launched worker processes will be
+        emplaced into the list for further customized job lifecycle
+        management. Default is None.
     vineyard_ipc_socket: str
         The local or remote vineyard's IPC socket location that the remote
         readers will use to establish connections with the vineyard server.
@@ -140,14 +152,14 @@ def open(path, *args, mode='r', handlers=None, **kwargs):
         Path to open.
     mode: char
         Mode about how to open the path, :code:`r` is for read and :code:`w` for write.
-    vineyard_ipc_socket: str
-        Vineyard's IPC socket location.
-    vineyard_endpoint: str
-        Vineyard's RPC socket address.
     handlers:
         A dict that will be filled with a :code:`handler` that contains the process
         handler of the underlying read/write process that can be joined using
         :code:`join` to capture the possible errors during the I/O proceeding.
+    vineyard_ipc_socket: str
+        Vineyard's IPC socket location.
+    vineyard_endpoint: str
+        Vineyard's RPC socket address.
 
     See Also
     --------

--- a/python/vineyard/launcher/script.py
+++ b/python/vineyard/launcher/script.py
@@ -57,7 +57,7 @@ class ScriptLauncher(Launcher):  # pylint: disable=too-many-instance-attributes
     def exit_code(self):
         return self._exit_code
 
-    def run(self, *args, **kw):
+    def run(self, *args, **kwargs):
         # FIXME run self._script on a set of host machines, the host is decided
         # by the arguments of the launcher in `__init__`, and those inputs object
         cmd = [self._script]
@@ -67,7 +67,7 @@ class ScriptLauncher(Launcher):  # pylint: disable=too-many-instance-attributes
             else:
                 cmd.append(repr(arg))
         env = os.environ.copy()
-        for key, value in kw.items():
+        for key, value in kwargs.items():
             # if key is all in lower cases, treat it as arguments, otherwise as the
             # environment variables.
             if key.islower():


### PR DESCRIPTION


What do these changes do?
-------------------------

Add `accumulate=False/True` option to `vineyard.io.open()` to read CSV/Parquet/ORC directly to global dataframes.

Related issue number
--------------------

Fixes #1136

