### PR TITLE
Improve the vineyardctl inject command for integrating with GraphScope

### DIFF
--- a/docs/notes/cloud-native/vineyard-operator.rst
+++ b/docs/notes/cloud-native/vineyard-operator.rst
@@ -396,23 +396,17 @@ available configurations.
          - The environment of vineyard sidecar.
          - nil
 
-<<<<<<< HEAD
-       * - | metric.
-||||||| constructed merge base
-       * - | metricConfig.
-=======
-       * - | vineyardConfig.
+       * - | vineyard.
            | memory
          - string
          - The requested memory of vineyard sidecar container.
 
-       * - | vineyardConfig.
+       * - | vineyard.
            | cpu
          - string
          - The requested cpu of vineyard sidecar container.
 
-       * - | metricConfig.
->>>>>>> Improve the vineyardctl inject command.
+       * - | metric.
            | enable
          - bool
          - Enable the metrics in vineyard sidecar.

--- a/docs/notes/cloud-native/vineyard-operator.rst
+++ b/docs/notes/cloud-native/vineyard-operator.rst
@@ -396,7 +396,23 @@ available configurations.
          - The environment of vineyard sidecar.
          - nil
 
+<<<<<<< HEAD
        * - | metric.
+||||||| constructed merge base
+       * - | metricConfig.
+=======
+       * - | vineyardConfig.
+           | memory
+         - string
+         - The requested memory of vineyard sidecar container.
+
+       * - | vineyardConfig.
+           | cpu
+         - string
+         - The requested cpu of vineyard sidecar container.
+
+       * - | metricConfig.
+>>>>>>> Improve the vineyardctl inject command.
            | enable
          - bool
          - Enable the metrics in vineyard sidecar.

--- a/k8s/apis/k8s/v1alpha1/vineyardd_types.go
+++ b/k8s/apis/k8s/v1alpha1/vineyardd_types.go
@@ -142,6 +142,16 @@ type VineyardConfig struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default:={}
 	Env []corev1.EnvVar `json:"env,omitempty"`
+
+	// the memory resources of vineyard container
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default:={}
+	Memory string `json:"memory,omitempty"`
+
+	// the cpu resources of vineyard container
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default:={}
+	CPU string `json:"cpu,omitempty"`
 }
 
 // PluginImageConfig holds all image configuration about pluggable drivers(backup, recover,

--- a/k8s/apis/k8s/v1alpha1/vineyardd_types.go
+++ b/k8s/apis/k8s/v1alpha1/vineyardd_types.go
@@ -49,10 +49,12 @@ type SpillConfig struct {
 
 	// the PersistentVolumeSpec of the spilling PV
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default:={}
 	PersistentVolumeSpec corev1.PersistentVolumeSpec `json:"persistentVolumeSpec,omitempty"`
 
 	// the PersistentVolumeClaimSpec of the spill file
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default:={}
 	PersistentVolumeClaimSpec corev1.PersistentVolumeClaimSpec `json:"persistentVolumeClaimSpec,omitempty"`
 }
 

--- a/k8s/cmd/README.md
+++ b/k8s/cmd/README.md
@@ -707,6 +707,7 @@ vineyardctl deploy vineyard-deployment [flags]
 ### Options
 
 ```
+<<<<<<< HEAD
   -f, --file string                                   the path of vineyardd
   -h, --help                                          help for vineyard-deployment
   -l, --label string                                  label of the vineyardd
@@ -737,6 +738,77 @@ vineyardctl deploy vineyard-deployment [flags]
       --vineyardd.syncCRDs                            enable metrics of vineyardd (default true)
       --vineyardd.volume.mountPath string             Set the mount path for the pvc
       --vineyardd.volume.pvcname string               Set the pvc name for storing the vineyard objects persistently, 
+||||||| constructed merge base
+  -f, --file string                               the path of vineyardd
+  -h, --help                                      help for vineyard-deployment
+  -l, --label string                              label of the vineyardd
+      --name string                               the name of vineyardd (default "vineyardd-sample")
+      --plugin.backupImage string                 the backup image of vineyardd (default "ghcr.io/v6d-io/v6d/backup-job")
+      --plugin.daskRepartitionImage string        the dask repartition image of vineyardd workflow (default "ghcr.io/v6d-io/v6d/dask-repartition")
+      --plugin.distributedAssemblyImage string    the distributed image of vineyard workflow (default "ghcr.io/v6d-io/v6d/distributed-assembly")
+      --plugin.localAssemblyImage string          the local assembly image of vineyardd workflow (default "ghcr.io/v6d-io/v6d/local-assembly")
+      --plugin.recoverImage string                the recover image of vineyardd (default "ghcr.io/v6d-io/v6d/recover-job")
+      --vineyard.etcd.replicas int                the number of etcd replicas in a vineyard cluster (default 3)
+      --vineyard.replicas int                     the number of vineyardd replicas (default 3)
+      --vineyardd.envs strings                    The environment variables of vineyardd
+      --vineyardd.etcdEndpoint string             The etcd endpoint of vineyardd (default "http://etcd-for-vineyard:2379")
+      --vineyardd.etcdPrefix string               The etcd prefix of vineyardd (default "/vineyard")
+      --vineyardd.image string                    the image of vineyardd (default "vineyardcloudnative/vineyardd:latest")
+      --vineyardd.imagePullPolicy string          the imagePullPolicy of vineyardd (default "IfNotPresent")
+      --vineyardd.metric.enable                   enable metrics of vineyardd
+      --vineyardd.metric.image string             the metic image of vineyardd (default "vineyardcloudnative/vineyard-grok-exporter:latest")
+      --vineyardd.metric.imagePullPolicy string   the imagePullPolicy of the metric image (default "IfNotPresent")
+      --vineyardd.service.port int                the service port of vineyard service (default 9600)
+      --vineyardd.service.selector string         the service selector of vineyard service (default "rpc.vineyardd.v6d.io/rpc=vineyard-rpc")
+      --vineyardd.service.type string             the service type of vineyard service (default "ClusterIP")
+      --vineyardd.size string                     The size of vineyardd. You can use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki.  (default "256Mi")
+      --vineyardd.socket string                   The directory on host for the IPC socket file. The namespace and name will be replaced with your vineyard config (default "/var/run/vineyard-kubernetes/{{.Namespace}}/{{.Name}}")
+      --vineyardd.spill.config string             If you want to enable the spill mechanism, please set the name of spill config
+      --vineyardd.spill.path string               The path of spill config
+      --vineyardd.spill.pv-pvc-spec string        the json string of the persistent volume and persistent volume claim
+      --vineyardd.spill.spillLowerRate string     The low watermark of spilling memory (default "0.3")
+      --vineyardd.spill.spillUpperRate string     The high watermark of spilling memory (default "0.8")
+      --vineyardd.streamThreshold int             memory threshold of streams (percentage of total memory) (default 80)
+      --vineyardd.syncCRDs                        enable metrics of vineyardd (default true)
+      --vineyardd.volume.mountPath string         Set the mount path for the pvc
+      --vineyardd.volume.pvcname string           Set the pvc name for storing the vineyard objects persistently, 
+=======
+  -f, --file string                               the path of vineyardd
+  -h, --help                                      help for vineyard-deployment
+  -l, --label string                              label of the vineyardd
+      --name string                               the name of vineyardd (default "vineyardd-sample")
+      --plugin.backupImage string                 the backup image of vineyardd (default "ghcr.io/v6d-io/v6d/backup-job")
+      --plugin.daskRepartitionImage string        the dask repartition image of vineyardd workflow (default "ghcr.io/v6d-io/v6d/dask-repartition")
+      --plugin.distributedAssemblyImage string    the distributed image of vineyard workflow (default "ghcr.io/v6d-io/v6d/distributed-assembly")
+      --plugin.localAssemblyImage string          the local assembly image of vineyardd workflow (default "ghcr.io/v6d-io/v6d/local-assembly")
+      --plugin.recoverImage string                the recover image of vineyardd (default "ghcr.io/v6d-io/v6d/recover-job")
+      --vineyard.etcd.replicas int                the number of etcd replicas in a vineyard cluster (default 3)
+      --vineyard.replicas int                     the number of vineyardd replicas (default 3)
+      --vineyardd.cpu string                      The cpu of vineyard container
+      --vineyardd.envs strings                    The environment variables of vineyardd
+      --vineyardd.etcdEndpoint string             The etcd endpoint of vineyardd (default "http://etcd-for-vineyard:2379")
+      --vineyardd.etcdPrefix string               The etcd prefix of vineyardd (default "/vineyard")
+      --vineyardd.image string                    the image of vineyardd (default "vineyardcloudnative/vineyardd:latest")
+      --vineyardd.imagePullPolicy string          the imagePullPolicy of vineyardd (default "IfNotPresent")
+      --vineyardd.memory string                   The memory of vineyard container
+      --vineyardd.metric.enable                   enable metrics of vineyardd
+      --vineyardd.metric.image string             the metic image of vineyardd (default "vineyardcloudnative/vineyard-grok-exporter:latest")
+      --vineyardd.metric.imagePullPolicy string   the imagePullPolicy of the metric image (default "IfNotPresent")
+      --vineyardd.service.port int                the service port of vineyard service (default 9600)
+      --vineyardd.service.selector string         the service selector of vineyard service (default "rpc.vineyardd.v6d.io/rpc=vineyard-rpc")
+      --vineyardd.service.type string             the service type of vineyard service (default "ClusterIP")
+      --vineyardd.size string                     The size of vineyardd. You can use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki.  (default "256Mi")
+      --vineyardd.socket string                   The directory on host for the IPC socket file. The namespace and name will be replaced with your vineyard config (default "/var/run/vineyard-kubernetes/{{.Namespace}}/{{.Name}}")
+      --vineyardd.spill.config string             If you want to enable the spill mechanism, please set the name of spill config
+      --vineyardd.spill.path string               The path of spill config
+      --vineyardd.spill.pv-pvc-spec string        the json string of the persistent volume and persistent volume claim
+      --vineyardd.spill.spillLowerRate string     The low watermark of spilling memory (default "0.3")
+      --vineyardd.spill.spillUpperRate string     The high watermark of spilling memory (default "0.8")
+      --vineyardd.streamThreshold int             memory threshold of streams (percentage of total memory) (default 80)
+      --vineyardd.syncCRDs                        enable metrics of vineyardd (default true)
+      --vineyardd.volume.mountPath string         Set the mount path for the pvc
+      --vineyardd.volume.pvcname string           Set the pvc name for storing the vineyard objects persistently, 
+>>>>>>> Improve the vineyardctl inject command.
 ```
 
 ## `vineyardctl deploy vineyardd`
@@ -838,6 +910,7 @@ vineyardctl deploy vineyardd [flags]
 ### Options
 
 ```
+<<<<<<< HEAD
   -f, --file string                                   the path of vineyardd
   -h, --help                                          help for vineyardd
       --name string                                   the name of vineyardd (default "vineyardd-sample")
@@ -867,6 +940,75 @@ vineyardctl deploy vineyardd [flags]
       --vineyardd.syncCRDs                            enable metrics of vineyardd (default true)
       --vineyardd.volume.mountPath string             Set the mount path for the pvc
       --vineyardd.volume.pvcname string               Set the pvc name for storing the vineyard objects persistently, 
+||||||| constructed merge base
+  -f, --file string                               the path of vineyardd
+  -h, --help                                      help for vineyardd
+      --name string                               the name of vineyardd (default "vineyardd-sample")
+      --plugin.backupImage string                 the backup image of vineyardd (default "ghcr.io/v6d-io/v6d/backup-job")
+      --plugin.daskRepartitionImage string        the dask repartition image of vineyardd workflow (default "ghcr.io/v6d-io/v6d/dask-repartition")
+      --plugin.distributedAssemblyImage string    the distributed image of vineyard workflow (default "ghcr.io/v6d-io/v6d/distributed-assembly")
+      --plugin.localAssemblyImage string          the local assembly image of vineyardd workflow (default "ghcr.io/v6d-io/v6d/local-assembly")
+      --plugin.recoverImage string                the recover image of vineyardd (default "ghcr.io/v6d-io/v6d/recover-job")
+      --vineyard.etcd.replicas int                the number of etcd replicas in a vineyard cluster (default 3)
+      --vineyard.replicas int                     the number of vineyardd replicas (default 3)
+      --vineyardd.envs strings                    The environment variables of vineyardd
+      --vineyardd.etcdEndpoint string             The etcd endpoint of vineyardd (default "http://etcd-for-vineyard:2379")
+      --vineyardd.etcdPrefix string               The etcd prefix of vineyardd (default "/vineyard")
+      --vineyardd.image string                    the image of vineyardd (default "vineyardcloudnative/vineyardd:latest")
+      --vineyardd.imagePullPolicy string          the imagePullPolicy of vineyardd (default "IfNotPresent")
+      --vineyardd.metric.enable                   enable metrics of vineyardd
+      --vineyardd.metric.image string             the metic image of vineyardd (default "vineyardcloudnative/vineyard-grok-exporter:latest")
+      --vineyardd.metric.imagePullPolicy string   the imagePullPolicy of the metric image (default "IfNotPresent")
+      --vineyardd.service.port int                the service port of vineyard service (default 9600)
+      --vineyardd.service.selector string         the service selector of vineyard service (default "rpc.vineyardd.v6d.io/rpc=vineyard-rpc")
+      --vineyardd.service.type string             the service type of vineyard service (default "ClusterIP")
+      --vineyardd.size string                     The size of vineyardd. You can use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki.  (default "256Mi")
+      --vineyardd.socket string                   The directory on host for the IPC socket file. The namespace and name will be replaced with your vineyard config (default "/var/run/vineyard-kubernetes/{{.Namespace}}/{{.Name}}")
+      --vineyardd.spill.config string             If you want to enable the spill mechanism, please set the name of spill config
+      --vineyardd.spill.path string               The path of spill config
+      --vineyardd.spill.pv-pvc-spec string        the json string of the persistent volume and persistent volume claim
+      --vineyardd.spill.spillLowerRate string     The low watermark of spilling memory (default "0.3")
+      --vineyardd.spill.spillUpperRate string     The high watermark of spilling memory (default "0.8")
+      --vineyardd.streamThreshold int             memory threshold of streams (percentage of total memory) (default 80)
+      --vineyardd.syncCRDs                        enable metrics of vineyardd (default true)
+      --vineyardd.volume.mountPath string         Set the mount path for the pvc
+      --vineyardd.volume.pvcname string           Set the pvc name for storing the vineyard objects persistently, 
+=======
+  -f, --file string                               the path of vineyardd
+  -h, --help                                      help for vineyardd
+      --name string                               the name of vineyardd (default "vineyardd-sample")
+      --plugin.backupImage string                 the backup image of vineyardd (default "ghcr.io/v6d-io/v6d/backup-job")
+      --plugin.daskRepartitionImage string        the dask repartition image of vineyardd workflow (default "ghcr.io/v6d-io/v6d/dask-repartition")
+      --plugin.distributedAssemblyImage string    the distributed image of vineyard workflow (default "ghcr.io/v6d-io/v6d/distributed-assembly")
+      --plugin.localAssemblyImage string          the local assembly image of vineyardd workflow (default "ghcr.io/v6d-io/v6d/local-assembly")
+      --plugin.recoverImage string                the recover image of vineyardd (default "ghcr.io/v6d-io/v6d/recover-job")
+      --vineyard.etcd.replicas int                the number of etcd replicas in a vineyard cluster (default 3)
+      --vineyard.replicas int                     the number of vineyardd replicas (default 3)
+      --vineyardd.cpu string                      The cpu of vineyard container
+      --vineyardd.envs strings                    The environment variables of vineyardd
+      --vineyardd.etcdEndpoint string             The etcd endpoint of vineyardd (default "http://etcd-for-vineyard:2379")
+      --vineyardd.etcdPrefix string               The etcd prefix of vineyardd (default "/vineyard")
+      --vineyardd.image string                    the image of vineyardd (default "vineyardcloudnative/vineyardd:latest")
+      --vineyardd.imagePullPolicy string          the imagePullPolicy of vineyardd (default "IfNotPresent")
+      --vineyardd.memory string                   The memory of vineyard container
+      --vineyardd.metric.enable                   enable metrics of vineyardd
+      --vineyardd.metric.image string             the metic image of vineyardd (default "vineyardcloudnative/vineyard-grok-exporter:latest")
+      --vineyardd.metric.imagePullPolicy string   the imagePullPolicy of the metric image (default "IfNotPresent")
+      --vineyardd.service.port int                the service port of vineyard service (default 9600)
+      --vineyardd.service.selector string         the service selector of vineyard service (default "rpc.vineyardd.v6d.io/rpc=vineyard-rpc")
+      --vineyardd.service.type string             the service type of vineyard service (default "ClusterIP")
+      --vineyardd.size string                     The size of vineyardd. You can use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki.  (default "256Mi")
+      --vineyardd.socket string                   The directory on host for the IPC socket file. The namespace and name will be replaced with your vineyard config (default "/var/run/vineyard-kubernetes/{{.Namespace}}/{{.Name}}")
+      --vineyardd.spill.config string             If you want to enable the spill mechanism, please set the name of spill config
+      --vineyardd.spill.path string               The path of spill config
+      --vineyardd.spill.pv-pvc-spec string        the json string of the persistent volume and persistent volume claim
+      --vineyardd.spill.spillLowerRate string     The low watermark of spilling memory (default "0.3")
+      --vineyardd.spill.spillUpperRate string     The high watermark of spilling memory (default "0.8")
+      --vineyardd.streamThreshold int             memory threshold of streams (percentage of total memory) (default 80)
+      --vineyardd.syncCRDs                        enable metrics of vineyardd (default true)
+      --vineyardd.volume.mountPath string         Set the mount path for the pvc
+      --vineyardd.volume.pvcname string           Set the pvc name for storing the vineyard objects persistently, 
+>>>>>>> Improve the vineyardctl inject command.
 ```
 
 ## `vineyardctl inject`
@@ -876,7 +1018,8 @@ Inject the vineyard sidecar container into a workload
 ### Synopsis
 
 Inject the vineyard sidecar container into a workload. You can
-get the injected workload yaml and some etcd yaml from the output.
+input a workload yaml or a workload json and then get the injected 
+workload yaml and some etcd yaml from the output.
 
 ```
 vineyardctl inject [flags]
@@ -890,18 +1033,40 @@ vineyardctl inject [flags]
 
 ```shell
   # inject the default vineyard sidecar container into a workload
+  # and deploy an external etcd cluster
   vineyardctl inject -f workload.yaml | kubectl apply -f -
+  
+  # inject the default vineyard sidecar container but use the
+  # internal etcd cluster instead of the external etcd cluster
+  vineyardctl inject -f workload.yaml --use-internal-etcd=true | \
+  kubectl apply -f -
+
+  # inject the default vineyard sidecar container and not to deploy
+  # the rpc service of the vineyard cluster
+  vineyardctl inject -f workload.yaml --use-internal-etcd=true \
+  --deploy-rpc-service=false | kubectl apply -f -
+
+  # use json format to output the injected workload
+  vineyardctl inject -f workload.yaml -o json
 ```
 
 ### Options
 
 ```
+      --deploy-etcd-service                     Whether to deploy service for etcd cluster (default true)
+      --deploy-rpc-service                      Whether to deploy service for vineyard cluster (default true)
       --etcd-replicas int                       the number of etcd replicas (default 1)
+      --etcd-service-name string                The name of etcd service (default "etcd-for-vineyard")
   -f, --file string                             The yaml of workload
   -h, --help                                    help for inject
+      --name string                             The name of sidecar (default "vineyard-sidecar")
+  -o, --output string                           The output format of the command, support yaml and json (default "yaml")
+      --resource string                         The resource of workload
+      --sidecar.cpu string                      The cpu of vineyard container
       --sidecar.envs strings                    The environment variables of vineyardd
       --sidecar.image string                    the image of vineyardd (default "vineyardcloudnative/vineyardd:latest")
       --sidecar.imagePullPolicy string          the imagePullPolicy of vineyardd (default "IfNotPresent")
+      --sidecar.memory string                   The memory of vineyard container
       --sidecar.metric.enable                   enable metrics of vineyardd
       --sidecar.metric.image string             the metic image of vineyardd (default "vineyardcloudnative/vineyard-grok-exporter:latest")
       --sidecar.metric.imagePullPolicy string   the imagePullPolicy of the metric image (default "IfNotPresent")
@@ -918,6 +1083,7 @@ vineyardctl inject [flags]
       --sidecar.syncCRDs                        enable metrics of vineyardd (default true)
       --sidecar.volume.mountPath string         Set the mount path for the pvc
       --sidecar.volume.pvcname string           Set the pvc name for storing the vineyard objects persistently, 
+      --use-internal-etcd                       Whether to use the internal etcd
 ```
 
 ## `vineyardctl manager`

--- a/k8s/cmd/README.md
+++ b/k8s/cmd/README.md
@@ -707,10 +707,8 @@ vineyardctl deploy vineyard-deployment [flags]
 ### Options
 
 ```
-<<<<<<< HEAD
   -f, --file string                                   the path of vineyardd
   -h, --help                                          help for vineyard-deployment
-  -l, --label string                                  label of the vineyardd
       --name string                                   the name of vineyardd (default "vineyardd-sample")
       --pluginImage.backupImage string                the backup image of vineyardd (default "ghcr.io/v6d-io/v6d/backup-job")
       --pluginImage.daskRepartitionImage string       the dask repartition image of vineyardd workflow (default "ghcr.io/v6d-io/v6d/dask-repartition")
@@ -738,77 +736,6 @@ vineyardctl deploy vineyard-deployment [flags]
       --vineyardd.syncCRDs                            enable metrics of vineyardd (default true)
       --vineyardd.volume.mountPath string             Set the mount path for the pvc
       --vineyardd.volume.pvcname string               Set the pvc name for storing the vineyard objects persistently, 
-||||||| constructed merge base
-  -f, --file string                               the path of vineyardd
-  -h, --help                                      help for vineyard-deployment
-  -l, --label string                              label of the vineyardd
-      --name string                               the name of vineyardd (default "vineyardd-sample")
-      --plugin.backupImage string                 the backup image of vineyardd (default "ghcr.io/v6d-io/v6d/backup-job")
-      --plugin.daskRepartitionImage string        the dask repartition image of vineyardd workflow (default "ghcr.io/v6d-io/v6d/dask-repartition")
-      --plugin.distributedAssemblyImage string    the distributed image of vineyard workflow (default "ghcr.io/v6d-io/v6d/distributed-assembly")
-      --plugin.localAssemblyImage string          the local assembly image of vineyardd workflow (default "ghcr.io/v6d-io/v6d/local-assembly")
-      --plugin.recoverImage string                the recover image of vineyardd (default "ghcr.io/v6d-io/v6d/recover-job")
-      --vineyard.etcd.replicas int                the number of etcd replicas in a vineyard cluster (default 3)
-      --vineyard.replicas int                     the number of vineyardd replicas (default 3)
-      --vineyardd.envs strings                    The environment variables of vineyardd
-      --vineyardd.etcdEndpoint string             The etcd endpoint of vineyardd (default "http://etcd-for-vineyard:2379")
-      --vineyardd.etcdPrefix string               The etcd prefix of vineyardd (default "/vineyard")
-      --vineyardd.image string                    the image of vineyardd (default "vineyardcloudnative/vineyardd:latest")
-      --vineyardd.imagePullPolicy string          the imagePullPolicy of vineyardd (default "IfNotPresent")
-      --vineyardd.metric.enable                   enable metrics of vineyardd
-      --vineyardd.metric.image string             the metic image of vineyardd (default "vineyardcloudnative/vineyard-grok-exporter:latest")
-      --vineyardd.metric.imagePullPolicy string   the imagePullPolicy of the metric image (default "IfNotPresent")
-      --vineyardd.service.port int                the service port of vineyard service (default 9600)
-      --vineyardd.service.selector string         the service selector of vineyard service (default "rpc.vineyardd.v6d.io/rpc=vineyard-rpc")
-      --vineyardd.service.type string             the service type of vineyard service (default "ClusterIP")
-      --vineyardd.size string                     The size of vineyardd. You can use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki.  (default "256Mi")
-      --vineyardd.socket string                   The directory on host for the IPC socket file. The namespace and name will be replaced with your vineyard config (default "/var/run/vineyard-kubernetes/{{.Namespace}}/{{.Name}}")
-      --vineyardd.spill.config string             If you want to enable the spill mechanism, please set the name of spill config
-      --vineyardd.spill.path string               The path of spill config
-      --vineyardd.spill.pv-pvc-spec string        the json string of the persistent volume and persistent volume claim
-      --vineyardd.spill.spillLowerRate string     The low watermark of spilling memory (default "0.3")
-      --vineyardd.spill.spillUpperRate string     The high watermark of spilling memory (default "0.8")
-      --vineyardd.streamThreshold int             memory threshold of streams (percentage of total memory) (default 80)
-      --vineyardd.syncCRDs                        enable metrics of vineyardd (default true)
-      --vineyardd.volume.mountPath string         Set the mount path for the pvc
-      --vineyardd.volume.pvcname string           Set the pvc name for storing the vineyard objects persistently, 
-=======
-  -f, --file string                               the path of vineyardd
-  -h, --help                                      help for vineyard-deployment
-  -l, --label string                              label of the vineyardd
-      --name string                               the name of vineyardd (default "vineyardd-sample")
-      --plugin.backupImage string                 the backup image of vineyardd (default "ghcr.io/v6d-io/v6d/backup-job")
-      --plugin.daskRepartitionImage string        the dask repartition image of vineyardd workflow (default "ghcr.io/v6d-io/v6d/dask-repartition")
-      --plugin.distributedAssemblyImage string    the distributed image of vineyard workflow (default "ghcr.io/v6d-io/v6d/distributed-assembly")
-      --plugin.localAssemblyImage string          the local assembly image of vineyardd workflow (default "ghcr.io/v6d-io/v6d/local-assembly")
-      --plugin.recoverImage string                the recover image of vineyardd (default "ghcr.io/v6d-io/v6d/recover-job")
-      --vineyard.etcd.replicas int                the number of etcd replicas in a vineyard cluster (default 3)
-      --vineyard.replicas int                     the number of vineyardd replicas (default 3)
-      --vineyardd.cpu string                      The cpu of vineyard container
-      --vineyardd.envs strings                    The environment variables of vineyardd
-      --vineyardd.etcdEndpoint string             The etcd endpoint of vineyardd (default "http://etcd-for-vineyard:2379")
-      --vineyardd.etcdPrefix string               The etcd prefix of vineyardd (default "/vineyard")
-      --vineyardd.image string                    the image of vineyardd (default "vineyardcloudnative/vineyardd:latest")
-      --vineyardd.imagePullPolicy string          the imagePullPolicy of vineyardd (default "IfNotPresent")
-      --vineyardd.memory string                   The memory of vineyard container
-      --vineyardd.metric.enable                   enable metrics of vineyardd
-      --vineyardd.metric.image string             the metic image of vineyardd (default "vineyardcloudnative/vineyard-grok-exporter:latest")
-      --vineyardd.metric.imagePullPolicy string   the imagePullPolicy of the metric image (default "IfNotPresent")
-      --vineyardd.service.port int                the service port of vineyard service (default 9600)
-      --vineyardd.service.selector string         the service selector of vineyard service (default "rpc.vineyardd.v6d.io/rpc=vineyard-rpc")
-      --vineyardd.service.type string             the service type of vineyard service (default "ClusterIP")
-      --vineyardd.size string                     The size of vineyardd. You can use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki.  (default "256Mi")
-      --vineyardd.socket string                   The directory on host for the IPC socket file. The namespace and name will be replaced with your vineyard config (default "/var/run/vineyard-kubernetes/{{.Namespace}}/{{.Name}}")
-      --vineyardd.spill.config string             If you want to enable the spill mechanism, please set the name of spill config
-      --vineyardd.spill.path string               The path of spill config
-      --vineyardd.spill.pv-pvc-spec string        the json string of the persistent volume and persistent volume claim
-      --vineyardd.spill.spillLowerRate string     The low watermark of spilling memory (default "0.3")
-      --vineyardd.spill.spillUpperRate string     The high watermark of spilling memory (default "0.8")
-      --vineyardd.streamThreshold int             memory threshold of streams (percentage of total memory) (default 80)
-      --vineyardd.syncCRDs                        enable metrics of vineyardd (default true)
-      --vineyardd.volume.mountPath string         Set the mount path for the pvc
-      --vineyardd.volume.pvcname string           Set the pvc name for storing the vineyard objects persistently, 
->>>>>>> Improve the vineyardctl inject command.
 ```
 
 ## `vineyardctl deploy vineyardd`
@@ -910,7 +837,6 @@ vineyardctl deploy vineyardd [flags]
 ### Options
 
 ```
-<<<<<<< HEAD
   -f, --file string                                   the path of vineyardd
   -h, --help                                          help for vineyardd
       --name string                                   the name of vineyardd (default "vineyardd-sample")
@@ -940,75 +866,6 @@ vineyardctl deploy vineyardd [flags]
       --vineyardd.syncCRDs                            enable metrics of vineyardd (default true)
       --vineyardd.volume.mountPath string             Set the mount path for the pvc
       --vineyardd.volume.pvcname string               Set the pvc name for storing the vineyard objects persistently, 
-||||||| constructed merge base
-  -f, --file string                               the path of vineyardd
-  -h, --help                                      help for vineyardd
-      --name string                               the name of vineyardd (default "vineyardd-sample")
-      --plugin.backupImage string                 the backup image of vineyardd (default "ghcr.io/v6d-io/v6d/backup-job")
-      --plugin.daskRepartitionImage string        the dask repartition image of vineyardd workflow (default "ghcr.io/v6d-io/v6d/dask-repartition")
-      --plugin.distributedAssemblyImage string    the distributed image of vineyard workflow (default "ghcr.io/v6d-io/v6d/distributed-assembly")
-      --plugin.localAssemblyImage string          the local assembly image of vineyardd workflow (default "ghcr.io/v6d-io/v6d/local-assembly")
-      --plugin.recoverImage string                the recover image of vineyardd (default "ghcr.io/v6d-io/v6d/recover-job")
-      --vineyard.etcd.replicas int                the number of etcd replicas in a vineyard cluster (default 3)
-      --vineyard.replicas int                     the number of vineyardd replicas (default 3)
-      --vineyardd.envs strings                    The environment variables of vineyardd
-      --vineyardd.etcdEndpoint string             The etcd endpoint of vineyardd (default "http://etcd-for-vineyard:2379")
-      --vineyardd.etcdPrefix string               The etcd prefix of vineyardd (default "/vineyard")
-      --vineyardd.image string                    the image of vineyardd (default "vineyardcloudnative/vineyardd:latest")
-      --vineyardd.imagePullPolicy string          the imagePullPolicy of vineyardd (default "IfNotPresent")
-      --vineyardd.metric.enable                   enable metrics of vineyardd
-      --vineyardd.metric.image string             the metic image of vineyardd (default "vineyardcloudnative/vineyard-grok-exporter:latest")
-      --vineyardd.metric.imagePullPolicy string   the imagePullPolicy of the metric image (default "IfNotPresent")
-      --vineyardd.service.port int                the service port of vineyard service (default 9600)
-      --vineyardd.service.selector string         the service selector of vineyard service (default "rpc.vineyardd.v6d.io/rpc=vineyard-rpc")
-      --vineyardd.service.type string             the service type of vineyard service (default "ClusterIP")
-      --vineyardd.size string                     The size of vineyardd. You can use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki.  (default "256Mi")
-      --vineyardd.socket string                   The directory on host for the IPC socket file. The namespace and name will be replaced with your vineyard config (default "/var/run/vineyard-kubernetes/{{.Namespace}}/{{.Name}}")
-      --vineyardd.spill.config string             If you want to enable the spill mechanism, please set the name of spill config
-      --vineyardd.spill.path string               The path of spill config
-      --vineyardd.spill.pv-pvc-spec string        the json string of the persistent volume and persistent volume claim
-      --vineyardd.spill.spillLowerRate string     The low watermark of spilling memory (default "0.3")
-      --vineyardd.spill.spillUpperRate string     The high watermark of spilling memory (default "0.8")
-      --vineyardd.streamThreshold int             memory threshold of streams (percentage of total memory) (default 80)
-      --vineyardd.syncCRDs                        enable metrics of vineyardd (default true)
-      --vineyardd.volume.mountPath string         Set the mount path for the pvc
-      --vineyardd.volume.pvcname string           Set the pvc name for storing the vineyard objects persistently, 
-=======
-  -f, --file string                               the path of vineyardd
-  -h, --help                                      help for vineyardd
-      --name string                               the name of vineyardd (default "vineyardd-sample")
-      --plugin.backupImage string                 the backup image of vineyardd (default "ghcr.io/v6d-io/v6d/backup-job")
-      --plugin.daskRepartitionImage string        the dask repartition image of vineyardd workflow (default "ghcr.io/v6d-io/v6d/dask-repartition")
-      --plugin.distributedAssemblyImage string    the distributed image of vineyard workflow (default "ghcr.io/v6d-io/v6d/distributed-assembly")
-      --plugin.localAssemblyImage string          the local assembly image of vineyardd workflow (default "ghcr.io/v6d-io/v6d/local-assembly")
-      --plugin.recoverImage string                the recover image of vineyardd (default "ghcr.io/v6d-io/v6d/recover-job")
-      --vineyard.etcd.replicas int                the number of etcd replicas in a vineyard cluster (default 3)
-      --vineyard.replicas int                     the number of vineyardd replicas (default 3)
-      --vineyardd.cpu string                      The cpu of vineyard container
-      --vineyardd.envs strings                    The environment variables of vineyardd
-      --vineyardd.etcdEndpoint string             The etcd endpoint of vineyardd (default "http://etcd-for-vineyard:2379")
-      --vineyardd.etcdPrefix string               The etcd prefix of vineyardd (default "/vineyard")
-      --vineyardd.image string                    the image of vineyardd (default "vineyardcloudnative/vineyardd:latest")
-      --vineyardd.imagePullPolicy string          the imagePullPolicy of vineyardd (default "IfNotPresent")
-      --vineyardd.memory string                   The memory of vineyard container
-      --vineyardd.metric.enable                   enable metrics of vineyardd
-      --vineyardd.metric.image string             the metic image of vineyardd (default "vineyardcloudnative/vineyard-grok-exporter:latest")
-      --vineyardd.metric.imagePullPolicy string   the imagePullPolicy of the metric image (default "IfNotPresent")
-      --vineyardd.service.port int                the service port of vineyard service (default 9600)
-      --vineyardd.service.selector string         the service selector of vineyard service (default "rpc.vineyardd.v6d.io/rpc=vineyard-rpc")
-      --vineyardd.service.type string             the service type of vineyard service (default "ClusterIP")
-      --vineyardd.size string                     The size of vineyardd. You can use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki.  (default "256Mi")
-      --vineyardd.socket string                   The directory on host for the IPC socket file. The namespace and name will be replaced with your vineyard config (default "/var/run/vineyard-kubernetes/{{.Namespace}}/{{.Name}}")
-      --vineyardd.spill.config string             If you want to enable the spill mechanism, please set the name of spill config
-      --vineyardd.spill.path string               The path of spill config
-      --vineyardd.spill.pv-pvc-spec string        the json string of the persistent volume and persistent volume claim
-      --vineyardd.spill.spillLowerRate string     The low watermark of spilling memory (default "0.3")
-      --vineyardd.spill.spillUpperRate string     The high watermark of spilling memory (default "0.8")
-      --vineyardd.streamThreshold int             memory threshold of streams (percentage of total memory) (default 80)
-      --vineyardd.syncCRDs                        enable metrics of vineyardd (default true)
-      --vineyardd.volume.mountPath string         Set the mount path for the pvc
-      --vineyardd.volume.pvcname string           Set the pvc name for storing the vineyard objects persistently, 
->>>>>>> Improve the vineyardctl inject command.
 ```
 
 ## `vineyardctl inject`
@@ -1019,7 +876,102 @@ Inject the vineyard sidecar container into a workload
 
 Inject the vineyard sidecar container into a workload. You can
 input a workload yaml or a workload json and then get the injected 
-workload yaml and some etcd yaml from the output.
+workload and some etcd manifests from the output.
+
+The output is a set of manifests that includes the injected workload,
+the rpc service, the etcd service and the etcd cluster(e.g. several
+pods and services). Next, we will introduce a simple example to show
+the injection.
+
+Assume you have the following workload yaml:
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+    # Notice, you must set the namespace here
+  namespace: vineyard-job
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80
+```
+Then, you can use the following command to inject the vineyard sidecar
+
+$ vineyardctl inject -f workload.yaml --apply-resources
+
+After running the command, the main output(removed some unnecessary fields)
+is as follows:
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: nginx-deployment
+  namespace: vineyard-job
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+template:
+  metadata:
+  labels:
+    app: nginx
+    # the default sidecar name is vineyard-sidecar
+    app.vineyard.io/name: vineyard-sidecar
+  spec:
+    containers:
+    - command: null
+      image: nginx:1.14.2
+      name: nginx
+      ports:
+      - containerPort: 80
+      volumeMounts:
+      - mountPath: /var/run
+        name: vineyard-socket
+    - command:
+      - /bin/bash
+      - -c
+      - |
+        /usr/bin/wait-for-it.sh -t 60 vineyard-sidecar-etcd-service.vineyard-job.svc.cluster.local:2379; \
+        sleep 1; /usr/local/bin/vineyardd --sync_crds true --socket /var/run/vineyard.sock --size 256Mi \
+        --stream_threshold 80 --etcd_cmd etcd --etcd_prefix /vineyard \
+        --etcd_endpoint http://vineyard-sidecar-etcd-service:2379
+      env:
+      - name: VINEYARDD_UID
+        value: null
+      - name: VINEYARDD_NAME
+        value: vineyard-sidecar
+      - name: VINEYARDD_NAMESPACE
+        value: vineyard-job
+      image: vineyardcloudnative/vineyardd:latest
+      imagePullPolicy: IfNotPresent
+      name: vineyard-sidecar
+      ports:
+      - containerPort: 9600
+        name: vineyard-rpc
+        protocol: TCP
+      volumeMounts:
+      - mountPath: /var/run
+        name: vineyard-socket
+    volumes:
+    - emptyDir: {}
+      name: vineyard-socket
+```
+The sidecar template can be accessed from the following link:
+https://github.com/v6d-io/v6d/blob/main/k8s/pkg/templates/sidecar/injection-template.yaml
+also you can get some inspiration from the doc link:
+https://v6d.io/notes/cloud-native/vineyard-operator.html#installing-vineyard-as-sidecar
 
 ```
 vineyardctl inject [flags]
@@ -1032,41 +984,52 @@ vineyardctl inject [flags]
 ### Examples
 
 ```shell
+  # use json format to output the injected workload
+  # notice that the output is a json string of all manifests
+  # it looks like:
+  # {
+  #   "workload": "workload json string",
+  #   "rpc_service": "rpc service json string",
+  #   "etcd_service": "etcd service json string",
+  #   "etcd_internal_service": [
+  #     "etcd internal service json string 1",
+  #     "etcd internal service json string 2",
+  #     "etcd internal service json string 3"
+  #   ],
+  #   "etcd_pod": [
+  #     "etcd pod json string 1",
+  #     "etcd pod json string 2",
+  #     "etcd pod json string 3"
+  #   ]
+  # }
+  vineyardctl inject -f workload.yaml -o json
+
   # inject the default vineyard sidecar container into a workload
-  # and deploy an external etcd cluster
+  # output all injected manifests and then deploy them
   vineyardctl inject -f workload.yaml | kubectl apply -f -
   
-  # inject the default vineyard sidecar container but use the
-  # internal etcd cluster instead of the external etcd cluster
-  vineyardctl inject -f workload.yaml --use-internal-etcd=true | \
-  kubectl apply -f -
-
-  # inject the default vineyard sidecar container and not to deploy
-  # the rpc service of the vineyard cluster
-  vineyardctl inject -f workload.yaml --use-internal-etcd=true \
-  --deploy-rpc-service=false | kubectl apply -f -
-
-  # use json format to output the injected workload
-  vineyardctl inject -f workload.yaml -o json
+  # if you only want to get the injected workload yaml rather than
+  # all manifests that includes the etcd cluster and the rpc service,
+  # you can enable the apply-resources and then the manifests will be
+  # created during the injection, finally you will get the injected
+  # workload yaml
+  vineyardctl inject -f workload.yaml --apply-resources
 ```
 
 ### Options
 
 ```
-      --deploy-etcd-service                     Whether to deploy service for etcd cluster (default true)
-      --deploy-rpc-service                      Whether to deploy service for vineyard cluster (default true)
-      --etcd-replicas int                       the number of etcd replicas (default 1)
-      --etcd-service-name string                The name of etcd service (default "etcd-for-vineyard")
+      --apply-resources                         Whether to apply the resources including the etcd cluster and the rpc service if you enable this flag, the etcd cluster and the rpc service will be created during the injection
+      --etcd-replicas int                       The number of etcd replicas (default 1)
   -f, --file string                             The yaml of workload
   -h, --help                                    help for inject
       --name string                             The name of sidecar (default "vineyard-sidecar")
   -o, --output string                           The output format of the command, support yaml and json (default "yaml")
+      --owner-references string                 The owner reference of all injectied resources
       --resource string                         The resource of workload
-      --sidecar.cpu string                      The cpu of vineyard container
       --sidecar.envs strings                    The environment variables of vineyardd
       --sidecar.image string                    the image of vineyardd (default "vineyardcloudnative/vineyardd:latest")
       --sidecar.imagePullPolicy string          the imagePullPolicy of vineyardd (default "IfNotPresent")
-      --sidecar.memory string                   The memory of vineyard container
       --sidecar.metric.enable                   enable metrics of vineyardd
       --sidecar.metric.image string             the metic image of vineyardd (default "vineyardcloudnative/vineyard-grok-exporter:latest")
       --sidecar.metric.imagePullPolicy string   the imagePullPolicy of the metric image (default "IfNotPresent")
@@ -1083,7 +1046,6 @@ vineyardctl inject [flags]
       --sidecar.syncCRDs                        enable metrics of vineyardd (default true)
       --sidecar.volume.mountPath string         Set the mount path for the pvc
       --sidecar.volume.pvcname string           Set the pvc name for storing the vineyard objects persistently, 
-      --use-internal-etcd                       Whether to use the internal etcd
 ```
 
 ## `vineyardctl manager`

--- a/k8s/cmd/commands/deploy/deploy_vineyard_deployment.go
+++ b/k8s/cmd/commands/deploy/deploy_vineyard_deployment.go
@@ -111,8 +111,8 @@ func GetObjectsFromTemplate() ([]*unstructured.Unstructured, error) {
 	}
 	objects = append(objects, objs...)
 
-	podObjs, svcObjs, err := util.BuildObjsFromEtcdManifests(&EtcdConfig, vineyardd.Namespace,
-		vineyardd.Spec.EtcdReplicas, vineyardd.Spec.Vineyard.Image, vineyardd,
+	podObjs, svcObjs, err := util.BuildObjsFromEtcdManifests(&EtcdConfig, vineyardd.Name,
+		vineyardd.Namespace, vineyardd.Spec.EtcdReplicas, vineyardd.Spec.Vineyard.Image, vineyardd,
 		tmplFunc)
 	if err != nil {
 		return objects, errors.Wrap(err, "failed to build etcd objects")

--- a/k8s/cmd/commands/flags/sidecar_flags.go
+++ b/k8s/cmd/commands/flags/sidecar_flags.go
@@ -24,9 +24,6 @@ import (
 var (
 	// the following label is for vineyard rpc service
 
-	// DefaultSidecarLabel is the default name of the vineyard sidecar container
-	DefaultSidecarLabel = "sidecar.v6d.io/name"
-
 	// SidecarName is the name of sidecar
 	// it is also the label selector value of sidecar
 	SidecarName string

--- a/k8s/cmd/commands/flags/sidecar_flags.go
+++ b/k8s/cmd/commands/flags/sidecar_flags.go
@@ -22,8 +22,30 @@ import (
 )
 
 var (
+	// the following label is for vineyard rpc service
+
+	// DefaultSidecarLabel is the default name of the vineyard sidecar container
+	DefaultSidecarLabel = "sidecar.v6d.io/name"
+
+	// SidecarName is the name of sidecar
+	// it is also the label selector value of sidecar
+	SidecarName string
+
 	// WorkloadYaml is the yaml of workload
 	WorkloadYaml string
+
+	// WorkloadResource is the resource of workload
+	WorkloadResource string
+
+	// OutputFormat is the output format of the command
+	OutputFormat string
+
+	// ApplyResources means whether to apply the resources
+	// including the etcd cluster and the rpc service
+	ApplyResources bool
+
+	// OwnerReference is the owner reference of the workload
+	OwnerReference string
 
 	// SidecarOpts holds all configuration of sidecar Spec
 	SidecarOpts v1alpha1.SidecarSpec
@@ -38,7 +60,18 @@ func ApplySidecarOpts(cmd *cobra.Command) {
 	ApplyServiceOpts(&SidecarOpts.Service, "sidecar", cmd)
 	// setup the vineyard volumes if needed
 	ApplyVolumeOpts(&SidecarOpts.Volume, "sidecar", cmd)
+	cmd.Flags().StringVarP(&SidecarName, "name", "", "vineyard-sidecar",
+		"The name of sidecar")
 	cmd.Flags().IntVarP(&SidecarOpts.Replicas, "etcd-replicas", "", 1,
-		"the number of etcd replicas")
+		"The number of etcd replicas")
 	cmd.Flags().StringVarP(&WorkloadYaml, "file", "f", "", "The yaml of workload")
+	cmd.Flags().StringVarP(&WorkloadResource, "resource", "", "", "The resource of workload")
+	cmd.Flags().StringVarP(&OwnerReference, "owner-references", "", "",
+		"The owner reference of all injectied resources")
+	cmd.Flags().BoolVarP(&ApplyResources, "apply-resources", "", false,
+		"Whether to apply the resources including the etcd cluster and the rpc service "+
+			"if you enable this flag, the etcd cluster and the rpc service will be created during "+
+			"the injection")
+	cmd.Flags().StringVarP(&OutputFormat, "output", "o", "yaml",
+		"The output format of the command, support yaml and json")
 }

--- a/k8s/cmd/commands/sidecar/inject.go
+++ b/k8s/cmd/commands/sidecar/inject.go
@@ -16,6 +16,7 @@ limitations under the License.
 package sidecar
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -34,20 +35,75 @@ import (
 	"github.com/v6d-io/v6d/k8s/pkg/templates"
 )
 
+// OutputManifests contains all output json string of the injection
+type OutputManifests struct {
+	// Workload is the json string of the injected workload
+	// which contains the vineyard sidecar container
+	Workload string `json:"workload"`
+
+	// RPCService is the json string of the rpc service of the
+	// injected vineyard sidecar container
+	RPCService string `json:"rpc_service"`
+
+	// EtcdService is the json string of the etcd service of the
+	// injected vineyard sidecar container, which is used to connect
+	// the other vineyard sidecar containers when the workload uses
+	// the internal etcd cluster or connects to the external etcd cluster
+	// when the workload uses the external etcd cluster
+	EtcdService string `json:"etcd_service"`
+
+	// EtcdInternalServiceJSON is the json string of the etcd service
+	// which is used as the internal service to build a etcd cluster
+	// for vineyard sidecar container
+	EtcdInternalService []string `json:"etcd_internal_service"`
+
+	// EtcdPodJSON is the json string of the etcd pod
+	// which is used as the external etcd cluster
+	EtcdPod []string `json:"etcd_pod"`
+}
+
 var (
+	// JSONFormat is the json format
+	JSONFormat = "json"
+	// YAMLFormat is the yaml format
+	YAMLFormat = "yaml"
+
 	injectLong = util.LongDesc(`
 	Inject the vineyard sidecar container into a workload. You can
-	get the injected workload yaml and some etcd yaml from the output.`)
+	input a workload yaml or a workload json and then get the injected 
+	workload yaml and some etcd yaml from the output.`)
 
 	injectExample = util.Examples(`
-	# inject the default vineyard sidecar container into a workload
-	vineyardctl inject -f workload.yaml | kubectl apply -f -`)
+	# use json format to output the injected workload
+	# notice that the output is a json string of all manifests
+	# it looks like:
+	# {
+	#   "workload": "workload json string",
+	#   "rpc_service": "rpc service json string",
+	#   "etcd_service": "etcd service json string",
+	#   "etcd_internal_service": [
+	#     "etcd internal service json string 1",
+	#     "etcd internal service json string 2",
+	#     "etcd internal service json string 3"
+	#   ],
+	#   "etcd_pod": [
+	#     "etcd pod json string 1",
+	#     "etcd pod json string 2",
+	#     "etcd pod json string 3"
+	#   ]
+	# }
+	vineyardctl inject -f workload.yaml -o json
 
-	// the following label is for vineyard rpc service
-	// DefaultSidecarLabelName is the default label name of the vineyard sidecar container
-	DefaultSidecarLabelName = "app.kubernetes.io/name"
-	// DefaultSidecarLabelValue = "vineyard-sidecar"
-	DefaultSidecarLabelValue = "vineyard-sidecar"
+	# inject the default vineyard sidecar container into a workload
+	# output all injected manifests and then deploy them
+	vineyardctl inject -f workload.yaml | kubectl apply -f -
+	
+	# if you only want to get the injected workload yaml rather than
+	# all manifests that includes the etcd cluster and the rpc service,
+	# you can enable the apply-resources and then the manifests will be
+	# created during the injection, finally you will get the injected
+	# workload yaml
+	vineyardctl inject -f workload.yaml --apply-resources`)
 )
 
 // injectCmd inject the vineyard sidecar container into a workload
@@ -59,18 +115,63 @@ var injectCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		util.AssertNoArgs(cmd, args)
 
-		resource, err := util.ReadFromFile(flags.WorkloadYaml)
-		if err != nil {
-			log.Fatal(err, "failed to read the YAML spec from file")
+		if err := validateFormat(flags.OutputFormat); err != nil {
+			log.Fatal(err, "invalid output format")
 		}
 
-		yamls, err := GetManifestFromTemplate(resource)
+		resource, err := getWorkloadResource()
+		if err != nil {
+			log.Fatal(err, "failed to get the workload resource")
+		}
+
+		manifests, err := GetManifestFromTemplate(resource)
 		if err != nil {
 			log.Fatal(err, "failed to load manifest from template")
 		}
 
-		fmt.Println(strings.Join(yamls, "---\n"))
+		if flags.ApplyResources {
+			if err := deployDuringInjection(&manifests); err != nil {
+				log.Fatal(err, "failed to deploy the manifests during injection")
+			}
+		}
+
+		if err := outputInjectedResult(manifests); err != nil {
+			log.Fatal(err, "failed to output the injected result")
+		}
 	},
+}
+
+// validateFormat checks the format of the output
+func validateFormat(format string) error {
+	if format != YAMLFormat && format != JSONFormat {
+		return errors.New("the output format must be yaml or json")
+	}
+	return nil
+}
+
+// getWorkloadResource returns the workload resource from the input
+// return a yaml string
+func getWorkloadResource() (string, error) {
+	var (
+		resource string
+		err      error
+	)
+	if flags.WorkloadResource != "" && flags.WorkloadYaml != "" {
+		return "", errors.New("cannot specify both workload resource and workload yaml")
+	}
+	if flags.WorkloadResource != "" {
+		// convert the json string to yaml string
+		resource, err = util.ConvertToYaml(flags.WorkloadResource)
+		if err != nil {
+			return "", errors.Wrap(err, "failed to convert the workload resource to yaml")
+		}
+		return resource, nil
+	}
+	resource, err = util.ReadFromFile(flags.WorkloadYaml)
+	if err != nil {
+		return resource, errors.Wrap(err, "failed to read the YAML from file")
+	}
+	return resource, nil
 }
 
 // EtcdConfig holds the configuration of etcd
@@ -80,6 +181,7 @@ func getEtcdConfig() k8s.EtcdConfig {
 	return EtcdConfig
 }
 
+// GetWorkloadObj returns the unstructured object of the workload
 func GetWorkloadObj(workload string) (*unstructured.Unstructured, error) {
 	unstructuredObj, err := util.ParseManifestToObject(workload)
 	if err != nil {
@@ -101,82 +203,207 @@ func GetWorkloadObj(workload string) (*unstructured.Unstructured, error) {
 	return unstructuredObj, nil
 }
 
-// sidecarLabelSelector contains the label selector of vineyard sidecar
-var sidecarLabelSelector []k8s.ServiceLabelSelector
+// GetManifestFromTemplate returns the manifests from the template
+func GetManifestFromTemplate(workload string) (OutputManifests, error) {
+	var om OutputManifests
 
-func getSidecarLabelSelector() []k8s.ServiceLabelSelector {
-	return sidecarLabelSelector
-}
-
-func GetManifestFromTemplate(workload string) ([]string, error) {
-	objects := make([]*unstructured.Unstructured, 0)
-	manifests := []string{}
-	yamls := []string{}
+	ownerRef, err := getOwnerRefFromInput()
+	if err != nil {
+		return om, errors.Wrap(err, "failed to get owner reference from input")
+	}
 
 	workloadObj, err := GetWorkloadObj(workload)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get workload object")
+		return om, errors.Wrap(err, "failed to get workload object")
 	}
 	namespace := workloadObj.GetNamespace()
 
 	sidecar, err := buildSidecar(namespace)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to build sidecar")
+		return om, errors.Wrap(err, "failed to build sidecar")
 	}
 
 	sidecarManifests, err := templates.GetFilesRecursive("sidecar")
 	if err != nil {
-		return manifests, errors.Wrap(err, "failed to get sidecar manifests")
+		return om, errors.Wrap(err, "failed to get sidecar manifests")
 	}
 
 	tmplFunc := map[string]interface{}{
-		"getEtcdConfig":           getEtcdConfig,
-		"getServiceLabelSelector": getSidecarLabelSelector,
+		"getEtcdConfig": getEtcdConfig,
 	}
 
-	objs, err := util.BuildObjsFromEtcdManifests(&EtcdConfig, namespace,
+	podObjs, svcObjs, err := util.BuildObjsFromEtcdManifests(&EtcdConfig, namespace,
 		sidecar.Spec.Replicas, sidecar.Spec.Vineyard.Image, sidecar, tmplFunc)
 	if err != nil {
-		return manifests, errors.Wrap(err, "failed to build etcd objects")
+		return om, errors.Wrap(err, "failed to build etcd objects")
 	}
-	objects = append(objects, objs...)
+	for i := range podObjs {
+		podObjs[i].SetOwnerReferences(ownerRef)
+		ss, err := podObjs[i].MarshalJSON()
+		if err != nil {
+			return om, errors.Wrap(err, "failed to marshal the unstructuredObj")
+		}
+		om.EtcdPod = append(om.EtcdPod, string(ss))
+	}
+
+	for i := range svcObjs {
+		svcObjs[i].SetOwnerReferences(ownerRef)
+		ss, err := svcObjs[i].MarshalJSON()
+		if err != nil {
+			return om, errors.Wrap(err, "failed to marshal the unstructuredObj")
+		}
+		om.EtcdInternalService = append(om.EtcdInternalService, string(ss))
+	}
 
 	// set up the service for etcd
-	files := []string{"vineyardd/etcd-service.yaml", "vineyardd/service.yaml"}
+	files := []string{"vineyardd/etcd-service.yaml"}
+	objs, err := util.BuildObjsFromVineyarddManifests(files, sidecar, tmplFunc)
+	if err != nil {
+		return om, errors.Wrap(err, "failed to build vineyardd objects")
+	}
+	objs[0].SetOwnerReferences(ownerRef)
+	ss, err := objs[0].MarshalJSON()
+	if err != nil {
+		return om, errors.Wrap(err, "failed to marshal the unstructuredObj")
+	}
+	om.EtcdService = string(ss)
+
+	// set up the rpc service for vineyardd
+	files = []string{"vineyardd/service.yaml"}
 	objs, err = util.BuildObjsFromVineyarddManifests(files, sidecar, tmplFunc)
 	if err != nil {
-		return manifests, errors.Wrap(err, "failed to build vineyardd objects")
+		return om, errors.Wrap(err, "failed to build vineyardd objects")
 	}
-	objects = append(objects, objs...)
+	objs[0].SetOwnerReferences(ownerRef)
+	ss, err = objs[0].MarshalJSON()
+	if err != nil {
+		return om, errors.Wrap(err, "failed to marshal the unstructuredObj")
+	}
+	om.RPCService = string(ss)
 
 	// set up the vineyard sidecar
 	for _, sf := range sidecarManifests {
 		obj, err := util.RenderManifestAsObj(sf, sidecar, tmplFunc)
 		if err != nil {
-			return manifests, errors.Wrap(err,
+			return om, errors.Wrap(err,
 				fmt.Sprintf("failed to render manifest %s", sf))
 		}
 		if err := InjectSidecarConfig(sidecar, workloadObj, obj); err != nil {
-			return manifests, errors.Wrap(err, "failed to inject the sidecar config")
+			return om, errors.Wrap(err, "failed to inject the sidecar config")
 		}
-		objects = append(objects, workloadObj)
+		workloadObj.SetOwnerReferences(ownerRef)
+		ss, err := workloadObj.MarshalJSON()
+		if err != nil {
+			return om, errors.Wrap(err, "failed to marshal the unstructuredObj")
+		}
+		om.Workload = string(ss)
 	}
 
-	for _, o := range objects {
-		ss, err := o.MarshalJSON()
-		if err != nil {
-			return manifests, errors.Wrap(err, "failed to marshal the unstructuredObj")
-		}
+	return om, nil
+}
 
-		yaml, err := util.ConvertToYaml(string(ss))
-		if err != nil {
-			return manifests, errors.Wrap(err,
-				"failed to convert the unstructuredObj to yaml")
+func getOwnerRefFromInput() ([]metav1.OwnerReference, error) {
+	ownerRef := []metav1.OwnerReference{}
+
+	if flags.OwnerReference != "" {
+		ownerRef = make([]metav1.OwnerReference, 1)
+		if err := json.Unmarshal([]byte(flags.OwnerReference), &ownerRef); err != nil {
+			return nil, errors.Wrap(err, "failed to unmarshal the owner reference")
 		}
-		yamls = append(yamls, yaml)
 	}
 
-	return yamls, nil
+	return ownerRef, nil
+}
+
+func parseManifestsAsYAML(om OutputManifests) ([]string, error) {
+	var results []string
+
+	if len(om.EtcdPod) != 0 {
+		for _, m := range om.EtcdPod {
+			output, err := util.ConvertToYaml(m)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to convert EtcdPodJSON to yaml")
+			}
+			results = append(results, output)
+		}
+	}
+	if len(om.EtcdInternalService) != 0 {
+		for _, m := range om.EtcdInternalService {
+			output, err := util.ConvertToYaml(m)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to convert EtcdInternalServiceJSON to yaml")
+			}
+			results = append(results, output)
+		}
+	}
+	if om.EtcdService != "" {
+		output, err := util.ConvertToYaml(om.EtcdService)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to convert EtcdServiceJSON to yaml")
+		}
+		results = append(results, output)
+	}
+	if om.RPCService != "" {
+		output, err := util.ConvertToYaml(om.RPCService)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to convert RPCServiceJSON to yaml")
+		}
+		results = append(results, output)
+	}
+	if om.Workload != "" {
+		output, err := util.ConvertToYaml(om.Workload)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to convert WorkloadJSON to yaml")
+		}
+		results = append(results, output)
+	}
+	return results, nil
+}
+
+// deployDuringInjection deploys the manifests including the etcd cluster and the rpc service
+func deployDuringInjection(om *OutputManifests) error {
+	jsons := []string{om.EtcdService, om.RPCService}
+	jsons = append(jsons, om.EtcdPod...)
+	jsons = append(jsons, om.EtcdInternalService...)
+	// set up the several jsons to nil to avoid the output
+	om.EtcdPod = nil
+	om.EtcdInternalService = nil
+	om.EtcdService = ""
+	om.RPCService = ""
+
+	client := util.KubernetesClient()
+	// convert the manifest to unstructured object
+	for _, json := range jsons {
+		manifest, err := util.ConvertToYaml(json)
+		if err != nil {
+			return errors.Wrap(err, "failed to convert json to yaml")
+		}
+		obj, err := util.ParseManifestToObject(manifest)
+		if err != nil {
+			return errors.Wrap(err, "failed to parse the manifest to object")
+		}
+
+		// create the object during the injection
+		if err := util.CreateIfNotExists(client, obj); err != nil {
+			return errors.Wrap(err, "failed to create the object during the injection")
+		}
+	}
+
+	return nil
+}
+
+func outputInjectedResult(om OutputManifests) error {
+	if flags.OutputFormat == JSONFormat {
+		outputJSON, _ := json.Marshal(om)
+		fmt.Println(string(outputJSON))
+		return nil
+	}
+	yamls, err := parseManifestsAsYAML(om)
+	if err != nil {
+		return errors.Wrap(err, "failed to parse manifests as yaml")
+	}
+	fmt.Println(strings.Join(yamls, "---\n"))
+	return nil
 }
 
 func buildSidecar(namespace string) (*v1alpha1.Sidecar, error) {
@@ -204,7 +431,7 @@ func buildSidecar(namespace string) (*v1alpha1.Sidecar, error) {
 
 	sidecar := &v1alpha1.Sidecar{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      DefaultSidecarLabelValue,
+			Name:      flags.SidecarName,
 			Namespace: namespace,
 		},
 		Spec: *opts,
@@ -216,7 +443,7 @@ func buildSidecar(namespace string) (*v1alpha1.Sidecar, error) {
 func InjectSidecarConfig(sidecar *v1alpha1.Sidecar, workloadObj,
 	sidecarObj *unstructured.Unstructured,
 ) error {
-	selector := DefaultSidecarLabelName + "=" + DefaultSidecarLabelValue
+	selector := flags.DefaultSidecarLabel + "=" + flags.SidecarName
 	err := injector.InjectSidecar(workloadObj, sidecarObj, sidecar, selector)
 	if err != nil {
 		return errors.Wrap(err, "failed to inject the sidecar")

--- a/k8s/cmd/commands/sidecar/inject.go
+++ b/k8s/cmd/commands/sidecar/inject.go
@@ -79,13 +79,13 @@ var (
 	pods and services). Next, we will introduce a simple example to show
 	the injection.
 
-	Suppose you have the following workload yaml:
-
+	Assume you have the following workload yaml:` +
+		"\n```yaml" + `
 	apiVersion: apps/v1
 	kind: Deployment
 	metadata:
 	  name: nginx-deployment
-	  # Notice, you must set the namespace here
+	    # Notice, you must set the namespace here
 	  namespace: vineyard-job
 	spec:
 	  selector:
@@ -100,70 +100,70 @@ var (
 	      - name: nginx
 	        image: nginx:1.14.2
 	        ports:
-	        - containerPort: 80
-
+	        - containerPort: 80` +
+		"\n```" + `
 	Then, you can use the following command to inject the vineyard sidecar
 	
 	$ vineyardctl inject -f workload.yaml --apply-resources
 	
 	After running the command, the main output(removed some unnecessary fields)
-	is as follows:
-	
+	is as follows:` +
+		"\n```yaml" + `
 	apiVersion: apps/v1
 	kind: Deployment
 	metadata:
-  	  creationTimestamp: null
+	  creationTimestamp: null
 	  name: nginx-deployment
-      namespace: vineyard-job
+	  namespace: vineyard-job
 	spec:
-  	  selector:
-    	matchLabels:
-          app: nginx
-    template:
-      metadata:
-      labels:
-        app: nginx
-		# the default sidecar name is vineyard-sidecar
-        app.vineyard.io/name: vineyard-sidecar
-      spec:
-        containers:
-        - command: null
-          image: nginx:1.14.2
-          name: nginx
-          ports:
-          - containerPort: 80
-          volumeMounts:
-          - mountPath: /var/run
-            name: vineyard-socket
-        - command:
-          - /bin/bash
-          - -c
-          - |
-		    /usr/bin/wait-for-it.sh -t 60 vineyard-sidecar-etcd-service.vineyard-job.svc.cluster.local:2379; \
-		    sleep 1; /usr/local/bin/vineyardd --sync_crds true --socket /var/run/vineyard.sock --size 256Mi \
-		    --stream_threshold 80 --etcd_cmd etcd --etcd_prefix /vineyard \
-		    --etcd_endpoint http://vineyard-sidecar-etcd-service:2379
-          env:
-          - name: VINEYARDD_UID
-            value: null
-          - name: VINEYARDD_NAME
-            value: vineyard-sidecar
-          - name: VINEYARDD_NAMESPACE
-            value: vineyard-job
-          image: vineyardcloudnative/vineyardd:latest
-          imagePullPolicy: IfNotPresent
-          name: vineyard-sidecar
-          ports:
-          - containerPort: 9600
-            name: vineyard-rpc
-            protocol: TCP
-          volumeMounts:
-          - mountPath: /var/run
-            name: vineyard-socket
-        volumes:
-        - emptyDir: {}
-          name: vineyard-socket
-	
+	  selector:
+	    matchLabels:
+	      app: nginx
+	template:
+	  metadata:
+	  labels:
+	    app: nginx
+	    # the default sidecar name is vineyard-sidecar
+	    app.vineyard.io/name: vineyard-sidecar
+	  spec:
+	    containers:
+	    - command: null
+	      image: nginx:1.14.2
+	      name: nginx
+	      ports:
+	      - containerPort: 80
+	      volumeMounts:
+	      - mountPath: /var/run
+	        name: vineyard-socket
+	    - command:
+	      - /bin/bash
+	      - -c
+	      - |
+	        /usr/bin/wait-for-it.sh -t 60 vineyard-sidecar-etcd-service.vineyard-job.svc.cluster.local:2379; \
+	        sleep 1; /usr/local/bin/vineyardd --sync_crds true --socket /var/run/vineyard.sock --size 256Mi \
+	        --stream_threshold 80 --etcd_cmd etcd --etcd_prefix /vineyard \
+	        --etcd_endpoint http://vineyard-sidecar-etcd-service:2379
+	      env:
+	      - name: VINEYARDD_UID
+	        value: null
+	      - name: VINEYARDD_NAME
+	        value: vineyard-sidecar
+	      - name: VINEYARDD_NAMESPACE
+	        value: vineyard-job
+	      image: vineyardcloudnative/vineyardd:latest
+	      imagePullPolicy: IfNotPresent
+	      name: vineyard-sidecar
+	      ports:
+	      - containerPort: 9600
+	        name: vineyard-rpc
+	        protocol: TCP
+	      volumeMounts:
+	      - mountPath: /var/run
+	        name: vineyard-socket
+	    volumes:
+	    - emptyDir: {}
+	      name: vineyard-socket` +
+		"\n```" + `
 	The sidecar template can be accessed from the following link:
 	https://github.com/v6d-io/v6d/blob/main/k8s/pkg/templates/sidecar/injection-template.yaml
 	also you can get some inspiration from the doc link:

--- a/k8s/config/crd/bases/k8s.v6d.io_sidecars.yaml
+++ b/k8s/config/crd/bases/k8s.v6d.io_sidecars.yaml
@@ -80,6 +80,8 @@ spec:
                   streamThreshold: 80
                   syncCRDs: true
                 properties:
+                  cpu:
+                    type: string
                   env:
                     items:
                       properties:
@@ -149,6 +151,8 @@ spec:
                     type: string
                   imagePullPolicy:
                     default: IfNotPresent
+                    type: string
+                  memory:
                     type: string
                   size:
                     default: 256Mi

--- a/k8s/config/crd/bases/k8s.v6d.io_vineyardds.yaml
+++ b/k8s/config/crd/bases/k8s.v6d.io_vineyardds.yaml
@@ -101,6 +101,8 @@ spec:
                   streamThreshold: 80
                   syncCRDs: true
                 properties:
+                  cpu:
+                    type: string
                   env:
                     items:
                       properties:
@@ -170,6 +172,8 @@ spec:
                     type: string
                   imagePullPolicy:
                     default: IfNotPresent
+                    type: string
+                  memory:
                     type: string
                   size:
                     default: 256Mi

--- a/k8s/config/manager/kustomization.yaml
+++ b/k8s/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: vineyardcloudnative/vineyard-operator
+  newName: localhost:5001/vineyard-operator
   newTag: latest

--- a/k8s/config/manager/kustomization.yaml
+++ b/k8s/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: localhost:5001/vineyard-operator
+  newName: vineyardcloudnative/vineyard-operator
   newTag: latest

--- a/k8s/controllers/k8s/sidecar_controller.go
+++ b/k8s/controllers/k8s/sidecar_controller.go
@@ -80,7 +80,8 @@ func (r *SidecarReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 	// setup the etcd configuration
 	etcdReplicas := sidecar.Spec.EtcdReplicas
-	SidecarEtcd = BuildEtcdConfig(sidecar.Namespace, etcdReplicas, sidecar.Spec.Vineyard.Image)
+	SidecarEtcd = BuildEtcdConfig(sidecar.Name, sidecar.Namespace,
+		etcdReplicas, sidecar.Spec.Vineyard.Image)
 
 	for i := 0; i < etcdReplicas; i++ {
 		SidecarEtcd.Rank = i

--- a/k8s/controllers/k8s/sidecar_controller.go
+++ b/k8s/controllers/k8s/sidecar_controller.go
@@ -44,19 +44,6 @@ func getSidecarEtcdConfig() EtcdConfig {
 	return SidecarEtcd
 }
 
-// sidecarSvcLabelSelector contains the label selector of sidecar service
-var sidecarSvcLabelSelector []ServiceLabelSelector
-
-func init() {
-	sidecarSvcLabelSelector = make([]ServiceLabelSelector, 1)
-	sidecarSvcLabelSelector[0].Key = "rpc.vineyardd.v6d.io/rpc"
-	sidecarSvcLabelSelector[0].Value = "vineyardd-rpc"
-}
-
-func getSidecarSvcLabelSelector() []ServiceLabelSelector {
-	return sidecarSvcLabelSelector
-}
-
 // SidecarReconciler reconciles a Sidecar object
 type SidecarReconciler struct {
 	client.Client
@@ -88,8 +75,7 @@ func (r *SidecarReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		GVK:      k8sv1alpha1.GroupVersion.WithKind("Sidecar"),
 		Recorder: r.EventRecorder,
 		TmplFunc: map[string]interface{}{
-			"getEtcdConfig":           getSidecarEtcdConfig,
-			"getServiceLabelSelector": getSidecarSvcLabelSelector,
+			"getEtcdConfig": getSidecarEtcdConfig,
 		},
 	}
 	// setup the etcd configuration

--- a/k8s/controllers/k8s/vineyardd_controller.go
+++ b/k8s/controllers/k8s/vineyardd_controller.go
@@ -48,6 +48,7 @@ type VineyarddReconciler struct {
 
 // EtcdConfig holds all configuration about etcd
 type EtcdConfig struct {
+	Name      string
 	Namespace string
 	Rank      int
 	Endpoints string
@@ -127,7 +128,8 @@ func (r *VineyarddReconciler) Reconcile(
 
 	// set up the etcd configuration
 	etcdReplicas := vineyardd.Spec.EtcdReplicas
-	Etcd = BuildEtcdConfig(vineyardd.Namespace, etcdReplicas, vineyardd.Spec.Vineyard.Image)
+	Etcd = BuildEtcdConfig(vineyardd.Name, vineyardd.Namespace,
+		etcdReplicas, vineyardd.Spec.Vineyard.Image)
 
 	for i := 0; i < etcdReplicas; i++ {
 		Etcd.Rank = i
@@ -197,9 +199,11 @@ func (r *VineyarddReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 // BuildEtcdConfig builds the etcd config.
-func BuildEtcdConfig(namespace string, replicas int, image string) EtcdConfig {
+func BuildEtcdConfig(name string, namespace string,
+	replicas int, image string) EtcdConfig {
 	etcdConfig := EtcdConfig{}
 	// the etcd is built in the vineyardd image
+	etcdConfig.Name = name
 	etcdConfig.Image = image
 	etcdConfig.Namespace = namespace
 	etcdEndpoints := make([]string, 0, replicas)

--- a/k8s/controllers/k8s/vineyardd_controller.go
+++ b/k8s/controllers/k8s/vineyardd_controller.go
@@ -72,19 +72,6 @@ type ServiceLabelSelector struct {
 	Value string
 }
 
-// svcLabelSelector is the label selector of the service
-var svcLabelSelector []ServiceLabelSelector
-
-func init() {
-	svcLabelSelector = make([]ServiceLabelSelector, 1)
-	svcLabelSelector[0].Key = "rpc.vineyardd.v6d.io/rpc"
-	svcLabelSelector[0].Value = "vineyardd-rpc"
-}
-
-func getServiceLabelSelector() []ServiceLabelSelector {
-	return svcLabelSelector
-}
-
 // +kubebuilder:rbac:groups=k8s.v6d.io,resources=vineyardds,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=k8s.v6d.io,resources=vineyardds/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=k8s.v6d.io,resources=vineyardds/finalizers,verbs=update
@@ -127,8 +114,7 @@ func (r *VineyarddReconciler) Reconcile(
 		GVK:      k8sv1alpha1.GroupVersion.WithKind("Vineyardd"),
 		Recorder: r.EventRecorder,
 		TmplFunc: map[string]interface{}{
-			"getStorage":              getStorage,
-			"getServiceLabelSelector": getServiceLabelSelector,
+			"getStorage": getStorage,
 		},
 	}
 	etcdApp := kubernetes.Application{

--- a/k8s/pkg/config/labels/labels.go
+++ b/k8s/pkg/config/labels/labels.go
@@ -17,6 +17,11 @@ limitations under the License.
 package labels
 
 const (
+	/* following labels are used for speficifying the vineyard components */
+
+	// VineyardAppLabel is the special label key for vineyard application
+	VineyardAppLabel = "app.vineyard.io/name"
+
 	/* following labels are used for scheduling */
 
 	// SchedulingEnabledLabel is the label key for enabling scheduling

--- a/k8s/pkg/templates/etcd/etcd.yaml
+++ b/k8s/pkg/templates/etcd/etcd.yaml
@@ -18,7 +18,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    app: etcd
+    app.vineyard.io/name: {{ $etcd.Name }}
     etcd_node: etcd {{- $etcd.Rank }}
   name: etcd {{- $etcd.Rank }}
   namespace: {{ $etcd.Namespace }}

--- a/k8s/pkg/templates/etcd/service.yaml
+++ b/k8s/pkg/templates/etcd/service.yaml
@@ -21,6 +21,8 @@ metadata:
     etcd_node: etcd {{- $etcd.Rank }}
   name: etcd {{- $etcd.Rank }}
   namespace: {{ $etcd.Namespace }}
+  ownerReferences:
+    
 spec:
   ports:
   - name: client

--- a/k8s/pkg/templates/etcd/service.yaml
+++ b/k8s/pkg/templates/etcd/service.yaml
@@ -21,8 +21,6 @@ metadata:
     etcd_node: etcd {{- $etcd.Rank }}
   name: etcd {{- $etcd.Rank }}
   namespace: {{ $etcd.Namespace }}
-  ownerReferences:
-    
 spec:
   ports:
   - name: client

--- a/k8s/pkg/templates/sidecar/injection-template.yaml
+++ b/k8s/pkg/templates/sidecar/injection-template.yaml
@@ -19,7 +19,7 @@ spec:
       - /bin/bash
       - -c
       - >
-        /usr/bin/wait-for-it.sh -t 60 etcd-for-vineyard.{{ .Namespace }}.svc.cluster.local:2379;
+        /usr/bin/wait-for-it.sh -t 60 {{ .Name }}-etcd-service.{{ .Namespace }}.svc.cluster.local:2379;
         sleep 1;
         /usr/local/bin/vineyardd
         --sync_crds {{ .Spec.Vineyard.SyncCRDs }}
@@ -28,7 +28,7 @@ spec:
         --stream_threshold {{ .Spec.Vineyard.StreamThreshold }}
         --etcd_cmd etcd
         --etcd_prefix /vineyard
-        --etcd_endpoint http://etcd-for-vineyard:2379
+        --etcd_endpoint http://{{ .Name }}-etcd-service:2379
         {{- if .Spec.Vineyard.Spill.Path }}
         --spill_path {{ .Spec.Vineyard.Spill.Path }}
         --spill_lower_rate {{ .Spec.Vineyard.Spill.SpillLowerRate }}

--- a/k8s/pkg/templates/sidecar/injection-template.yaml
+++ b/k8s/pkg/templates/sidecar/injection-template.yaml
@@ -49,6 +49,15 @@ spec:
       {{- else }}
         mountPath: /var/run
       {{- end }}
+      {{- if and .Spec.Vineyard.CPU .Spec.Vineyard.Memory }}
+      resources:
+        requests:
+          cpu: "{{ .Spec.Vineyard.CPU }}"
+          memory: "{{ .Spec.Vineyard.Memory }}"
+        limits:
+          cpu: "{{ .Spec.Vineyard.CPU }}"
+          memory: "{{ .Spec.Vineyard.Memory }}"
+      {{- end }}
     {{- if .Spec.Metric.Enable }}
     - name: metrics
       image : {{ .Spec.Metric.Image }}
@@ -56,9 +65,9 @@ spec:
       command: ["./grok_exporter"]
       args: ["-config", "grok_exporter.yml", "-disable-exporter-metrics", "&"]
       ports:
-        - name: exporter
-          containerPort: 9144
-          protocol: TCP
+      - name: exporter
+        containerPort: 9144
+        protocol: TCP
       volumeMounts:
       - name: log
         mountPath: /var/log/vineyard

--- a/k8s/pkg/templates/vineyardd/deployment.yaml
+++ b/k8s/pkg/templates/vineyardd/deployment.yaml
@@ -12,31 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-{{- $l := getServiceLabelSelector }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Name }}
   namespace: {{ .Namespace }}
   labels:
-    app.kubernetes.io/name: {{ .Name }}
+    app.vineyard.io/name: {{ .Name }}
     app.kubernetes.io/instance: {{ .Namespace -}} - {{- .Name }}
     app.kubernetes.io/component: deployment
 spec:
   replicas: {{ .Spec.Replicas }}
   selector:
     matchLabels:
-      {{- range $l }}
-      {{.Key}}: "{{.Value}}"
-      {{- end }}
+      app.vineyard.io/name: {{ .Name }}
       app.kubernetes.io/name: {{ .Name }}
       app.kubernetes.io/instance: {{ .Namespace -}} - {{- .Name }}
   template:
     metadata:
       labels:
-        {{- range $l }}
-        {{.Key}}: "{{.Value}}"
-        {{- end }}
+        app.vineyard.io/name: {{ .Name }}
         app.kubernetes.io/name: {{ .Name }}
         app.kubernetes.io/instance: {{ .Namespace -}} - {{- .Name }}
         app.kubernetes.io/component: deployment
@@ -139,6 +135,15 @@ spec:
               mountPath: /dev/shm
             - name: log
               mountPath: /var/log/vineyard
+          {{- if and .Spec.VineyardConfig.CPU .Spec.VineyardConfig.Memory }}
+          resources:
+            requests:
+              cpu: "{{ .Spec.VineyardConfig.CPU }}"
+              memory: "{{ .Spec.VineyardConfig.Memory }}"
+            limits:
+              cpu: "{{ .Spec.VineyardConfig.CPU }}"
+              memory: "{{ .Spec.VineyardConfig.Memory }}"
+          {{- end }}
         {{- if .Spec.Metric.Enable }}
         - name: metrics
           image : {{ .Spec.Metric.Image }}

--- a/k8s/pkg/templates/vineyardd/deployment.yaml
+++ b/k8s/pkg/templates/vineyardd/deployment.yaml
@@ -48,7 +48,7 @@ spec:
           - /bin/bash
           - -c
           - >
-            /usr/bin/wait-for-it.sh -t 60 etcd-for-vineyard.{{ .Namespace }}.svc.cluster.local:2379;
+            /usr/bin/wait-for-it.sh -t 60 {{ .Name }}-etcd-service.{{ .Namespace }}.svc.cluster.local:2379;
             sleep 1;
             /usr/local/bin/vineyardd
             --sync_crds {{ .Spec.Vineyard.SyncCRDs }}
@@ -57,7 +57,7 @@ spec:
             --stream_threshold {{ .Spec.Vineyard.StreamThreshold }}
             --etcd_cmd etcd
             --etcd_prefix /vineyard
-            --etcd_endpoint http://etcd-for-vineyard:2379
+            --etcd_endpoint http://{{ .Name }}-etcd-service:2379
             {{- if .Spec.Vineyard.Spill.Path }}
             --spill_path {{ .Spec.Vineyard.Spill.Path }}
             --spill_lower_rate {{ .Spec.Vineyard.Spill.SpillLowerRate }}

--- a/k8s/pkg/templates/vineyardd/deployment.yaml
+++ b/k8s/pkg/templates/vineyardd/deployment.yaml
@@ -135,14 +135,14 @@ spec:
               mountPath: /dev/shm
             - name: log
               mountPath: /var/log/vineyard
-          {{- if and .Spec.VineyardConfig.CPU .Spec.VineyardConfig.Memory }}
+          {{- if and .Spec.Vineyard.CPU .Spec.Vineyard.Memory }}
           resources:
             requests:
-              cpu: "{{ .Spec.VineyardConfig.CPU }}"
-              memory: "{{ .Spec.VineyardConfig.Memory }}"
+              cpu: "{{ .Spec.Vineyard.CPU }}"
+              memory: "{{ .Spec.Vineyard.Memory }}"
             limits:
-              cpu: "{{ .Spec.VineyardConfig.CPU }}"
-              memory: "{{ .Spec.VineyardConfig.Memory }}"
+              cpu: "{{ .Spec.Vineyard.CPU }}"
+              memory: "{{ .Spec.Vineyard.Memory }}"
           {{- end }}
         {{- if .Spec.Metric.Enable }}
         - name: metrics

--- a/k8s/pkg/templates/vineyardd/etcd-service.yaml
+++ b/k8s/pkg/templates/vineyardd/etcd-service.yaml
@@ -16,7 +16,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: etcd-for-vineyard
+  name: {{ .Name }}-etcd-service
   namespace: {{ .Namespace }}
 spec:
   ports:
@@ -25,4 +25,4 @@ spec:
     protocol: TCP
     targetPort: 2379
   selector:
-    app: etcd
+    app.vineyard.io/name: {{ .Name }}

--- a/k8s/pkg/templates/vineyardd/service.yaml
+++ b/k8s/pkg/templates/vineyardd/service.yaml
@@ -13,17 +13,13 @@
 # limitations under the License.
 #
 
-{{- $l := getServiceLabelSelector }}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Name }}-rpc
   namespace: {{ .Namespace }}
   labels:
-    app.kubernetes.io/name: {{ .Name }}
-    {{- range $l }}
-    {{.Key}}: "{{.Value}}"
-    {{- end }}
+    app.vineyard.io/name: {{ .Name }}
 spec:
   type: {{ .Spec.Service.Type }}
   ports:
@@ -31,7 +27,4 @@ spec:
       protocol: TCP
       name: vineyard-rpc
   selector:
-    app.kubernetes.io/name: {{ .Name }}
-    {{- range $l }}
-    {{.Key}}: "{{.Value}}"
-    {{- end }}
+    app.vineyard.io/name: {{ .Name }}

--- a/k8s/pkg/templates/vineyardd/spill-pv.yaml
+++ b/k8s/pkg/templates/vineyardd/spill-pv.yaml
@@ -20,7 +20,7 @@ metadata:
   name: {{ .Spec.Vineyard.Spill.Name }}
   namespace: {{ .Namespace }}
   labels:
-    app.vineyard.io/name: {{ .Name }}
+    app.vineyard.io/name: {{ .Spec.Vineyard.Spill.Name }}
     app.kubernetes.io/name: {{ .Spec.Vineyard.Spill.Name }}
     app.kubernetes.io/instance: vineyardd
     app.kubernetes.io/component: PersistentVolume

--- a/k8s/pkg/templates/vineyardd/spill-pv.yaml
+++ b/k8s/pkg/templates/vineyardd/spill-pv.yaml
@@ -20,6 +20,7 @@ metadata:
   name: {{ .Spec.Vineyard.Spill.Name }}
   namespace: {{ .Namespace }}
   labels:
+    app.vineyard.io/name: {{ .Name }}
     app.kubernetes.io/name: {{ .Spec.Vineyard.Spill.Name }}
     app.kubernetes.io/instance: vineyardd
     app.kubernetes.io/component: PersistentVolume

--- a/k8s/pkg/templates/vineyardd/spill-pvc.yaml
+++ b/k8s/pkg/templates/vineyardd/spill-pvc.yaml
@@ -20,7 +20,7 @@ metadata:
   name: {{ .Spec.Vineyard.Spill.Name }}
   namespace: {{ .Namespace }}
   labels:
-    app.kubernetes.io/name: {{ .Name }}
+    app.vineyard.io/name: {{ .Name }}
     app.kubernetes.io/instance: vineyardd
     app.kubernetes.io/component: PersistentVolumeClaim
 spec:

--- a/k8s/pkg/templates/vineyardd/spill-pvc.yaml
+++ b/k8s/pkg/templates/vineyardd/spill-pvc.yaml
@@ -20,7 +20,7 @@ metadata:
   name: {{ .Spec.Vineyard.Spill.Name }}
   namespace: {{ .Namespace }}
   labels:
-    app.vineyard.io/name: {{ .Name }}
+    app.vineyard.io/name: {{ .Spec.Vineyard.Spill.Name }}
     app.kubernetes.io/instance: vineyardd
     app.kubernetes.io/component: PersistentVolumeClaim
 spec:

--- a/k8s/pkg/templates/vineyardd/spill-pvc.yaml
+++ b/k8s/pkg/templates/vineyardd/spill-pvc.yaml
@@ -21,6 +21,7 @@ metadata:
   namespace: {{ .Namespace }}
   labels:
     app.vineyard.io/name: {{ .Spec.Vineyard.Spill.Name }}
+    app.kubernetes.io/name: {{ .Spec.Vineyard.Spill.Name }}
     app.kubernetes.io/instance: vineyardd
     app.kubernetes.io/component: PersistentVolumeClaim
 spec:

--- a/k8s/test/e2e/sidecar/e2e.yaml
+++ b/k8s/test/e2e/sidecar/e2e.yaml
@@ -24,7 +24,8 @@ setup:
     - name: install app with default sidecar
       command: |
         kubectl create namespace vineyard-job
-        go run k8s/cmd/main.go inject -f k8s/test/e2e/sidecar-demo/sidecar-with-default-sidecar.yaml | kubectl apply -f -
+        go run k8s/cmd/main.go inject -f k8s/test/e2e/sidecar-demo/sidecar-with-default-sidecar.yaml --apply-resources\
+        | kubectl apply -f -
       wait:
         - namespace: vineyard-job
           resource: deployment/job-deployment-with-default-sidecar


### PR DESCRIPTION
What do these changes do?
-------------------------

* Support setting up the memory and cpu of vineyard sidecar container.
* Support applying the resources during injection such as etcd cluster.
* Delete the cmd and prefix of etcd in the sidecar template.
* Use a json string to output all manifests when set up the output as json format.
* Add OwnerReferences for the injected manifests in the vineyardctl inject command.


Related issue number
--------------------

Fixes #1303

