### PR TITLE
Fix the error when parsing and executing bool variables in the python wrapper of vineyarctl

### DIFF
--- a/python/vineyard/deploy/_cobra.py
+++ b/python/vineyard/deploy/_cobra.py
@@ -117,16 +117,9 @@ def make_command(executable, usage, exclude_args, scope=None):
                 # get(key, default...) won't work, as we cannot diff not exists and None
                 if key in defaults and value == defaults[key]:
                     continue
-                # for boolean flags, if the value is false, we should skip the flag part
-                if isinstance(value, bool) and not value:
-                    continue
-                command_and_args.append("--" + arguments.get(key, key))
-                # if the value is true, we should skip the value part
-                # as the flag itself is enough
-                if not isinstance(value, bool):
-                    if not isinstance(value, str):
-                        value = json.dumps(value)
-                    command_and_args.append(value)
+                if not isinstance(value, str):
+                    value = json.dumps(value)
+                command_and_args.append("--%s=%s" % (arguments.get(key, key), value))
             logger.debug('Executing: %s', ' '.join(command_and_args))
             parameters = {
                 'args': command_and_args,

--- a/python/vineyard/deploy/_cobra.py
+++ b/python/vineyard/deploy/_cobra.py
@@ -117,10 +117,16 @@ def make_command(executable, usage, exclude_args, scope=None):
                 # get(key, default...) won't work, as we cannot diff not exists and None
                 if key in defaults and value == defaults[key]:
                     continue
+                # for boolean flags, if the value is false, we should skip the flag part
+                if isinstance(value, bool) and not value:
+                    continue
                 command_and_args.append("--" + arguments.get(key, key))
-                if not isinstance(value, str):
-                    value = json.dumps(value)
-                command_and_args.append(value)
+                # if the value is true, we should skip the value part
+                # as the flag itself is enough
+                if not isinstance(value, bool):
+                    if not isinstance(value, str):
+                        value = json.dumps(value)
+                    command_and_args.append(value)
             logger.debug('Executing: %s', ' '.join(command_and_args))
             parameters = {
                 'args': command_and_args,


### PR DESCRIPTION

<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

While executing the following code, get some errors as follows.
```
vineyard.deploy.vineyardctl.deploy.vineyard_deployment(cre
   ...: ate_namespace=True,wait=False)
2023-03-12T17:31:50.859+0800    ERROR   Expects no positional arguments   {"error": "unknown command \"false\" for \"vineyardctl deploy vineyard-deployment\""}
github.com/v6d-io/v6d/k8s/pkg/log.Logger.Fatal
        /opt/caoye/v6d/k8s/pkg/log/log.go:81
github.com/v6d-io/v6d/k8s/pkg/log.Fatal
        /opt/caoye/v6d/k8s/pkg/log/log.go:114
github.com/v6d-io/v6d/k8s/cmd/commands/util.AssertNoArgs
        /opt/caoye/v6d/k8s/cmd/commands/util/arg.go:26
github.com/v6d-io/v6d/k8s/cmd/commands/deploy.glob..func4
        /opt/caoye/v6d/k8s/cmd/commands/deploy/deploy_vineyard_deployment.go:70
github.com/spf13/cobra.(*Command).execute
        /home/gsbot/go/pkg/mod/github.com/spf13/cobra@v1.5.0/command.go:876
github.com/spf13/cobra.(*Command).ExecuteC
        /home/gsbot/go/pkg/mod/github.com/spf13/cobra@v1.5.0/command.go:990
github.com/spf13/cobra.(*Command).Execute
        /home/gsbot/go/pkg/mod/github.com/spf13/cobra@v1.5.0/command.go:918
main.main
        /opt/caoye/v6d/k8s/cmd/main.go:76
runtime.main
        /usr/lib/go-1.19/src/runtime/proc.go:250
------------------------------------------------------------------
CalledProcessError               Traceback (most recent call last)
Cell In [7], line 1
----> 1 vineyard.deploy.vineyardctl.deploy.vineyard_deployment(create_namespace=True,wait=False)

File <makefun-gen-37>:2, in vineyard_deployment(create_namespace, kubeconfig, namespace, wait, file, label, name, plugin_backupimage, plugin_daskrepartitionimage, plugin_distributedassemblyimage, plugin_localassemblyimage, plugin_recoverimage, vineyard_create_serviceaccount, vineyard_etcd_replicas, vineyard_replicas, vineyard_serviceaccount_name, vineyardd_envs, vineyardd_etcdendpoint, vineyardd_etcdprefix, vineyardd_image, vineyardd_imagepullpolicy, vineyardd_metric_enable, vineyardd_metric_image, vineyardd_metric_imagepullpolicy, vineyardd_service_port, vineyardd_service_selector, vineyardd_service_type, vineyardd_size, vineyardd_socket, vineyardd_spill_config, vineyardd_spill_path, vineyardd_spill_pv_pvc_spec, vineyardd_spill_spilllowerrate, vineyardd_spill_spillupperrate, vineyardd_streamthreshold, vineyardd_synccrds, vineyardd_volume_mountpath, vineyardd_volume_pvcname, capture)

File ~/.local/lib/python3.8/site-packages/vineyard/deploy/_cobra.py:148, in make_command.<locals>.cmd(capture, *args, **kwargs)
    146     return output
    147 else:
--> 148     return subprocess.check_call(
    149         **parameters,
    150         bufsize=1,
    151         stderr=subprocess.STDOUT,
    152     )

File /usr/lib/python3.8/subprocess.py:364, in check_call(*popenargs, **kwargs)
    362     if cmd is None:
    363         cmd = popenargs[0]
--> 364     raise CalledProcessError(retcode, cmd)
    365 return 0

CalledProcessError: Command '['/home/gsbot/.local/lib/python3.8/site-packages/vineyard/bdist/vineyardctl', 'deploy', 'vineyard-deployment', '--create-namespace', '--wait', 'false']' returned non-zero exit status 1.

In [8]: vineyard.deploy.vineyardctl.deploy.vineyard_deployment(create_namespace=True,wait=False)
2023-03-12T17:32:14.264+0800    ERROR   Expects no positional arguments   {"error": "unknown command \"false\" for \"vineyardctl deploy vineyard-deployment\""}
github.com/v6d-io/v6d/k8s/pkg/log.Logger.Fatal
        /opt/caoye/v6d/k8s/pkg/log/log.go:81
github.com/v6d-io/v6d/k8s/pkg/log.Fatal
        /opt/caoye/v6d/k8s/pkg/log/log.go:114
github.com/v6d-io/v6d/k8s/cmd/commands/util.AssertNoArgs
        /opt/caoye/v6d/k8s/cmd/commands/util/arg.go:26
github.com/v6d-io/v6d/k8s/cmd/commands/deploy.glob..func4
        /opt/caoye/v6d/k8s/cmd/commands/deploy/deploy_vineyard_deployment.go:70
github.com/spf13/cobra.(*Command).execute
        /home/gsbot/go/pkg/mod/github.com/spf13/cobra@v1.5.0/command.go:876
github.com/spf13/cobra.(*Command).ExecuteC
        /home/gsbot/go/pkg/mod/github.com/spf13/cobra@v1.5.0/command.go:990
github.com/spf13/cobra.(*Command).Execute
        /home/gsbot/go/pkg/mod/github.com/spf13/cobra@v1.5.0/command.go:918
main.main
        /opt/caoye/v6d/k8s/cmd/main.go:76
runtime.main
        /usr/lib/go-1.19/src/runtime/proc.go:250
------------------------------------------------------------------
CalledProcessError               Traceback (most recent call last)
Cell In [8], line 1
----> 1 vineyard.deploy.vineyardctl.deploy.vineyard_deployment(create_namespace=True,wait=False)

File <makefun-gen-37>:2, in vineyard_deployment(create_namespace, kubeconfig, namespace, wait, file, label, name, plugin_backupimage, plugin_daskrepartitionimage, plugin_distributedassemblyimage, plugin_localassemblyimage, plugin_recoverimage, vineyard_create_serviceaccount, vineyard_etcd_replicas, vineyard_replicas, vineyard_serviceaccount_name, vineyardd_envs, vineyardd_etcdendpoint, vineyardd_etcdprefix, vineyardd_image, vineyardd_imagepullpolicy, vineyardd_metric_enable, vineyardd_metric_image, vineyardd_metric_imagepullpolicy, vineyardd_service_port, vineyardd_service_selector, vineyardd_service_type, vineyardd_size, vineyardd_socket, vineyardd_spill_config, vineyardd_spill_path, vineyardd_spill_pv_pvc_spec, vineyardd_spill_spilllowerrate, vineyardd_spill_spillupperrate, vineyardd_streamthreshold, vineyardd_synccrds, vineyardd_volume_mountpath, vineyardd_volume_pvcname, capture)

File ~/.local/lib/python3.8/site-packages/vineyard/deploy/_cobra.py:148, in make_command.<locals>.cmd(capture, *args, **kwargs)
    146     return output
    147 else:
--> 148     return subprocess.check_call(
    149         **parameters,
    150         bufsize=1,
    151         stderr=subprocess.STDOUT,
    152     )

File /usr/lib/python3.8/subprocess.py:364, in check_call(*popenargs, **kwargs)
    362     if cmd is None:
    363         cmd = popenargs[0]
--> 364     raise CalledProcessError(retcode, cmd)
    365 return 0

CalledProcessError: Command '['/home/gsbot/.local/lib/python3.8/site-packages/vineyard/bdist/vineyardctl', 'deploy', 'vineyard-deployment', '--create-namespace', '--wait', 'false']' returned non-zero exit status 1.
```

That's because vineyardctl can not separate bool-type parameters by spaces such as `--wait true` or `--wait false`, and can only receive parameters through `--wait=True`, `--wait=False`, `--wait` for True and not set for False.


Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1246

