### PR TITLE
Fixes the error parsing issues in the vineyardctl command line tool

### DIFF
--- a/k8s/cmd/commands/flags/global_flags.go
+++ b/k8s/cmd/commands/flags/global_flags.go
@@ -70,11 +70,25 @@ func RemoveVersionFlag(f *pflag.FlagSet) {
 		if name == "version" /* the argument `f` should be pflag.CommandLine */ {
 			return pflag.NormalizedName("x-version")
 		}
-		return pflag.NormalizedName("version")
+		return pflag.NormalizedName(name)
 	})
 	// restore
 	f.SetNormalizeFunc(normalize)
 
 	// hidden it from the help/usage
 	f.Lookup("x-version").Hidden = true
+}
+
+func RestoreVersionFlag(f *pflag.FlagSet) {
+	// Restore the "version" flag in `verflag` package back to makes kube-scheduler
+	// work as expected.
+	normalize := f.GetNormalizeFunc()
+	f.SetNormalizeFunc(func(f *pflag.FlagSet, name string) pflag.NormalizedName {
+		if name == "x-version" /* the argument `f` should be pflag.CommandLine */ {
+			return pflag.NormalizedName("version")
+		}
+		return pflag.NormalizedName(name)
+	})
+	// restore
+	f.SetNormalizeFunc(normalize)
 }

--- a/k8s/cmd/commands/manager/manager.go
+++ b/k8s/cmd/commands/manager/manager.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"go.uber.org/zap/zapcore"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -286,6 +287,9 @@ func startManager(
 }
 
 func startScheduler(mgr manager.Manager, schedulerConfigFile string) {
+	// restore the global "x-version" flag back to "version" in `verflag`
+	flags.RestoreVersionFlag(pflag.CommandLine)
+
 	command := app.NewSchedulerCommand(
 		app.WithPlugin(schedulers.Name,
 			func(obj runtime.Object, handle framework.Handle) (framework.Plugin, error) {

--- a/k8s/cmd/commands/sidecar/inject.go
+++ b/k8s/cmd/commands/sidecar/inject.go
@@ -233,7 +233,8 @@ func buildSidecar(namespace string) (*v1alpha1.Sidecar, error) {
 
 // InjectSidecarConfig injects the sidecar config into the workload
 func InjectSidecarConfig(sidecar *v1alpha1.Sidecar, workloadObj,
-	sidecarObj *unstructured.Unstructured) error {
+	sidecarObj *unstructured.Unstructured,
+) error {
 	var errList error
 
 	// get the template spec of the workload
@@ -247,7 +248,7 @@ func InjectSidecarConfig(sidecar *v1alpha1.Sidecar, workloadObj,
 
 	workloadContainers, err := convertInterfaceToContainers(
 		templateSpec["containers"].([]interface{}))
-	multierr.Append(errList, err)
+	_ = multierr.Append(errList, err)
 
 	if templateSpec["volumes"] == nil {
 		templateSpec["volumes"] = []interface{}{}
@@ -255,17 +256,17 @@ func InjectSidecarConfig(sidecar *v1alpha1.Sidecar, workloadObj,
 
 	workloadVolumes, err := convertInterfaceToVolumes(
 		templateSpec["volumes"].([]interface{}))
-	multierr.Append(errList, err)
+	_ = multierr.Append(errList, err)
 
 	// get the containers and volumes of the sidecar
 	sidecarSpec := sidecarObj.Object["spec"].(map[string]interface{})
 	sidecarContainers, err := convertInterfaceToContainers(
 		sidecarSpec["containers"].([]interface{}))
-	multierr.Append(errList, err)
+	_ = multierr.Append(errList, err)
 
 	sidecarVolumes, err := convertInterfaceToVolumes(
 		sidecarSpec["volumes"].([]interface{}))
-	multierr.Append(errList, err)
+	_ = multierr.Append(errList, err)
 
 	injector.InjectSidecar(workloadContainers, workloadVolumes,
 		sidecarContainers, sidecarVolumes, sidecar)

--- a/k8s/cmd/main.go
+++ b/k8s/cmd/main.go
@@ -68,11 +68,21 @@ func init() {
 }
 
 func main() {
-	/*if err := cmd.ParseFlags(os.Args); err != nil {
-		_ = cmd.Usage()
-		cmd.PrintErrf("\nError xxx: %v\n", err)
+	tryDumpUsage()
+	if err := cmd.Execute(); err != nil {
+		util.ErrLogger.Fatalf("Failed to execute root command: %+v", err)
 		os.Exit(-1)
-	} */
+	}
+}
+
+func tryDumpUsage() {
+	cmd.FParseErrWhitelist.UnknownFlags = true
+	if err := cmd.ParseFlags(os.Args); err != nil {
+		_ = cmd.Usage()
+		cmd.PrintErrf("\nError when parsing flags: %v\n", err)
+		os.Exit(-1)
+	}
+	cmd.FParseErrWhitelist.UnknownFlags = false
 
 	if flags.DumpUsage {
 		cmd.SetUsageFunc(usage.UsageJson)
@@ -80,9 +90,5 @@ func main() {
 			cmd.PrintErrf("\nError: %+v\n", err)
 		}
 		os.Exit(0)
-	}
-	if err := cmd.Execute(); err != nil {
-		util.ErrLogger.Fatalf("failed to execute root command: %+v", err)
-		os.Exit(-1)
 	}
 }


### PR DESCRIPTION
What do these changes do?
-------------------------

- Fixes the errors about dump-usage flag parsing
