### PR TITLE
Use manylinux 2014 instead of 2010

### DIFF
--- a/modules/graph/tools/graph_loader.cc
+++ b/modules/graph/tools/graph_loader.cc
@@ -383,7 +383,7 @@ int main(int argc, char** argv) {
 
     - or: ./vineyard-graph-loader [--socket <vineyard-ipc-socket>] --config <config.json>
 
-          The config is a json file and should look like
+          The `config.json` is a json file which should looks like
 
           {
               "vertices": [

--- a/setup_bdist.py
+++ b/setup_bdist.py
@@ -37,7 +37,7 @@ class bdist_wheel_plat(bdist_wheel):
         _, _, plat = bdist_wheel.get_tag(self)
         if plat.startswith('linux'):
             # Linux: make wheel has valid name without auditwheel
-            plat = 'manylinux2010' + plat[len('linux'):]
+            plat = 'manylinux2014' + plat[len('linux'):]
         return ('py3', 'none', plat)
 
 


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

<!-- Please give a short brief about these changes. -->

When building `bdist_wheel` under arm-based linux, the resulting tag would be
`vineyard_bdist-0.13.3-py3-none-manylinux2010_aarch64.whl`, where as `manylinux2010_aarch64` is not a valid tag, makes it an invalid wheels. 

Here's an description of tags in [pypa/manylinux](https://github.com/pypa/manylinux)
```
PEP 571 defined manylinux2010_x86_64 and manylinux2010_i686 platform tags and the wheels were built on Centos6. Centos6 reached End of Life (EOL) on November 30th, 2020.

PEP 599 defines the following platform tags:

manylinux2014_x86_64
manylinux2014_i686
manylinux2014_aarch64
manylinux2014_armv7l
manylinux2014_ppc64
manylinux2014_ppc64le
manylinux2014_s390x
```

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

N/A

