### PR TITLE
Delete CRDs when deleting objects from vineyard

### DIFF
--- a/src/server/util/kubectl.h
+++ b/src/server/util/kubectl.h
@@ -37,9 +37,9 @@ class Kubectl {
 
   ~Kubectl();
 
-  void Apply(const std::string& content, callback_t<> callback);
+  void CreateObject(const json& cluster_meta, const json& object);
 
-  void ApplyObject(const json& meta, const json& object);
+  void DeleteObject(const json& object);
 
   void Finish();
 
@@ -49,6 +49,10 @@ class Kubectl {
 
  private:
   std::shared_ptr<Process> proc_;
+
+  void Create(const std::string& content, callback_t<> callback);
+
+  void Delete(const std::string& content, callback_t<> callback);
 };
 
 }  // namespace vineyard

--- a/src/server/util/meta_tree.cc
+++ b/src/server/util/meta_tree.cc
@@ -446,7 +446,10 @@ Status DelDataOps(const json& tree, const std::set<ObjectID>& ids,
     auto s = DelDataOps(tree, id, ops, sync_remote);
     if (!s.ok() && !IsBlob(id)) {
       // here it might be a "remote" blobs.
-      return s;
+      if (!s.IsMetaTreeSubtreeNotExists()) {
+        // non-exists is not an error.
+        return s;
+      }
     }
   }
   return Status::OK();
@@ -458,7 +461,10 @@ Status DelDataOps(const json& tree, const std::vector<ObjectID>& ids,
     auto s = DelDataOps(tree, id, ops, sync_remote);
     if (!s.ok() && !IsBlob(id)) {
       // here it might be a "remote" blobs.
-      return s;
+      if (!s.IsMetaTreeSubtreeNotExists()) {
+        // non-exists is not an error.
+        return s;
+      }
     }
   }
   return Status::OK();


### PR DESCRIPTION

What do these changes do?
-------------------------

The CRDs should be dropped from Kubernetes when we deleting the objects from vineyard. 


Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

- Fixes #1174
- See also: https://github.com/v6d-io/v6d/issues/1150#issuecomment-1413187626

