### PR TITLE
Fixes issue1312: resolve std::string with pa.large_binary

### DIFF
--- a/python/vineyard/data/tensor.py
+++ b/python/vineyard/data/tensor.py
@@ -76,11 +76,17 @@ def numpy_ndarray_resolver(obj):
     value_type = normalize_dtype(value_type_name, meta.get('value_type_meta_', None))
     # process string ndarray from c++
     if value_type_name in ['str', 'string', 'std::string', 'std::__1::string']:
+        from .arrow import binary_array_resolver
         from .arrow import string_array_resolver
 
-        return string_array_resolver(obj.member('buffer_')).to_numpy(
-            zero_copy_only=False
-        )
+        try:
+            return string_array_resolver(obj.member('buffer_')).to_numpy(
+                zero_copy_only=False
+            )
+        except:  # noqa: E722, pylint: disable=bare-except
+            return binary_array_resolver(obj.member('buffer_')).to_numpy(
+                zero_copy_only=False
+            )
 
     shape = from_json(meta['shape_'])
     if 'order_' in meta:


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

<!-- Please give a short brief about these changes. -->
std::string encoding without 'utf-8' cannot resolve with pa.large_string, 
use pa.large_binary to resolve it.

my local test is passed.

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1312 

