### PR TITLE
Add `evict/load/unpin` APIs

### DIFF
--- a/.github/workflows/build-test-graph.yml
+++ b/.github/workflows/build-test-graph.yml
@@ -19,6 +19,8 @@ on:
     paths:
       modules/graph
   pull_request:
+    branches:
+      - "*"
     paths:
       modules/graph
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -699,7 +699,6 @@ if(BUILD_VINEYARD_SERVER)
 
     install_vineyard_target(vineyardd)
     install_vineyard_headers("${PROJECT_SOURCE_DIR}/src/server")
-    target_enable_sanitizer(vineyardd PRIVATE)
     if(NOT BUILD_SHARED_LIBS)
         if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
             target_compile_options(vineyardd PRIVATE -static-libgcc -static-libstdc++ -Os)

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -234,6 +234,7 @@ The vineyard python package is built using the `manylinux1`_ environments. The
 release version is built with Docker. The description of the base image can be
 found at `docker/pypa/Dockerfile.manylinux1`_.
 
+.. _pre-commit: https://pre-commit.com/
 .. _file an issue: https://github.com/v6d-io/v6d/issues/new/new
 .. _manylinux1: https://github.com/pypa/manylinux
 .. _search: https://github.com/v6d-io/v6d/pulls

--- a/modules/basic/ds/dataframe.cc
+++ b/modules/basic/ds/dataframe.cc
@@ -181,10 +181,10 @@ void GlobalDataFrame::Construct(const ObjectMeta& meta) {
   this->meta_ = meta;
   this->id_ = meta.GetId();
 
-  if (meta.Haskey("partition_shape_row_")) {
+  if (meta.HasKey("partition_shape_row_")) {
     meta.GetKeyValue("partition_shape_row_", this->partition_shape_row_);
   }
-  if (meta.Haskey("partition_shape_column_")) {
+  if (meta.HasKey("partition_shape_column_")) {
     meta.GetKeyValue("partition_shape_column_", this->partition_shape_column_);
   }
 

--- a/modules/basic/ds/tensor.cc
+++ b/modules/basic/ds/tensor.cc
@@ -31,10 +31,10 @@ void GlobalTensor::Construct(const ObjectMeta& meta) {
   this->meta_ = meta;
   this->id_ = meta.GetId();
 
-  if (meta.Haskey("shape_")) {
+  if (meta.HasKey("shape_")) {
     meta.GetKeyValue("shape_", this->shape_);
   }
-  if (meta.Haskey("partition_shape_")) {
+  if (meta.HasKey("partition_shape_")) {
     meta.GetKeyValue("partition_shape_", this->partition_shape_);
   }
   for (size_t __idx = 0; __idx < meta.GetKeyValue<size_t>("partitions_-size");

--- a/modules/graph/loader/fragment_loader_utils.cc
+++ b/modules/graph/loader/fragment_loader_utils.cc
@@ -285,9 +285,9 @@ EdgeTableInfo FlattenTableInfos(const std::vector<EdgeTableInfo>& edge_tables) {
 std::pair<int64_t, int64_t> BinarySearchChunkPair(
     const std::vector<int64_t>& agg_num, int64_t got) {
   // binary search;
-  int64_t low = 0, high = agg_num.size() - 1;
+  size_t low = 0, high = agg_num.size() - 1;
   while (low <= high) {
-    int64_t mid = (low + high) / 2;
+    size_t mid = (low + high) / 2;
     if (agg_num[mid] <= got &&
         (mid == agg_num.size() - 1 || agg_num[mid + 1] > got)) {
       return std::make_pair(mid, got - agg_num[mid]);

--- a/modules/graph/writer/arrow_fragment_writer_impl.h
+++ b/modules/graph/writer/arrow_fragment_writer_impl.h
@@ -238,7 +238,7 @@ boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::writeEdgeImpl(
 
   GraphArchive::EdgeChunkWriter writer(edge_info, graph_info_.GetPrefix(),
                                        adj_list_type);
-  int64_t vertex_chunk_num =
+  size_t vertex_chunk_num =
       std::ceil(vertices.size() / static_cast<double>(main_vertex_chunk_size));
 
   // collect properties

--- a/python/client.cc
+++ b/python/client.cc
@@ -413,6 +413,25 @@ void bind_client(py::module& mod) {
           },
           "object_id"_a)
       .def("clear", [](ClientBase* self) { throw_on_error(self->Clear()); })
+      .def(
+          "evict",
+          [](ClientBase* self, std::vector<ObjectID> const& objects) -> void {
+            throw_on_error(self->Evict(objects));
+          },
+          "objects"_a)
+      .def(
+          "load",
+          [](ClientBase* self, std::vector<ObjectID> const& objects,
+             const bool pin) -> void {
+            throw_on_error(self->Load(objects, pin));
+          },
+          "objects"_a, py::arg("pin") = false)
+      .def(
+          "unpin",
+          [](ClientBase* self, std::vector<ObjectID> const& objects) -> void {
+            throw_on_error(self->Unpin(objects));
+          },
+          "objects"_a)
       .def("reset", [](ClientBase* self) { throw_on_error(self->Clear()); })
       .def_property_readonly("connected", &Client::Connected)
       .def_property_readonly("instance_id", &Client::instance_id)

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -1464,7 +1464,7 @@ ObjectID SharedMemoryManager::resolveObjectID(const uintptr_t target,
   // if (key <= target && target < key + data_size) {
   if (key == target) {
 #if defined(WITH_VERBOSE)
-    std::clog << "[trace] resuing blob " << ObjectIDToString(object_id)
+    std::clog << "[trace] reusing blob " << ObjectIDToString(object_id)
               << " for pointer " << reinterpret_cast<void*>(target)
               << " (size is " << data_size << ")" << std::endl;
 #endif

--- a/src/client/client_base.cc
+++ b/src/client/client_base.cc
@@ -366,6 +366,36 @@ Status ClientBase::Clear() {
   return Status::OK();
 }
 
+Status ClientBase::Evict(std::vector<ObjectID> const& objects) {
+  std::string message_out;
+  WriteEvictRequest(objects, message_out);
+  RETURN_ON_ERROR(doWrite(message_out));
+  json message_in;
+  RETURN_ON_ERROR(doRead(message_in));
+  RETURN_ON_ERROR(ReadEvictReply(message_in));
+  return Status::OK();
+}
+
+Status ClientBase::Load(std::vector<ObjectID> const& objects, const bool pin) {
+  std::string message_out;
+  WriteLoadRequest(objects, pin, message_out);
+  RETURN_ON_ERROR(doWrite(message_out));
+  json message_in;
+  RETURN_ON_ERROR(doRead(message_in));
+  RETURN_ON_ERROR(ReadLoadReply(message_in));
+  return Status::OK();
+}
+
+Status ClientBase::Unpin(std::vector<ObjectID> const& objects) {
+  std::string message_out;
+  WriteUnpinRequest(objects, message_out);
+  RETURN_ON_ERROR(doWrite(message_out));
+  json message_in;
+  RETURN_ON_ERROR(doRead(message_in));
+  RETURN_ON_ERROR(ReadUnpinReply(message_in));
+  return Status::OK();
+}
+
 bool ClientBase::Connected() const {
   if (connected_ &&
       recv(vineyard_conn_, NULL, 1, MSG_PEEK | MSG_DONTWAIT) != -1) {

--- a/src/client/client_base.h
+++ b/src/client/client_base.h
@@ -426,6 +426,29 @@ class ClientBase {
   Status Clear();
 
   /**
+   * @brief Evict objects from the vineyardd server.
+   *
+   * @param objects Objects to be evicted.
+   */
+  Status Evict(std::vector<ObjectID> const& objects);
+
+  /**
+   * @brief Load objects to ensure they resident in vineyardd server's memory,
+   *        with an optional arguments to pin these objects to prevent from
+   *        being spilled.
+   *
+   * @param objects Objects to be reloaded, and possibly pinned.
+   */
+  Status Load(std::vector<ObjectID> const& objects, const bool pin = false);
+
+  /**
+   * @brief Unpin objects from the vineyardd server's memory
+   *
+   * @param objects Objects to be unpinned.
+   */
+  Status Unpin(std::vector<ObjectID> const& objects);
+
+  /**
    * @brief Check if the client still connects to the vineyard server.
    *
    * @return True when the connection is still alive, otherwise false.

--- a/src/common/util/protocols.cc
+++ b/src/common/util/protocols.cc
@@ -147,6 +147,12 @@ CommandType ParseCommandType(const std::string& str_type) {
     return CommandType::CreateGPUBufferRequest;
   } else if (str_type == "get_gpu_buffers_request") {
     return CommandType::GetGPUBuffersRequest;
+  } else if (str_type == "evict_request") {
+    return CommandType::EvictRequest;
+  } else if (str_type == "load_request") {
+    return CommandType::LoadRequest;
+  } else if (str_type == "unpin_request") {
+    return CommandType::UnpinRequest;
   } else {
     return CommandType::NullCommand;
   }
@@ -1878,7 +1884,7 @@ void WriteIncreaseReferenceCountRequest(const std::vector<ObjectID>& ids,
                                         std::string& msg) {
   json root;
   root["type"] = "increase_reference_count_request";
-  root["ids"] = std::vector<ObjectID>{ids};
+  root["ids"] = ids;
   encode_msg(root, msg);
 }
 
@@ -1897,6 +1903,82 @@ void WriteIncreaseReferenceCountReply(std::string& msg) {
 
 Status ReadIncreaseReferenceCountReply(json const& root) {
   CHECK_IPC_ERROR(root, "increase_reference_count_reply");
+  return Status::OK();
+}
+
+void WriteEvictRequest(const std::vector<ObjectID>& ids, std::string& msg) {
+  json root;
+  root["type"] = "evict_request";
+  root["ids"] = ids;
+  encode_msg(root, msg);
+}
+
+Status ReadEvictRequest(json const& root, std::vector<ObjectID>& ids) {
+  RETURN_ON_ASSERT(root["type"] == "evict_request");
+  ids = root["ids"].get_to(ids);
+  return Status::OK();
+}
+
+void WriteEvictReply(std::string& msg) {
+  json root;
+  root["type"] = "evict_reply";
+  encode_msg(root, msg);
+}
+
+Status ReadEvictReply(json const& root) {
+  CHECK_IPC_ERROR(root, "evict_reply");
+  return Status::OK();
+}
+
+void WriteLoadRequest(const std::vector<ObjectID>& ids, const bool pin,
+                      std::string& msg) {
+  json root;
+  root["type"] = "load_request";
+  root["ids"] = std::vector<ObjectID>{ids};
+  root["pin"] = pin;
+  encode_msg(root, msg);
+}
+
+Status ReadLoadRequest(json const& root, std::vector<ObjectID>& ids,
+                       bool& pin) {
+  RETURN_ON_ASSERT(root["type"] == "load_request");
+  ids = root["ids"].get_to(ids);
+  pin = root.value("pin", false);
+  return Status::OK();
+}
+
+void WriteLoadReply(std::string& msg) {
+  json root;
+  root["type"] = "load_reply";
+  encode_msg(root, msg);
+}
+
+Status ReadLoadReply(json const& root) {
+  CHECK_IPC_ERROR(root, "load_reply");
+  return Status::OK();
+}
+
+void WriteUnpinRequest(const std::vector<ObjectID>& ids, std::string& msg) {
+  json root;
+  root["type"] = "unpin_request";
+  root["ids"] = ids;
+  encode_msg(root, msg);
+}
+
+Status ReadUnpinRequest(json const& root, std::vector<ObjectID>& ids) {
+  RETURN_ON_ASSERT(root["type"] == "unpin_request");
+  ids = root["ids"].get_to(ids);
+  return Status::OK();
+}
+
+void WriteUnpinReply(std::string& msg) {
+  json root;
+  root["type"] = "unpin_reply";
+  encode_msg(root, msg);
+}
+
+Status ReadUnpinReply(json const& root) {
+  CHECK_IPC_ERROR(root, "unpin_reply");
   return Status::OK();
 }
 

--- a/src/common/util/protocols.h
+++ b/src/common/util/protocols.h
@@ -91,6 +91,9 @@ enum class CommandType {
   GetGPUBuffersRequest = 57,
   CreateDiskBufferRequest = 58,
   ListNameRequest = 59,
+  EvictRequest = 80,
+  LoadRequest = 81,  // = {load, load + pin}
+  UnpinRequest = 82,
 };
 
 enum class StoreType {
@@ -645,6 +648,31 @@ Status ReadIncreaseReferenceCountRequest(json const& root,
 void WriteIncreaseReferenceCountReply(std::string& msg);
 
 Status ReadIncreaseReferenceCountReply(json const& root);
+
+void WriteEvictRequest(const std::vector<ObjectID>& ids, std::string& msg);
+
+Status ReadEvictRequest(json const& root, std::vector<ObjectID>& ids);
+
+void WriteEvictReply(std::string& msg);
+
+Status ReadEvictReply(json const& root);
+
+void WriteLoadRequest(const std::vector<ObjectID>& ids, const bool pin,
+                      std::string& msg);
+
+Status ReadLoadRequest(json const& root, std::vector<ObjectID>& ids, bool& pin);
+
+void WriteLoadReply(std::string& msg);
+
+Status ReadLoadReply(json const& root);
+
+void WriteUnpinRequest(const std::vector<ObjectID>& ids, std::string& msg);
+
+Status ReadUnpinRequest(json const& root, std::vector<ObjectID>& ids);
+
+void WriteUnpinReply(std::string& msg);
+
+Status ReadUnpinReply(json const& root);
 
 }  // namespace vineyard
 

--- a/src/server/async/socket_server.h
+++ b/src/server/async/socket_server.h
@@ -174,6 +174,12 @@ class SocketConnection : public std::enable_shared_from_this<SocketConnection> {
 
   bool doGetGPUBuffers(json const& root);
 
+  bool doEvictObjects(json const& root);
+
+  bool doLoadObjects(json const& root);
+
+  bool doUnpinObjects(json const& root);
+
  protected:
   template <typename FROM, typename TO>
   Status MoveBuffers(std::map<FROM, TO> mapping,

--- a/src/server/memory/memory.h
+++ b/src/server/memory/memory.h
@@ -108,11 +108,11 @@ class BulkStoreBase {
   Status RemoveOwnership(std::set<ID> const& ids,
                          std::map<ID, P>& successed_ids);
 
-  void SetMemSpillUpBound(size_t mem_spill_upper_bound) {
-    mem_spill_upper_bound_ = mem_spill_upper_bound;
+  void SetMemSpillUpBound(const size_t mem_spill_upper_bound) {
+    mem_spill_upper_bound_ = static_cast<int64_t>(mem_spill_upper_bound);
   }
-  void SetMemSpillLowBound(size_t mem_spill_lower_bound) {
-    mem_spill_lower_bound_ = mem_spill_lower_bound;
+  void SetMemSpillLowBound(const size_t mem_spill_lower_bound) {
+    mem_spill_lower_bound_ = static_cast<int64_t>(mem_spill_lower_bound);
   }
 
  protected:
@@ -137,9 +137,8 @@ class BulkStoreBase {
 
   object_map_t objects_;
 
-  size_t mem_spill_upper_bound_;
-
-  size_t mem_spill_lower_bound_;
+  int64_t mem_spill_upper_bound_;
+  int64_t mem_spill_lower_bound_;
 };
 
 class BulkStore

--- a/src/server/server/vineyard_server.h
+++ b/src/server/server/vineyard_server.h
@@ -161,6 +161,13 @@ class VineyardServer : public std::enable_shared_from_this<VineyardServer> {
   Status MigrateObject(const ObjectID object_id,
                        callback_t<const ObjectID&> callback);
 
+  Status EvictObjects(const std::vector<ObjectID>& ids, callback_t<> callback);
+
+  Status LoadObjects(const std::vector<ObjectID>& ids, const bool pin,
+                     callback_t<> callback);
+
+  Status UnpinObjects(const std::vector<ObjectID>& ids, callback_t<> callback);
+
   Status ClusterInfo(callback_t<const json&> callback);
 
   Status InstanceStatus(callback_t<const json&> callback);

--- a/src/server/util/file_io_adaptor.cc
+++ b/src/server/util/file_io_adaptor.cc
@@ -22,8 +22,8 @@ limitations under the License.
 #include "arrow/filesystem/filesystem.h"
 #include "common/util/arrow.h"
 
-namespace util {
-using vineyard::Status;
+namespace vineyard {
+namespace io {
 
 FileIOAdaptor::FileIOAdaptor(const std::string& location) {
   // TODO(ZjuYTW): Maybe we should check the validation of dir_path
@@ -113,15 +113,19 @@ Status FileIOAdaptor::CreateDir(const std::string& path) {
 }
 
 Status FileIOAdaptor::DeleteDir() {
-  return Status::ArrowError(fs_->DeleteDir(location_));
+  auto _ = fs_->DeleteDir(location_);  // discard the deletion error
+  return Status::OK();
 }
 
 Status FileIOAdaptor::RemoveFiles(const std::vector<std::string>& paths) {
-  return Status::ArrowError(fs_->DeleteFiles(paths));
+  auto _ = fs_->DeleteFiles(paths);  // discard the deletion error
+  return Status::OK();
 }
 
 Status FileIOAdaptor::RemoveFile(const std::string& path) {
-  return Status::ArrowError(fs_->DeleteFile(path));
+  auto _ = fs_->DeleteFile(path);  // discard the deletion error
+  return Status::OK();
 }
 
-}  // namespace util
+}  // namespace io
+}  // namespace vineyard

--- a/src/server/util/file_io_adaptor.h
+++ b/src/server/util/file_io_adaptor.h
@@ -18,7 +18,6 @@ limitations under the License.
 
 #include <memory>
 #include <string>
-#include <unordered_set>
 #include <vector>
 
 #include "arrow/api.h"
@@ -26,9 +25,10 @@ limitations under the License.
 #include "arrow/io/api.h"
 #include "arrow/io/interfaces.h"
 #include "common/util/status.h"
-#include "common/util/uuid.h"
 
-namespace util {
+namespace vineyard {
+namespace io {
+
 /**
  * @brief A customized adaptor for spilling and reloading file,
  * especailly implement `RemoveFile` for garbage collection
@@ -38,24 +38,26 @@ class FileIOAdaptor {
   FileIOAdaptor() = delete;
   explicit FileIOAdaptor(const std::string& dir_path);
   ~FileIOAdaptor();
-  vineyard::Status Open();
-  vineyard::Status Open(const char* mode);
-  vineyard::Status Write(const char* buf, size_t size);
-  vineyard::Status Flush();
-  vineyard::Status Read(void* buffer, size_t size);
-  vineyard::Status Close();
-  vineyard::Status RemoveFile(const std::string& path);
-  vineyard::Status RemoveFiles(const std::vector<std::string>& paths);
-  vineyard::Status DeleteDir();
+  Status Open();
+  Status Open(const char* mode);
+  Status Write(const char* buf, size_t size);
+  Status Flush();
+  Status Read(void* buffer, size_t size);
+  Status Close();
+  Status RemoveFile(const std::string& path);
+  Status RemoveFiles(const std::vector<std::string>& paths);
+  Status DeleteDir();
 
  private:
-  vineyard::Status CreateDir(const std::string& path);
+  Status CreateDir(const std::string& path);
 
   std::string location_;
   std::shared_ptr<arrow::fs::FileSystem> fs_;
   std::shared_ptr<arrow::io::RandomAccessFile> ifp_;
   std::shared_ptr<arrow::io::OutputStream> ofp_;
 };
-}  // namespace util
+
+}  // namespace io
+}  // namespace vineyard
 
 #endif  // SRC_SERVER_UTIL_FILE_IO_ADAPTOR_H_

--- a/src/server/util/spill_file.cc
+++ b/src/server/util/spill_file.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "server/util/spill_file.h"
 
+#include <limits>
 #include <memory>
 #include <string>
 
@@ -26,18 +27,10 @@ limitations under the License.
 #include "server/memory/memory.h"
 #include "server/util/file_io_adaptor.h"
 
-namespace util {
-using vineyard::BulkStore;
-using vineyard::Payload;
-using vineyard::Status;
+namespace vineyard {
+namespace io {
 
-void PutFixed64(std::string* dst, uint64_t value) {
-  char buf[sizeof(value)];
-  EncodeFixed64(buf, value);
-  dst->append(buf, sizeof(buf));
-}
-
-Status SpillWriteFile::Init(uint64_t object_id) {
+Status SpillFileWriter::Init(const ObjectID object_id) {
   if (io_adaptor_) {
     return Status::Invalid(
         "Warning: may not flushed before io_adaptor_ is overwritten");
@@ -47,27 +40,29 @@ Status SpillWriteFile::Init(uint64_t object_id) {
   return Status::OK();
 }
 
-Status SpillWriteFile::Write(const std::shared_ptr<Payload>& payload) {
+Status SpillFileWriter::Write(const std::shared_ptr<Payload>& payload) {
   RETURN_ON_ERROR(Init(payload->object_id));
   if (io_adaptor_ == nullptr) {
     return Status::IOError("Can't open io_adaptor");
   }
   RETURN_ON_ERROR(io_adaptor_->Open("w"));
-  std::string to_spill;
-  PutFixed64(&to_spill, payload->object_id);
-  PutFixed64(&to_spill, static_cast<uint64_t>(payload->data_size));
-  to_spill.append(reinterpret_cast<const char*>(payload->pointer),
-                  payload->data_size);
-  return io_adaptor_->Write(to_spill.data(), to_spill.size());
+  RETURN_ON_ERROR(
+      io_adaptor_->Write(reinterpret_cast<char*>(&(payload->object_id)),
+                         sizeof(payload->object_id)));
+  RETURN_ON_ERROR(
+      io_adaptor_->Write(reinterpret_cast<char*>(&(payload->data_size)),
+                         sizeof(payload->data_size)));
+  return io_adaptor_->Write(reinterpret_cast<const char*>(payload->pointer),
+                            payload->data_size);
 }
 
-Status SpillWriteFile::Sync() {
+Status SpillFileWriter::Sync() {
   RETURN_ON_ERROR(io_adaptor_->Flush());
   io_adaptor_ = nullptr;
   return Status::OK();
 }
 
-Status SpillReadFile::Init(uint64_t object_id) {
+Status SpillFileReader::Init(const ObjectID object_id) {
   if (io_adaptor_) {
     return Status::Invalid(
         "Warning: may not flushed before io_adaptor_ is overwritten");
@@ -77,8 +72,8 @@ Status SpillReadFile::Init(uint64_t object_id) {
   return Status::OK();
 }
 
-Status SpillReadFile::Read(std::shared_ptr<Payload>& payload,
-                           std::shared_ptr<BulkStore> bulk_store_ptr) {
+Status SpillFileReader::Read(const std::shared_ptr<Payload>& payload,
+                             const std::shared_ptr<BulkStore>& bulk_store) {
   RETURN_ON_ERROR(Init(payload->object_id));
   // reload 1. object_id 2. data_size 3. content
   if (io_adaptor_ == nullptr) {
@@ -86,24 +81,26 @@ Status SpillReadFile::Read(std::shared_ptr<Payload>& payload,
   }
   RETURN_ON_ERROR(io_adaptor_->Open());
   {
-    char buf[sizeof(payload->object_id)];
-    RETURN_ON_ERROR(io_adaptor_->Read(buf, sizeof(payload->object_id)));
-    if (payload->object_id != util::DecodeFixed64(buf)) {
-      return Status::IOError("Open wrong file: " + spill_path_ +
-                             std::to_string(payload->object_id));
+    ObjectID object_id = InvalidObjectID();
+    RETURN_ON_ERROR(io_adaptor_->Read(&object_id, sizeof(object_id)));
+    if (payload->object_id != object_id) {
+      return Status::IOError(
+          "Incorrect 'object_id': opening wrong file: " + spill_path_ +
+          ObjectIDToString(payload->object_id));
     }
   }
   {
-    char buf[sizeof(payload->data_size)];
-    RETURN_ON_ERROR(io_adaptor_->Read(buf, sizeof(payload->data_size)));
-    if (static_cast<uint64_t>(payload->data_size) != util::DecodeFixed64(buf)) {
-      return Status::IOError("Open wrong file: " + spill_path_ +
-                             std::to_string(payload->object_id));
+    int64_t data_size = std::numeric_limits<int64_t>::min();
+    RETURN_ON_ERROR(io_adaptor_->Read(&data_size, sizeof(data_size)));
+    if (payload->data_size != data_size) {
+      return Status::IOError(
+          "Incorrect 'data_size': opening wrong file: " + spill_path_ +
+          ObjectIDToString(payload->object_id));
     }
   }
-  payload->pointer = bulk_store_ptr->AllocateMemoryWithSpill(
-      payload->data_size, &payload->store_fd, &payload->map_size,
-      &payload->data_offset);
+  payload->pointer = bulk_store->AllocateMemoryWithSpill(
+      payload->data_size, &(payload->store_fd), &(payload->map_size),
+      &(payload->data_offset));
   if (payload->pointer == nullptr) {
     return Status::NotEnoughMemory("Failed to allocate memory of size " +
                                    std::to_string(payload->data_size) +
@@ -115,12 +112,13 @@ Status SpillReadFile::Read(std::shared_ptr<Payload>& payload,
   return Status::OK();
 }
 
-Status SpillReadFile::Delete_(const vineyard::ObjectID& id) {
+Status SpillFileReader::Delete_(const ObjectID id) {
   if (!io_adaptor_) {
-    return Status::Invalid("io_adaptor_ is not initialized");
+    return Status::Invalid("I/O adaptor is not initialized");
   }
   RETURN_ON_ERROR(io_adaptor_->RemoveFile(spill_path_ + std::to_string(id)));
   return Status::OK();
 }
 
-}  // namespace util
+}  // namespace io
+}  // namespace vineyard

--- a/src/server/util/spill_file.h
+++ b/src/server/util/spill_file.h
@@ -27,7 +27,8 @@ limitations under the License.
 #include "common/util/uuid.h"
 #include "server/util/file_io_adaptor.h"
 
-namespace util {
+namespace vineyard {
+namespace io {
 
 /*
   For each spilled file, the disk-format is:
@@ -35,85 +36,60 @@ namespace util {
     - data_size: uint64
     - content: uint8[data_size]
 */
-class SpillWriteFile {
+class SpillFileWriter {
  public:
-  SpillWriteFile() = delete;
+  SpillFileWriter() = delete;
 
-  explicit SpillWriteFile(const std::string& spill_path)
+  explicit SpillFileWriter(const std::string& spill_path)
       : spill_path_(spill_path) {}
 
-  SpillWriteFile(const SpillWriteFile&) = delete;
+  SpillFileWriter(const SpillFileWriter&) = delete;
 
-  SpillWriteFile& operator=(const SpillWriteFile&) = delete;
+  SpillFileWriter& operator=(const SpillFileWriter&) = delete;
 
-  ~SpillWriteFile() {
+  ~SpillFileWriter() {
     if (io_adaptor_) {
       DISCARD_ARROW_ERROR(io_adaptor_->Flush());
     }
   }
 
-  vineyard::Status Write(const std::shared_ptr<vineyard::Payload>& payload);
-  vineyard::Status Sync();
+  Status Write(const std::shared_ptr<Payload>& payload);
+  Status Sync();
 
  private:
-  vineyard::Status Init(uint64_t object_id);
-  // TODO(ZjuYTW): change to string_view
+  Status Init(const ObjectID object_id);
+
   std::string spill_path_;
-  std::unique_ptr<util::FileIOAdaptor> io_adaptor_ = nullptr;
+  std::unique_ptr<FileIOAdaptor> io_adaptor_ = nullptr;
 };
 
-class SpillReadFile {
+class SpillFileReader {
  public:
-  SpillReadFile() = delete;
+  SpillFileReader() = delete;
 
-  explicit SpillReadFile(const std::string& spill_path)
+  explicit SpillFileReader(const std::string& spill_path)
       : spill_path_(spill_path) {}
 
-  SpillReadFile(const SpillReadFile&) = delete;
+  SpillFileReader(const SpillFileReader&) = delete;
 
-  SpillReadFile& operator=(const SpillReadFile&) = delete;
+  SpillFileReader& operator=(const SpillFileReader&) = delete;
 
-  ~SpillReadFile() = default;
+  ~SpillFileReader() = default;
 
-  vineyard::Status Read(std::shared_ptr<vineyard::Payload>& payload,
-                        std::shared_ptr<vineyard::BulkStore> bulk_store_ptr);
+  Status Read(const std::shared_ptr<Payload>& payload,
+              const std::shared_ptr<BulkStore>& bulk_store);
 
  private:
-  vineyard::Status Init(uint64_t object_id);
+  Status Init(const ObjectID object_id);
 
   // Delete should be called after Init()
-  vineyard::Status Delete_(const vineyard::ObjectID& id);
+  Status Delete_(const ObjectID id);
+
   std::string spill_path_;
-  std::unique_ptr<util::FileIOAdaptor> io_adaptor_ = nullptr;
+  std::unique_ptr<FileIOAdaptor> io_adaptor_ = nullptr;
 };
 
-void PutFixed64(std::string* dst, uint64_t value);
+}  // namespace io
+}  // namespace vineyard
 
-inline void EncodeFixed64(char* dst, uint64_t value) {
-  uint8_t* const buffer = reinterpret_cast<uint8_t*>(dst);
-
-  buffer[0] = static_cast<uint8_t>(value);
-  buffer[1] = static_cast<uint8_t>(value >> 8);
-  buffer[2] = static_cast<uint8_t>(value >> 16);
-  buffer[3] = static_cast<uint8_t>(value >> 24);
-  buffer[4] = static_cast<uint8_t>(value >> 32);
-  buffer[5] = static_cast<uint8_t>(value >> 40);
-  buffer[6] = static_cast<uint8_t>(value >> 48);
-  buffer[7] = static_cast<uint8_t>(value >> 56);
-}
-
-inline uint64_t DecodeFixed64(const char* ptr) {
-  const uint8_t* const buffer = reinterpret_cast<const uint8_t*>(ptr);
-
-  return (static_cast<uint64_t>(buffer[0])) |
-         (static_cast<uint64_t>(buffer[1]) << 8) |
-         (static_cast<uint64_t>(buffer[2]) << 16) |
-         (static_cast<uint64_t>(buffer[3]) << 24) |
-         (static_cast<uint64_t>(buffer[4]) << 32) |
-         (static_cast<uint64_t>(buffer[5]) << 40) |
-         (static_cast<uint64_t>(buffer[6]) << 48) |
-         (static_cast<uint64_t>(buffer[7]) << 56);
-}
-
-}  // namespace util
 #endif  // SRC_SERVER_UTIL_SPILL_FILE_H_

--- a/test/compressor_test.cc
+++ b/test/compressor_test.cc
@@ -48,7 +48,7 @@ void CompressSingleBlobTest() {
   // compression
   {
     std::shared_ptr<Compressor> compressor = std::make_shared<Compressor>();
-    compressor->Compress(data.data(), length);
+    VINEYARD_CHECK_OK(compressor->Compress(data.data(), length));
 
     while (true) {
       void* data = nullptr;

--- a/test/name_test.cc
+++ b/test/name_test.cc
@@ -75,7 +75,7 @@ int main(int argc, char** argv) {
   // meta should contains name
   ObjectMeta meta;
   VINEYARD_CHECK_OK(client.GetMetaData(id, meta));
-  CHECK(meta.Haskey("__name"));
+  CHECK(meta.HasKey("__name"));
   CHECK_EQ(meta.GetKeyValue<std::string>("__name"), "test_name");
 
   ObjectID id3 = 0;
@@ -92,7 +92,7 @@ int main(int argc, char** argv) {
 
   // meta shouldn't contains name anymore
   VINEYARD_CHECK_OK(client.GetMetaData(id, meta));
-  CHECK(!meta.Haskey("__name"));
+  CHECK(!meta.HasKey("__name"));
 
   {
     std::map<std::string, ObjectID> names;


### PR DESCRIPTION
What do these changes do?
-------------------------

- Add `evict/load/unpin` APIs
- Overhual the spill/reload implementation details in `usage.h` and `spill_file.{h,cc}`
- Bump submodules for etcd-cpp-apiv3 for bugfix and graphar for bugfix
- Fixes some warnings during compliation.

Related issue number
--------------------

Fixes #1180

