### PR TITLE
Kubernetes CI: build latest vineyardd image from source

### DIFF
--- a/.github/workflows/vineyard-operator.yaml
+++ b/.github/workflows/vineyard-operator.yaml
@@ -149,6 +149,11 @@ jobs:
         run: |
           make -C docker build-python-dev
 
+      - name: Generate the vineyardd image for tests
+        if: ${{ matrix.job != 'release' }}
+        run: |
+          docker build . -f docker/Dockerfile.vineyardd -t vineyardcloudnative/vineyardd:alpine-latest
+
       - name: e2e-tests-assembly-local
         if: ${{ matrix.job == 'e2e-tests-assembly-local' }}
         run: |

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -94,6 +94,8 @@ install-vineyard-operator:
 # install the vineyard cluster and wait for ready
 install-vineyard-cluster:
 	@echo "Installing vineyard cluster..."
+	@docker tag vineyardcloudnative/vineyardd:alpine-latest localhost:5001/vineyardd:alpine-latest
+	@docker push localhost:5001/vineyardd:alpine-latest
 	@kubectl apply -f test/e2e/vineyardd.yaml --kubeconfig=/tmp/e2e-k8s.config
 	@kubectl wait vineyardd/vineyardd-sample --for condition=Available -n vineyard-system --timeout=300s --kubeconfig=/tmp/e2e-k8s.config
 	@echo "Vineyard cluster Ready"

--- a/k8s/test/e2e/vineyardd.yaml
+++ b/k8s/test/e2e/vineyardd.yaml
@@ -27,7 +27,7 @@ spec:
     type: ClusterIP
     port: 9600
   vineyardConfig:
-    image: ghcr.io/v6d-io/v6d/vineyardd:alpine-latest
+    image: localhost:5001/vineyardd:alpine-latest
     imagePullPolicy: IfNotPresent
   # Users can define their own plugin image here,
   # the next images are only for kubernetes CI test.


### PR DESCRIPTION
What do these changes do?
-------------------------

as titled, avoid using stale image to run CI.

Related issue number
--------------------

Address issue discussed in https://github.com/v6d-io/v6d/pull/1161#issuecomment-1408128311

