### PR TITLE
Less copy between in-process memory and vineyard during building a fragment

### DIFF
--- a/modules/basic/ds/arrow.cc
+++ b/modules/basic/ds/arrow.cc
@@ -314,6 +314,59 @@ template class NumericArrayBuilder<uint64_t>;
 template class NumericArrayBuilder<float>;
 template class NumericArrayBuilder<double>;
 
+template <typename T>
+FixedNumericArrayBuilder<T>::FixedNumericArrayBuilder(Client& client,
+                                                      const size_t size)
+    : NumericArrayBaseBuilder<T>(client), size_(size) {
+  if (size_ > 0) {
+    VINEYARD_CHECK_OK(client.CreateBlob(size_ * sizeof(T), writer_));
+    data_ = reinterpret_cast<T*>(writer_->data());
+  }
+}
+
+template <typename T>
+size_t FixedNumericArrayBuilder<T>::size() const {
+  return size_;
+}
+
+template <typename T>
+T* FixedNumericArrayBuilder<T>::MutablePointer(int64_t i) const {
+  if (data_) {
+    return data_ + i;
+  }
+  return nullptr;
+}
+
+template <typename T>
+T* FixedNumericArrayBuilder<T>::data() const {
+  return data_;
+}
+
+template <typename T>
+Status FixedNumericArrayBuilder<T>::Build(Client& client) {
+  this->set_length_(size_);
+  this->set_null_count_(0);
+  this->set_offset_(0);
+  if (size_ > 0) {
+    this->set_buffer_(std::move(writer_));
+  } else {
+    this->set_buffer_(Blob::MakeEmpty(client));
+  }
+  this->set_null_bitmap_(Blob::MakeEmpty(client));
+  return Status::OK();
+}
+
+template class FixedNumericArrayBuilder<int8_t>;
+template class FixedNumericArrayBuilder<int16_t>;
+template class FixedNumericArrayBuilder<int32_t>;
+template class FixedNumericArrayBuilder<int64_t>;
+template class FixedNumericArrayBuilder<uint8_t>;
+template class FixedNumericArrayBuilder<uint16_t>;
+template class FixedNumericArrayBuilder<uint32_t>;
+template class FixedNumericArrayBuilder<uint64_t>;
+template class FixedNumericArrayBuilder<float>;
+template class FixedNumericArrayBuilder<double>;
+
 BooleanArrayBuilder::BooleanArrayBuilder(Client& client)
     : BooleanArrayBaseBuilder(client) {
   std::shared_ptr<ArrayType> array;

--- a/modules/basic/ds/arrow_utils.h
+++ b/modules/basic/ds/arrow_utils.h
@@ -50,6 +50,9 @@ class NumericArray;
 template <typename T>
 class NumericArrayBuilder;
 
+template <typename T>
+class FixedNumericArrayBuilder;
+
 #define CONVERT_TO_ARROW_TYPE(type, data_type, array_type, builder_type,       \
                               type_value)                                      \
   template <>                                                                  \
@@ -59,6 +62,7 @@ class NumericArrayBuilder;
     using VineyardArrayType = NumericArray<type>;                              \
     using BuilderType = builder_type;                                          \
     using VineyardBuilderType = NumericArrayBuilder<type>;                     \
+    using FixedVineyardBuilderType = FixedNumericArrayBuilder<type>;           \
     static std::shared_ptr<arrow::DataType> TypeValue() { return type_value; } \
   };
 
@@ -78,6 +82,10 @@ using ArrowBuilderType = typename ConvertToArrowType<T>::BuilderType;
 template <typename T>
 using ArrowVineyardBuilderType =
     typename ConvertToArrowType<T>::VineyardBuilderType;
+
+template <typename T>
+using FixedArrowVineyardBuilderType =
+    typename ConvertToArrowType<T>::FixedVineyardBuilderType;
 
 CONVERT_TO_ARROW_TYPE(void, arrow::NullType, arrow::NullArray,
                       arrow::NullBuilder, arrow::null())

--- a/modules/graph/fragment/arrow_fragment.h
+++ b/modules/graph/fragment/arrow_fragment.h
@@ -112,7 +112,7 @@ class BasicArrowFragmentBuilder
 
   std::vector<std::vector<std::shared_ptr<PodArrayBuilder<nbr_unit_t>>>>
       ie_lists_, oe_lists_;
-  std::vector<std::vector<std::shared_ptr<arrow::Int64Array>>>
+  std::vector<std::vector<std::shared_ptr<FixedInt64Builder>>>
       ie_offsets_lists_, oe_offsets_lists_;
 
   std::shared_ptr<vertex_map_t> vm_ptr_;

--- a/modules/graph/fragment/arrow_fragment.vineyard-mod
+++ b/modules/graph/fragment/arrow_fragment.vineyard-mod
@@ -678,7 +678,7 @@ class [[vineyard]] ArrowFragment
       vineyard::Client & client,
       std::vector<std::vector<std::shared_ptr<PodArrayBuilder<nbr_unit_t>>>> &
           oe_lists,
-      std::vector<std::vector<std::shared_ptr<arrow::Int64Array>>> &
+      std::vector<std::vector<std::shared_ptr<FixedInt64Builder>>> &
           oe_offsets_lists,
       int concurrency, bool& is_multigraph);
 

--- a/modules/graph/fragment/property_graph_utils.h
+++ b/modules/graph/fragment/property_graph_utils.h
@@ -98,14 +98,13 @@ template <typename VID_T, typename EID_T>
 void sort_edges_with_respect_to_vertex(
     vineyard::PodArrayBuilder<property_graph_utils::NbrUnit<VID_T, EID_T>>&
         builder,
-    std::shared_ptr<arrow::Int64Array> offsets, VID_T tvnum, int concurrency);
+    const int64_t* offsets, VID_T tvnum, int concurrency);
 
 template <typename VID_T, typename EID_T>
 void check_is_multigraph(
     vineyard::PodArrayBuilder<property_graph_utils::NbrUnit<VID_T, EID_T>>&
         builder,
-    std::shared_ptr<arrow::Int64Array> offsets, VID_T tvnum, int concurrency,
-    bool& is_multigraph);
+    const int64_t* offsets, VID_T tvnum, int concurrency, bool& is_multigraph);
 
 /**
  * @brief Generate CSR from given COO.
@@ -118,7 +117,7 @@ boost::leaf::result<void> generate_directed_csr(
     std::vector<VID_T> tvnums, int vertex_label_num, int concurrency,
     std::vector<std::shared_ptr<
         PodArrayBuilder<property_graph_utils::NbrUnit<VID_T, EID_T>>>>& edges,
-    std::vector<std::shared_ptr<arrow::Int64Array>>& edge_offsets,
+    std::vector<std::shared_ptr<FixedInt64Builder>>& edge_offsets,
     bool& is_multigraph);
 
 /**
@@ -130,10 +129,10 @@ boost::leaf::result<void> generate_directed_csc(
     int vertex_label_num, int concurrency,
     std::vector<std::shared_ptr<
         PodArrayBuilder<property_graph_utils::NbrUnit<VID_T, EID_T>>>>& oedges,
-    std::vector<std::shared_ptr<arrow::Int64Array>>& oedge_offsets,
+    std::vector<std::shared_ptr<FixedInt64Builder>>& oedge_offsets,
     std::vector<std::shared_ptr<
         PodArrayBuilder<property_graph_utils::NbrUnit<VID_T, EID_T>>>>& iedges,
-    std::vector<std::shared_ptr<arrow::Int64Array>>& iedge_offsets,
+    std::vector<std::shared_ptr<FixedInt64Builder>>& iedge_offsets,
     bool& is_multigraph);
 
 /**
@@ -148,7 +147,7 @@ boost::leaf::result<void> generate_undirected_csr(
     std::vector<VID_T> tvnums, int vertex_label_num, int concurrency,
     std::vector<std::shared_ptr<
         PodArrayBuilder<property_graph_utils::NbrUnit<VID_T, EID_T>>>>& edges,
-    std::vector<std::shared_ptr<arrow::Int64Array>>& edge_offsets,
+    std::vector<std::shared_ptr<FixedInt64Builder>>& edge_offsets,
     bool& is_multigraph);
 
 /**
@@ -163,7 +162,7 @@ boost::leaf::result<void> generate_undirected_csr_memopt(
     std::vector<VID_T> tvnums, int vertex_label_num, int concurrency,
     std::vector<std::shared_ptr<
         PodArrayBuilder<property_graph_utils::NbrUnit<VID_T, EID_T>>>>& edges,
-    std::vector<std::shared_ptr<arrow::Int64Array>>& edge_offsets,
+    std::vector<std::shared_ptr<FixedInt64Builder>>& edge_offsets,
     bool& is_multigraph);
 
 }  // namespace vineyard

--- a/modules/graph/fragment/property_graph_utils_uint32.cc
+++ b/modules/graph/fragment/property_graph_utils_uint32.cc
@@ -42,13 +42,12 @@ template boost::leaf::result<void> generate_local_id_list<uint32_t>(
 template void sort_edges_with_respect_to_vertex<uint32_t, uint64_t>(
     vineyard::PodArrayBuilder<
         property_graph_utils::NbrUnit<uint32_t, uint64_t>>& builder,
-    std::shared_ptr<arrow::Int64Array> offsets, uint32_t tvnum,
-    int concurrency);
+    const int64_t* offsets, uint32_t tvnum, int concurrency);
 
 template void check_is_multigraph<uint32_t, uint64_t>(
     vineyard::PodArrayBuilder<
         property_graph_utils::NbrUnit<uint32_t, uint64_t>>& builder,
-    std::shared_ptr<arrow::Int64Array> offsets, uint32_t tvnum, int concurrency,
+    const int64_t* offsets, uint32_t tvnum, int concurrency,
     bool& is_multigraph);
 
 template boost::leaf::result<void> generate_directed_csr<uint32_t, uint64_t>(
@@ -59,7 +58,7 @@ template boost::leaf::result<void> generate_directed_csr<uint32_t, uint64_t>(
     std::vector<std::shared_ptr<
         PodArrayBuilder<property_graph_utils::NbrUnit<uint32_t, uint64_t>>>>&
         edges,
-    std::vector<std::shared_ptr<arrow::Int64Array>>& edge_offsets,
+    std::vector<std::shared_ptr<FixedInt64Builder>>& edge_offsets,
     bool& is_multigraph);
 
 template boost::leaf::result<void> generate_directed_csc<uint32_t, uint64_t>(
@@ -68,11 +67,11 @@ template boost::leaf::result<void> generate_directed_csc<uint32_t, uint64_t>(
     std::vector<std::shared_ptr<
         PodArrayBuilder<property_graph_utils::NbrUnit<uint32_t, uint64_t>>>>&
         oedges,
-    std::vector<std::shared_ptr<arrow::Int64Array>>& oedge_offsets,
+    std::vector<std::shared_ptr<FixedInt64Builder>>& oedge_offsets,
     std::vector<std::shared_ptr<
         PodArrayBuilder<property_graph_utils::NbrUnit<uint32_t, uint64_t>>>>&
         iedges,
-    std::vector<std::shared_ptr<arrow::Int64Array>>& iedge_offsets,
+    std::vector<std::shared_ptr<FixedInt64Builder>>& iedge_offsets,
     bool& is_multigraph);
 
 template boost::leaf::result<void> generate_undirected_csr<uint32_t, uint64_t>(
@@ -83,7 +82,7 @@ template boost::leaf::result<void> generate_undirected_csr<uint32_t, uint64_t>(
     std::vector<std::shared_ptr<
         PodArrayBuilder<property_graph_utils::NbrUnit<uint32_t, uint64_t>>>>&
         edges,
-    std::vector<std::shared_ptr<arrow::Int64Array>>& edge_offsets,
+    std::vector<std::shared_ptr<FixedInt64Builder>>& edge_offsets,
     bool& is_multigraph);
 
 template boost::leaf::result<void>
@@ -95,7 +94,7 @@ generate_undirected_csr_memopt<uint32_t, uint64_t>(
     std::vector<std::shared_ptr<
         PodArrayBuilder<property_graph_utils::NbrUnit<uint32_t, uint64_t>>>>&
         edges,
-    std::vector<std::shared_ptr<arrow::Int64Array>>& edge_offsets,
+    std::vector<std::shared_ptr<FixedInt64Builder>>& edge_offsets,
     bool& is_multigraph);
 
 }  // namespace vineyard

--- a/modules/graph/fragment/property_graph_utils_uint64.cc
+++ b/modules/graph/fragment/property_graph_utils_uint64.cc
@@ -42,13 +42,12 @@ template boost::leaf::result<void> generate_local_id_list<uint64_t>(
 template void sort_edges_with_respect_to_vertex<uint64_t, uint64_t>(
     vineyard::PodArrayBuilder<
         property_graph_utils::NbrUnit<uint64_t, uint64_t>>& builder,
-    std::shared_ptr<arrow::Int64Array> offsets, uint64_t tvnum,
-    int concurrency);
+    const int64_t* offsets, uint64_t tvnum, int concurrency);
 
 template void check_is_multigraph<uint64_t, uint64_t>(
     vineyard::PodArrayBuilder<
         property_graph_utils::NbrUnit<uint64_t, uint64_t>>& builder,
-    std::shared_ptr<arrow::Int64Array> offsets, uint64_t tvnum, int concurrency,
+    const int64_t* offsets, uint64_t tvnum, int concurrency,
     bool& is_multigraph);
 
 template boost::leaf::result<void> generate_directed_csr<uint64_t, uint64_t>(
@@ -59,7 +58,7 @@ template boost::leaf::result<void> generate_directed_csr<uint64_t, uint64_t>(
     std::vector<std::shared_ptr<
         PodArrayBuilder<property_graph_utils::NbrUnit<uint64_t, uint64_t>>>>&
         edges,
-    std::vector<std::shared_ptr<arrow::Int64Array>>& edge_offsets,
+    std::vector<std::shared_ptr<FixedInt64Builder>>& edge_offsets,
     bool& is_multigraph);
 
 template boost::leaf::result<void> generate_directed_csc<uint64_t, uint64_t>(
@@ -68,11 +67,11 @@ template boost::leaf::result<void> generate_directed_csc<uint64_t, uint64_t>(
     std::vector<std::shared_ptr<
         PodArrayBuilder<property_graph_utils::NbrUnit<uint64_t, uint64_t>>>>&
         oedges,
-    std::vector<std::shared_ptr<arrow::Int64Array>>& oedge_offsets,
+    std::vector<std::shared_ptr<FixedInt64Builder>>& oedge_offsets,
     std::vector<std::shared_ptr<
         PodArrayBuilder<property_graph_utils::NbrUnit<uint64_t, uint64_t>>>>&
         iedges,
-    std::vector<std::shared_ptr<arrow::Int64Array>>& iedge_offsets,
+    std::vector<std::shared_ptr<FixedInt64Builder>>& iedge_offsets,
     bool& is_multigraph);
 
 template boost::leaf::result<void> generate_undirected_csr<uint64_t, uint64_t>(
@@ -83,7 +82,7 @@ template boost::leaf::result<void> generate_undirected_csr<uint64_t, uint64_t>(
     std::vector<std::shared_ptr<
         PodArrayBuilder<property_graph_utils::NbrUnit<uint64_t, uint64_t>>>>&
         edges,
-    std::vector<std::shared_ptr<arrow::Int64Array>>& edge_offsets,
+    std::vector<std::shared_ptr<FixedInt64Builder>>& edge_offsets,
     bool& is_multigraph);
 
 template boost::leaf::result<void>
@@ -95,7 +94,7 @@ generate_undirected_csr_memopt<uint64_t, uint64_t>(
     std::vector<std::shared_ptr<
         PodArrayBuilder<property_graph_utils::NbrUnit<uint64_t, uint64_t>>>>&
         edges,
-    std::vector<std::shared_ptr<arrow::Int64Array>>& edge_offsets,
+    std::vector<std::shared_ptr<FixedInt64Builder>>& edge_offsets,
     bool& is_multigraph);
 
 }  // namespace vineyard

--- a/modules/graph/loader/arrow_fragment_loader.cc
+++ b/modules/graph/loader/arrow_fragment_loader.cc
@@ -50,12 +50,12 @@ static Status ReadRecordBatchesFromVineyardStreamImpl(
   size_t end_to_read =
       std::min(local_streams.size(), (part_id + 1) * split_size);
 
-  VLOG(10) << "reading recordbatches from vineyard: total chunks = "
-           << local_streams.size() << ", part id = " << part_id
-           << ", part num = " << part_num
-           << ", start to read = " << start_to_read
-           << ", end to read = " << end_to_read
-           << ", split size = " << split_size;
+  VLOG(100) << "reading recordbatches from vineyard: total chunks = "
+            << local_streams.size() << ", part id = " << part_id
+            << ", part num = " << part_num
+            << ", start to read = " << start_to_read
+            << ", end to read = " << end_to_read
+            << ", split size = " << split_size;
 
   std::mutex mutex_for_results;
 
@@ -71,9 +71,7 @@ static Status ReadRecordBatchesFromVineyardStreamImpl(
     RETURN_ON_ERROR(stream->ReadRecordBatches(read_batches));
     {
       std::lock_guard<std::mutex> scoped_lock(mutex_for_results);
-      for (auto const& batch : read_batches) {
-        batches.emplace_back(batch);
-      }
+      batches.insert(batches.end(), read_batches.begin(), read_batches.end());
     }
     return Status::OK();
   };

--- a/modules/graph/loader/arrow_fragment_loader_impl.h
+++ b/modules/graph/loader/arrow_fragment_loader_impl.h
@@ -313,8 +313,8 @@ ArrowFragmentLoader<OID_T, VID_T, VERTEX_MAP_T>::loadVertexTables(
         VY_OK_OR_RAISE(ReadTableFromVineyard(client_, sourceId, table, index,
                                              total_parts));
       } else {
-        VY_OK_OR_RAISE(ReadTableFromLocation(
-            files[label_id] + "#header_row=true", table, index, total_parts));
+        VY_OK_OR_RAISE(
+            ReadTableFromLocation(files[label_id], table, index, total_parts));
       }
       return table;
     };

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -351,7 +351,8 @@ Status Client::PullNextStreamChunk(ObjectID const id,
 std::shared_ptr<Object> Client::GetObject(const ObjectID id) {
   ObjectMeta meta;
   RETURN_NULL_ON_ERROR(this->GetMetaData(id, meta, true));
-  RETURN_NULL_ON_ASSERT(!meta.MetaData().empty());
+  RETURN_NULL_ON_ASSERT(!meta.MetaData().empty(),
+                        "metadata shouldn't be empty");
   auto object = ObjectFactory::Create(meta.GetTypeName());
   if (object == nullptr) {
     object = std::unique_ptr<Object>(new Object());

--- a/src/common/util/env.cc
+++ b/src/common/util/env.cc
@@ -109,7 +109,13 @@ void create_dirs(const char* path) {
  * c.f.: https://stackoverflow.com/a/14927379/5080177
  */
 size_t get_rss(bool include_shared_memory) {
+  // why "trim_rss" first?
+  //
+  //  - for more accurate statistics
+  //  - as a hint for allocator to release pages in places where `get_rss()`
+  //    is called (where memory information is in cencern) in programs.
   trim_rss();
+
 #if defined(__APPLE__) && defined(__MACH__)
   /* OSX ------------------------------------------------------ */
   struct mach_task_basic_info info;


### PR DESCRIPTION
What do these changes do?
-------------------------

as titled, avoid copying the "offset" arrays.

Related issue number
--------------------

N/A