### PR TITLE
Enable pass storage options from both kw and path

### DIFF
--- a/modules/io/python/drivers/io/adaptors/README.rst
+++ b/modules/io/python/drivers/io/adaptors/README.rst
@@ -10,12 +10,14 @@ Behind the scene, it leverage `fsspec` to delegate the workload to various file 
 Specifically, we can specify parameters to be passed to the file system, through the `storage_options` parameter.
 `storage_options` is a dict that pass additional keywords to the file system,
 For instance, we could combine `path` = `hdfs:///path/to/file` with `storage_options` = `{"host": "localhost", "port": 9600}`
-to read from a HDFS.
+to read from a HDFS. 
 
-Alternatively, we can encode such information into the path by using methods,
+Note that you must encode the `storage_options` by base64 before passing it to the scripts.
+
+Alternatively, we can encode such information into the path,
 such as: `hdfs://<ip>:<port>/path/to/file`.
 
-To read from multiple files you can pass a globstring or a list of paths,
+To read from multiple files you can pass a glob string or a list of paths,
 with the caveat that they must all have the same protocol.
 
 Their functionality are described as follows:

--- a/modules/io/python/drivers/io/adaptors/README.rst
+++ b/modules/io/python/drivers/io/adaptors/README.rst
@@ -4,6 +4,20 @@ IO Adaptors
 Vineyard has a set of prebuilt IO adaptors, that can serve as common routines for
 various IO operations and can take place of boilerplate parts in computation tasks.
 
+Vineyard is capable of reading from and writing data to multiple file systems.
+Behind the scene, it leverage `fsspec` to delegate the workload to various file system implementations.
+
+Specifically, we can specify parameters to be passed to the file system, through the `storage_options` parameter.
+`storage_options` is a dict that pass additional keywords to the file system,
+For instance, we could combine `path` = `hdfs:///path/to/file` with `storage_options` = `{"host": "localhost", "port": 9600}`
+to read from a HDFS.
+
+Alternatively, we can encode such information into the path by using methods,
+such as: `hdfs://<ip>:<port>/path/to/file`.
+
+To read from multiple files you can pass a globstring or a list of paths,
+with the caveat that they must all have the same protocol.
+
 Their functionality are described as follows:
 
 + :code:`read_bytes`

--- a/modules/io/python/drivers/io/adaptors/read_bytes_collection.py
+++ b/modules/io/python/drivers/io/adaptors/read_bytes_collection.py
@@ -28,7 +28,7 @@ from typing import Dict
 from typing import Tuple  # pylint: disable=unused-import
 
 import fsspec
-from fsspec.core import split_protocol
+from fsspec.core import get_fs_token_paths
 from fsspec.spec import AbstractFileSystem
 from fsspec.utils import read_block
 
@@ -177,8 +177,9 @@ def read_bytes_collection(
     """Read a set of files as a collection of ByteStreams."""
     client = vineyard.connect(vineyard_socket)
 
-    protocol, prefix_path = split_protocol(prefix)
-    fs = fsspec.filesystem(protocol, **storage_options)
+    # files would be empty if it's a glob pattern and globbed nothing.
+    fs, _, files = get_fs_token_paths(prefix, storage_options=storage_options)
+    prefix_path = files[0]
 
     worker_prefix = os.path.join(prefix_path, '%s-%s' % (proc_num, proc_index))
 

--- a/modules/io/python/drivers/io/adaptors/read_orc.py
+++ b/modules/io/python/drivers/io/adaptors/read_orc.py
@@ -24,7 +24,7 @@ import traceback
 from typing import Dict
 
 import fsspec
-from fsspec.core import split_protocol
+from fsspec.core import get_fs_token_paths
 
 import vineyard
 from vineyard.data.utils import str_to_bool
@@ -121,24 +121,19 @@ def read_bytes(  # noqa: C901, pylint: disable=too-many-statements
         params[k] = v
 
     try:
-        protocol = split_protocol(path)[0]
-        fs = fsspec.filesystem(protocol, **storage_options)
+        # files would be empty if it's a glob pattern and globbed nothing.
+        fs, _, files = get_fs_token_paths(path, storage_options=storage_options)
     except Exception:  # pylint: disable=broad-except
         report_error(
             f"Cannot initialize such filesystem for '{path}', "
             f"exception is:\n{traceback.format_exc()}"
         )
         sys.exit(-1)
-
-    if fs.isfile(path):
-        files = [path]
-    else:
-        try:
-            files = fs.glob(path + '*')
-            assert files, f"Cannot find such files: {path}"
-        except Exception:  # pylint: disable=broad-except
-            report_error(f"Cannot find such files for '{path}'")
-            sys.exit(-1)
+    try:
+        assert files
+    except Exception:  # pylint: disable=broad-except
+        report_error(f"Cannot find such files for '{path}'")
+        sys.exit(-1)
     files = sorted(files)
 
     stream, writer, chunks = None, None, []

--- a/modules/io/python/drivers/io/adaptors/read_parquet.py
+++ b/modules/io/python/drivers/io/adaptors/read_parquet.py
@@ -25,7 +25,7 @@ from typing import Dict
 
 import fsspec
 import fsspec.implementations.arrow
-from fsspec.core import split_protocol
+from fsspec.core import get_fs_token_paths
 
 import vineyard
 from vineyard.data.utils import str_to_bool
@@ -127,24 +127,19 @@ def read_bytes(  # noqa: C901, pylint: disable=too-many-statements
         params[k] = v
 
     try:
-        protocol = split_protocol(path)[0]
-        fs = fsspec.filesystem(protocol, **storage_options)
+        # files would be empty if it's a glob pattern and globbed nothing.
+        fs, _, files = get_fs_token_paths(path, storage_options=storage_options)
     except Exception:  # pylint: disable=broad-except
         report_error(
             f"Cannot initialize such filesystem for '{path}', "
             f"exception is:\n{traceback.format_exc()}"
         )
         sys.exit(-1)
-
-    if fs.isfile(path):
-        files = [path]
-    else:
-        try:
-            files = fs.glob(path + '*')
-            assert files, f"Cannot find such files: {path}"
-        except Exception:  # pylint: disable=broad-except
-            report_error(f"Cannot find such files for '{path}'")
-            sys.exit(-1)
+    try:
+        assert files
+    except Exception:  # pylint: disable=broad-except
+        report_error(f"Cannot find such files for '{path}'")
+        sys.exit(-1)
     files = sorted(files)
 
     stream, writer, chunks = None, None, []

--- a/modules/io/python/drivers/io/stream.py
+++ b/modules/io/python/drivers/io/stream.py
@@ -101,7 +101,7 @@ class ParallelStreamLauncher(ScriptLauncher):
         """
         kwargs = kwargs.copy()
         self.vineyard_endpoint = kwargs.pop("vineyard_endpoint", None)
-        if ":" in self.vineyard_endpoint:
+        if self.vineyard_endpoint is not None and ":" in self.vineyard_endpoint:
             self.vineyard_endpoint = tuple(self.vineyard_endpoint.split(":"))
 
         hosts = kwargs.pop("hosts", ["localhost"])


### PR DESCRIPTION
- Enable storage options be passed through parameter `storage_options`, or from the URI directly, e.g. `hdfs://<ip>:<port>/path/to/file`
- Leverage methods from fsspec to handle glob patterns.