### PR TITLE
Use memfd_create(2) for sharable file descriptor allocation

### DIFF
--- a/.github/workflows/build-test-graph.yml
+++ b/.github/workflows/build-test-graph.yml
@@ -19,8 +19,6 @@ on:
     paths:
       - modules/graph
   pull_request:
-    branches:
-      - "*"
     paths:
       - modules/graph
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -28,6 +28,10 @@ WHEEL_IMAGE					:= vineyard-wheel
 WHEEL_MANIFEST_TAG 			:= $(WHEEL_VERSION)_$(WHEEL_PYTHON)
 WHEEL_TAG 					:= $(WHEEL_MANIFEST_TAG)_$(PLATFORM)
 
+DEV_REGISTRY				:= $(REGISTRY)
+DEV_IMAGE					:= vineyard-dev
+DEV_TAG						:= latest_$(PLATFORM)
+
 PYTHON_DEV_REGISTRY			:= $(REGISTRY)
 PYTHON_DEV_IMAGE			:= vineyard-python-dev
 PYTHON_DEV_TAG				:= latest_$(PLATFORM)
@@ -89,6 +93,13 @@ python-wheel:
 		--load \
 		--platform linux/$(ARCH)
 .PHONY: python-wheel
+
+# build dev image
+build-dev:
+	docker build ./dev/ \
+		-f ./dev/Dockerfile.dev \
+		-t $(DEV_REGISTRY)/$(DEV_IMAGE):$(DEV_TAG)
+.PHONY: build-dev
 
 # build python-dev image
 build-python-dev:

--- a/docker/dev/Dockerfile.dev
+++ b/docker/dev/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 RUN chmod 1777 /tmp
 

--- a/docker/dev/build_scripts/install-arrow.sh
+++ b/docker/dev/build_scripts/install-arrow.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -ex
+set -o pipefail
+
 export DEBIAN_FRONTEND=noninteractive
 export DEBCONF_NONINTERACTIVE_SEEN=true
 
@@ -7,12 +10,11 @@ export DEBCONF_NONINTERACTIVE_SEEN=true
 wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
 apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
 apt update
-apt install -y libarrow-dev=6.0.1-1 libparquet-dev=6.0.1-1 libarrow-python-dev=6.0.1-1
+apt install -y libarrow-dev=10.0.1-1 libparquet-dev=10.0.1-1
 
 # install pyarrow from scratch
-sudo pip3 install --no-binary pyarrow pyarrow==6.0.1
+sudo pip3 install --no-binary pyarrow pyarrow==10.0.1
 
 # apt-get cleanup
 apt-get autoclean
 rm -rf ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-

--- a/docker/dev/build_scripts/install-deps.sh
+++ b/docker/dev/build_scripts/install-deps.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -ex
+set -o pipefail
+
 export DEBIAN_FRONTEND=noninteractive
 export DEBCONF_NONINTERACTIVE_SEEN=true
 

--- a/docker/dev/build_scripts/install-miscs.sh
+++ b/docker/dev/build_scripts/install-miscs.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -ex
+set -o pipefail
+
 # install python packages for codegen, and io adaptors
 sudo pip3 install -U "Pygments>=2.4.1"
 sudo pip3 install -r build_scripts/requirements.txt
@@ -7,4 +10,3 @@ sudo pip3 install -r build_scripts/requirements.txt
 # install clang-format
 sudo curl -L https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-22538c65/clang-format-8_linux-amd64 --output /usr/bin/clang-format
 sudo chmod +x /usr/bin/clang-format
-

--- a/docker/dev/build_scripts/requirements.txt
+++ b/docker/dev/build_scripts/requirements.txt
@@ -1,34 +1,38 @@
 argcomplete
-black
+black>=22.3.0
 breathe
 click
 docutils==0.16
 etcd-distro
-flake8
+flake8>=4.0.1
+flake8-comprehensions
+flake8-logging-format
 furo        # sphinx theme
-isort
+isort>=5.10.1
 jinja2>=3.0.0
 libclang
+linkify-it-py
+makefun
+myst-parser>=0.13.0
 nbsphinx
 numpy>=1.18.5
-parsec
 pandas<1.0.0; python_version<"3.6"
-pandas<1.2.0; python_version<"3.7"
 pandas>=1.0.0; python_version>="3.7"
+pandas<1.2.0; python_version<"3.7"
 pickle5; python_version<="3.7"
-pygments>=2.4.1
 psutil
+pyarrow
+pygments>=2.4.1
 pytest
 pytest-benchmark
 pytest-datafiles
+pytest-timeout
 setuptools
 shared-memory38; python_version<="3.7"
 sortedcontainers
-sphinx>=3.0.2
+sphinx>=3.0.2,<6
 sphinx-copybutton
-sphinx-panels
 sphinxemoji
 sphinxext-opengraph
+sphinx-panels
 treelib
-wheel
-


### PR DESCRIPTION
What do these changes do?
-------------------------

- Use `memfd_create()` on Linux, verified both on Docker and on Kubernetes (between pods)
- Fixes the `vineyard-dev` docker image

Related issue number
--------------------

Fixes #1292

