### PR TITLE
Collections, tables, and schema: keep backwards compatibility

### DIFF
--- a/modules/basic/ds/arrow.cc
+++ b/modules/basic/ds/arrow.cc
@@ -812,6 +812,11 @@ void SchemaProxy::PostConstruct(const ObjectMeta& meta) {
   } else if (this->schema_binary_.contains("bytes")) {
     this->schema_binary_["bytes"].get_to(binary_vec);
     wrapper = arrow::Buffer::Wrap(binary_vec.data(), binary_vec.size());
+  } else if (this->meta_.HasKey("buffer_")) {
+    // for backward compatibility
+    std::shared_ptr<Blob> buffer;
+    VINEYARD_CHECK_OK(this->meta_.GetMember("buffer_", buffer));
+    wrapper = buffer->BufferOrEmpty();
   }
   if (wrapper == nullptr) {
     LOG(ERROR) << "Invalid schema binary: " << this->schema_binary_.dump(4);

--- a/modules/basic/ds/dataframe.cc
+++ b/modules/basic/ds/dataframe.cc
@@ -182,6 +182,15 @@ void GlobalDataFrame::PostConstruct(const ObjectMeta& meta) {
   }
 }
 
+const std::vector<std::shared_ptr<DataFrame>> GlobalDataFrame::LocalPartitions(
+    Client& client) const {
+  std::vector<std::shared_ptr<DataFrame>> local_chunks;
+  for (auto iter = LocalBegin(); iter != LocalEnd(); iter.NextLocal()) {
+    local_chunks.emplace_back(*iter);
+  }
+  return local_chunks;
+}
+
 const std::pair<size_t, size_t> GlobalDataFrame::partition_shape() const {
   return std::make_pair(this->partition_shape_row_,
                         this->partition_shape_column_);
@@ -200,4 +209,14 @@ void GlobalDataFrameBuilder::set_partition_shape(
   this->AddKeyValue("partition_shape_row_", partition_shape_row_);
   this->AddKeyValue("partition_shape_column_", partition_shape_column_);
 }
+
+void GlobalDataFrameBuilder::AddPartition(const ObjectID partition_id) {
+  this->AddMember(partition_id);
+}
+
+void GlobalDataFrameBuilder::AddPartitions(
+    const std::vector<ObjectID>& partition_ids) {
+  this->AddMembers(partition_ids);
+}
+
 }  // namespace vineyard

--- a/modules/basic/ds/dataframe.h
+++ b/modules/basic/ds/dataframe.h
@@ -140,6 +140,10 @@ class GlobalDataFrame : public BareRegistered<GlobalDataFrame>,
    */
   const std::pair<size_t, size_t> partition_shape() const;
 
+  /// backwards compatibility
+  const std::vector<std::shared_ptr<DataFrame>> LocalPartitions(
+      Client& client) const;
+
  private:
   size_t partition_shape_row_;
   size_t partition_shape_column_;
@@ -177,6 +181,10 @@ class GlobalDataFrameBuilder : public CollectionBuilder<DataFrame> {
    */
   void set_partition_shape(const size_t partition_shape_row,
                            const size_t partition_shape_column);
+
+  /// Backwards compatibility
+  void AddPartition(const ObjectID partition_id);
+  void AddPartitions(const std::vector<ObjectID>& partition_ids);
 
  private:
   size_t partition_shape_row_;

--- a/modules/basic/ds/tensor.cc
+++ b/modules/basic/ds/tensor.cc
@@ -32,6 +32,15 @@ std::vector<int64_t> const& GlobalTensor::partition_shape() const {
   return partition_shape_;
 }
 
+const std::vector<std::shared_ptr<ITensor>> GlobalTensor::LocalPartitions(
+    Client& client) const {
+  std::vector<std::shared_ptr<ITensor>> local_chunks;
+  for (auto iter = LocalBegin(); iter != LocalEnd(); iter.NextLocal()) {
+    local_chunks.emplace_back(*iter);
+  }
+  return local_chunks;
+}
+
 std::vector<int64_t> const& GlobalTensorBuilder::partition_shape() const {
   return this->partition_shape_;
 }
@@ -49,6 +58,15 @@ std::vector<int64_t> const& GlobalTensorBuilder::shape() const {
 void GlobalTensorBuilder::set_shape(std::vector<int64_t> const& shape) {
   this->shape_ = shape;
   this->AddKeyValue("shape_", shape);
+}
+
+void GlobalTensorBuilder::AddPartition(const ObjectID partition_id) {
+  this->AddMember(partition_id);
+}
+
+void GlobalTensorBuilder::AddPartitions(
+    const std::vector<ObjectID>& partition_ids) {
+  this->AddMembers(partition_ids);
 }
 
 }  // namespace vineyard

--- a/modules/basic/ds/tensor.h
+++ b/modules/basic/ds/tensor.h
@@ -319,6 +319,10 @@ class GlobalTensor : public BareRegistered<GlobalTensor>,
 
   std::vector<int64_t> const& partition_shape() const;
 
+  /// backwards compatibility
+  const std::vector<std::shared_ptr<ITensor>> LocalPartitions(
+      Client& client) const;
+
  private:
   std::vector<int64_t> shape_;
   std::vector<int64_t> partition_shape_;
@@ -365,6 +369,10 @@ class GlobalTensorBuilder : public CollectionBuilder<ITensor> {
    *
    */
   void set_shape(std::vector<int64_t> const& shape);
+
+  /// Backwards compatibility
+  void AddPartition(const ObjectID partition_id);
+  void AddPartitions(const std::vector<ObjectID>& partition_ids);
 
  private:
   std::vector<int64_t> shape_;


### PR DESCRIPTION
What do these changes do?
-------------------------

- Add `AddPartitions`, `LocalPartitions` back
- Add backwards compabitility with `SchemaProxy`.