### PR TITLE
Make sure use dataframe in GlobalDataFrame

### DIFF
--- a/modules/io/python/drivers/io/adaptors/parse_bytes_to_dataframe.py
+++ b/modules/io/python/drivers/io/adaptors/parse_bytes_to_dataframe.py
@@ -157,7 +157,7 @@ def parse_bytes(  # noqa: C901, pylint: disable=too-many-statements
                 stream_writer.write_table(table)
             else:
                 for batch in table.to_batches():
-                    chunks.append(client.put(batch, persist=True))
+                    chunks.append(client.put(batch.to_pandas(), persist=True))
     except Exception:  # pylint: disable=broad-except
         report_exception()
         stream_writer.fail()

--- a/modules/io/python/drivers/io/adaptors/read_orc.py
+++ b/modules/io/python/drivers/io/adaptors/read_orc.py
@@ -75,13 +75,13 @@ def read_orc_blocks(
                 if writer is not None:
                     writer.write(batch)
                 else:
-                    chunks.append(client.put(batch, persist=True))
+                    chunks.append(client.put(batch.to_pandas(), persist=True))
         else:
             batch = make_empty_batch(reader.schema)
             if writer is not None:
                 writer.write(batch)
             else:
-                chunks.append(client.put(batch, persist=True))
+                chunks.append(client.put(batch.to_pandas(), persist=True))
 
 
 def read_bytes(  # noqa: C901, pylint: disable=too-many-statements

--- a/modules/io/python/drivers/io/adaptors/read_parquet.py
+++ b/modules/io/python/drivers/io/adaptors/read_parquet.py
@@ -81,13 +81,13 @@ def read_parquet_blocks(
                 if writer is not None:
                     writer.write(batch)
                 else:
-                    chunks.append(client.put(batch, persist=True))
+                    chunks.append(client.put(batch.to_pandas(), persist=True))
         else:
             batch = make_empty_batch(reader.schema_arrow)
             if writer is not None:
                 writer.write(batch)
             else:
-                chunks.append(client.put(batch, persist=True))
+                chunks.append(client.put(batch.to_pandas(), persist=True))
 
 
 def read_bytes(  # noqa: C901, pylint: disable=too-many-statements


### PR DESCRIPTION
What do these changes do?
-------------------------

Mixing recordbatch into global dataframe would cause some problems in mars integration.

Credited to @dashanji.
