### PR TITLE
Mitigate the race condition about send/recv file descriptors

### DIFF
--- a/go/vineyard/pkg/common/memory/fling.cc
+++ b/go/vineyard/pkg/common/memory/fling.cc
@@ -107,6 +107,8 @@ int recv_fd(int conn) {
     ssize_t r = recvmsg(conn, &msg, 0);
     if (r == -1) {
       if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+        std::clog << "[warn] error occurred while looping in sending fd: "
+                  << strerror(errno) << std::endl;
         continue;
       } else {
         std::clog << "[error] Error in recv_fd (errno = " << errno << ")"

--- a/python/vineyard/_C.pyi
+++ b/python/vineyard/_C.pyi
@@ -278,6 +278,22 @@ class ClientBase:
     def version(self) -> str: ...
 
 class IPCClient(ClientBase):
+    def get(
+        self,
+        object_id: ObjectID = None,
+        name: str = None,
+        resolver: "ResolverContext" = None,
+        fetch: bool = False,
+        **kw
+    ): ...
+    def put(
+        self,
+        value: Any,
+        builder: "BuilderContext" = None,
+        persist: bool = False,
+        name: str = None,
+        **kwargs
+    ): ...
     def create_blob(self, size: int) -> BlobBuilder: ...
     def create_empty_blob(self) -> BlobBuilder: ...
     def get_blob(self, object_id: ObjectID, unsafe: bool = False) -> Blob: ...
@@ -309,6 +325,22 @@ class IPCClient(ClientBase):
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None: ...
 
 class RPCClient(ClientBase):
+    def get(
+        self,
+        object_id: ObjectID = None,
+        name: str = None,
+        resolver: "ResolverContext" = None,
+        fetch: bool = False,
+        **kw
+    ): ...
+    def put(
+        self,
+        value: Any,
+        builder: "BuilderContext" = None,
+        persist: bool = False,
+        name: str = None,
+        **kwargs
+    ): ...
     def create_remote_blob(self, size: int) -> RemoteBlobBuilder: ...
     def get_remote_blob(
         self, object_id: ObjectID, unsafe: bool = False

--- a/python/vineyard/conftest.py
+++ b/python/vineyard/conftest.py
@@ -104,12 +104,20 @@ def pytest_addoption(parser):
 
 @pytest.fixture(scope='session')
 def vineyard_ipc_sockets(request):
-    return request.config.option.vineyard_ipc_sockets.split(',')
+    if request.config.option.vineyard_ipc_sockets:
+        return request.config.option.vineyard_ipc_sockets.split(',')
+    if request.config.option.vineyard_ipc_socket:
+        return [request.config.option.vineyard_ipc_socket]
+    return None
 
 
 @pytest.fixture(scope='session')
 def vineyard_endpoints(request):
-    return request.config.option.vineyard_endpoint.split(',')
+    if request.config.option.vineyard_endpoints:
+        return request.config.option.vineyard_endpoints.split(',')
+    if request.config.option.vineyard_endpoint:
+        return [request.config.option.vineyard_endpoint]
+    return None
 
 
 @pytest.fixture(scope='session')

--- a/python/vineyard/core/builder.py
+++ b/python/vineyard/core/builder.py
@@ -21,6 +21,7 @@ import copy
 import inspect
 import threading
 import warnings
+from typing import Any
 
 from vineyard._C import IPCClient
 from vineyard._C import Object
@@ -134,7 +135,14 @@ def builder_context(builders=None, base=None):
         _builder_context_local.default_builder = current_builder
 
 
-def put(client, value, builder=None, persist=False, name=None, **kwargs):
+def put(
+    client,
+    value: Any,
+    builder: BuilderContext = None,
+    persist: bool = False,
+    name: str = None,
+    **kwargs
+):
     """Put python value to vineyard.
 
     .. code:: python

--- a/python/vineyard/core/resolver.py
+++ b/python/vineyard/core/resolver.py
@@ -168,7 +168,14 @@ def resolver_context(resolvers=None, base=None):
         _resolver_context_local.default_resolver = current_resolver
 
 
-def get(client, object_id=None, name=None, resolver=None, fetch=False, **kw):
+def get(
+    client,
+    object_id: ObjectID = None,
+    name: str = None,
+    resolver: ResolverContext = None,
+    fetch: bool = False,
+    **kw
+):
     """Get vineyard object as python value.
 
     .. code:: python

--- a/python/vineyard/core/tests/test_client.py
+++ b/python/vineyard/core/tests/test_client.py
@@ -16,10 +16,31 @@
 # limitations under the License.
 #
 
+import itertools
+import multiprocessing
+import random
+import traceback
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+
+import pytest
+
+import vineyard
 from vineyard._C import ObjectMeta
 from vineyard.core import default_builder_context
 from vineyard.core import default_resolver_context
 from vineyard.data import register_builtin_types
+
+
+def generate_vineyard_ipc_sockets(vineyard_ipc_sockets, nclients):
+    return list(itertools.islice(itertools.cycle(vineyard_ipc_sockets), nclients))
+
+
+def generate_vineyard_ipc_clients(vineyard_ipc_sockets, nclients):
+    vineyard_ipc_sockets = generate_vineyard_ipc_sockets(vineyard_ipc_sockets, nclients)
+    return tuple(vineyard.connect(sock) for sock in vineyard_ipc_sockets)
+
 
 register_builtin_types(default_builder_context, default_resolver_context)
 
@@ -95,3 +116,168 @@ def test_persist_multiref(vineyard_client):
     meta.set_global(True)
     rmeta = vineyard_client.create_metadata(meta)
     vineyard_client.persist(rmeta)
+
+
+def test_concurrent_blob(vineyard_ipc_sockets):  # noqa: C901
+    clients = generate_vineyard_ipc_clients(vineyard_ipc_sockets, 4)
+
+    def job1(client):
+        o = None
+        try:
+            o = client.get_object(client.put(np.ones((1, 2, 3))))
+            client.delete(o.id)
+        except Exception as e:  # pylint: disable=broad-except
+            pytest.fail('failed: %s' % e)
+        return True
+
+    def job2(client):
+        o = None
+        try:
+            o = client.get_object(client.put(np.ones((2, 3, 4))))
+            client.delete(o.id)
+        except Exception as e:  # pylint: disable=broad-except
+            pytest.fail('failed: %s' % e)
+        return True
+
+    def job3(client):
+        o = None
+        try:
+            o = client.get_object(client.put(np.ones((3, 4, 5))))
+            client.delete(o.id)
+        except Exception as e:  # pylint: disable=broad-except
+            pytest.fail('failed: %s' % e)
+        return True
+
+    def job4(client):
+        o = None
+        try:
+            o = client.get_object(client.put(np.ones((4, 5, 6))))
+            client.delete(o.id)
+        except Exception as e:  # pylint: disable=broad-except
+            pytest.fail('failed: %s' % e)
+        return True
+
+    def job5(client):
+        o = None
+        try:
+            o = client.get_object(client.put((np.ones((1, 2, 3)), np.ones((2, 3, 4)))))
+            client.delete(o.id)
+        except Exception as e:  # pylint: disable=broad-except
+            pytest.fail('failed: %s' % e)
+        return True
+
+    jobs = [job1, job2, job3, job4, job5]
+
+    with ThreadPoolExecutor(32) as executor:
+        fs, rs = [], []
+        for _ in range(1024):
+            job = random.choice(jobs)
+            client = random.choice(clients)
+            fs.append(executor.submit(job, client))
+        for future in fs:
+            rs.append(future.result())
+        if not all(rs):
+            pytest.fail("Failed to execute tests ...")
+
+
+def test_concurrent_blob_mp(  # noqa: C901, pylint: disable=too-many-statements
+    vineyard_ipc_sockets,
+):
+    num_proc = 32
+    job_per_proc = 64
+
+    vineyard_ipc_sockets = generate_vineyard_ipc_sockets(vineyard_ipc_sockets, num_proc)
+
+    def job1(rs, state, client):
+        o = None
+        try:
+            o = client.get_object(client.put(np.ones((1, 2, 3))))
+            client.delete(o.id)
+        except Exception as e:  # pylint: disable=broad-except
+            print('failed with %r: %s' % (o, e), flush=True)
+            traceback.print_exc()
+            state.value = -1
+            rs.put((False, 'failed: %s' % e))
+        else:
+            rs.put((True, ''))
+
+    def job2(rs, state, client):
+        o = None
+        try:
+            o = client.get_object(client.put(np.ones((2, 3, 4))))
+            client.delete(o.id)
+        except Exception as e:  # pylint: disable=broad-except
+            print('failed with %r: %s' % (o, e), flush=True)
+            traceback.print_exc()
+            state.value = -1
+            rs.put((False, 'failed: %s' % e))
+        else:
+            rs.put((True, ''))
+
+    def job3(rs, state, client):
+        o = None
+        try:
+            o = client.get_object(client.put(np.ones((3, 4, 5))))
+            client.delete(o.id)
+        except Exception as e:  # pylint: disable=broad-except
+            print('failed with %r: %s' % (o, e), flush=True)
+            traceback.print_exc()
+            state.value = -1
+            rs.put((False, 'failed: %s' % e))
+        else:
+            rs.put((True, ''))
+
+    def job4(rs, state, client):
+        o = None
+        try:
+            o = client.get_object(client.put((np.ones((4, 5, 6)))))
+            client.delete(o.id)
+        except Exception as e:  # pylint: disable=broad-except
+            print('failed with %r: %s' % (o, e), flush=True)
+            traceback.print_exc()
+            state.value = -1
+            rs.put((False, 'failed: %s' % e))
+        else:
+            rs.put((True, ''))
+
+    def job5(rs, state, client):
+        o = None
+        try:
+            o = client.get_object(client.put((np.ones((1, 2, 3)), np.ones((2, 3, 4)))))
+            client.delete(o.id)
+        except Exception as e:  # pylint: disable=broad-except
+            print('failed with %r: %s' % (o, e), flush=True)
+            traceback.print_exc()
+            state.value = -1
+            rs.put((False, 'failed: %s' % e))
+        else:
+            rs.put((True, ''))
+
+    def start_requests(rs, state, ipc_socket):
+        jobs = [job1, job2, job3, job4, job5]
+        client = vineyard.connect(ipc_socket).fork()
+
+        for _ in range(job_per_proc):
+            if state.value != 0:
+                break
+            job = random.choice(jobs)
+            job(rs, state, client)
+
+    ctx = multiprocessing.get_context(method='fork')
+    procs, rs, state = [], ctx.Queue(), ctx.Value('i', 0)
+    for sock in vineyard_ipc_sockets:
+        proc = ctx.Process(
+            target=start_requests,
+            args=(
+                rs,
+                state,
+                sock,
+            ),
+        )
+        proc.start()
+        procs.append(proc)
+
+    for _ in range(num_proc * job_per_proc):
+        r, message = rs.get(block=True)
+        if not r:
+            pytest.fail(message)

--- a/python/vineyard/deploy/tests/test_distributed.py
+++ b/python/vineyard/deploy/tests/test_distributed.py
@@ -169,7 +169,6 @@ def test_concurrent_meta(vineyard_ipc_sockets):  # noqa: C901
                 client.delete(o.id)
         except Exception as e:  # pylint: disable=broad-except
             pytest.fail('failed: %s' % e)
-            return False
         return True
 
     def job2(client):
@@ -179,7 +178,6 @@ def test_concurrent_meta(vineyard_ipc_sockets):  # noqa: C901
                 client.delete(o.id)
         except Exception as e:  # pylint: disable=broad-except
             pytest.fail('failed: %s' % e)
-            return False
         return True
 
     def job3(client):
@@ -189,7 +187,6 @@ def test_concurrent_meta(vineyard_ipc_sockets):  # noqa: C901
                 client.delete(o.id)
         except Exception as e:  # pylint: disable=broad-except
             pytest.fail('failed: %s' % e)
-            return False
         return True
 
     def job4(client):
@@ -199,7 +196,6 @@ def test_concurrent_meta(vineyard_ipc_sockets):  # noqa: C901
                 client.delete(o.id)
         except Exception as e:  # pylint: disable=broad-except
             pytest.fail('failed: %s' % e)
-            return False
         return True
 
     def job5(client):
@@ -209,7 +205,6 @@ def test_concurrent_meta(vineyard_ipc_sockets):  # noqa: C901
                 client.delete(o.id)
         except Exception as e:  # pylint: disable=broad-except
             pytest.fail('failed: %s' % e)
-            return False
         return True
 
     jobs = [job1, job2, job3, job4, job5]
@@ -235,6 +230,7 @@ def test_concurrent_meta_mp(  # noqa: C901, pylint: disable=too-many-statements
     vineyard_ipc_sockets = generate_vineyard_ipc_sockets(vineyard_ipc_sockets, num_proc)
 
     def job1(rs, state, client):
+        o = None
         try:
             o = client.get_object(client.put(1))
             # client.persist(o.id)
@@ -249,10 +245,9 @@ def test_concurrent_meta_mp(  # noqa: C901, pylint: disable=too-many-statements
             rs.put((False, 'failed: %s' % e))
         else:
             rs.put((True, ''))
-        finally:
-            print('job finished', flush=True)
 
     def job2(rs, state, client):
+        o = None
         try:
             o = client.get_object(client.put(1.23456))
             # client.persist(o.id)
@@ -267,10 +262,9 @@ def test_concurrent_meta_mp(  # noqa: C901, pylint: disable=too-many-statements
             rs.put((False, 'failed: %s' % e))
         else:
             rs.put((True, ''))
-        finally:
-            print('job finished', flush=True)
 
     def job3(rs, state, client):
+        o = None
         try:
             o = client.get_object(client.put('xxxxabcd'))
             # client.persist(o.id)
@@ -285,10 +279,9 @@ def test_concurrent_meta_mp(  # noqa: C901, pylint: disable=too-many-statements
             rs.put((False, 'failed: %s' % e))
         else:
             rs.put((True, ''))
-        finally:
-            print('job finished', flush=True)
 
     def job4(rs, state, client):
+        o = None
         try:
             o = client.get_object(client.put((1, 1.2345)))
             # client.persist(o.id)
@@ -303,10 +296,9 @@ def test_concurrent_meta_mp(  # noqa: C901, pylint: disable=too-many-statements
             rs.put((False, 'failed: %s' % e))
         else:
             rs.put((True, ''))
-        finally:
-            print('job finished', flush=True)
 
     def job5(rs, state, client):
+        o = None
         try:
             o = client.get_object(client.put((1, 1.2345, 'xxxxabcd')))
             # client.persist(o.id)
@@ -321,8 +313,6 @@ def test_concurrent_meta_mp(  # noqa: C901, pylint: disable=too-many-statements
             rs.put((False, 'failed: %s' % e))
         else:
             rs.put((True, ''))
-        finally:
-            print('job finished', flush=True)
 
     def start_requests(rs, state, ipc_socket):
         jobs = [job1, job2, job3, job4, job5]
@@ -360,6 +350,7 @@ def test_concurrent_persist(  # noqa: C901, pylint: disable=too-many-statements
     clients = generate_vineyard_ipc_clients(vineyard_ipc_sockets, 4)
 
     def job1(client):
+        o = None
         try:
             o = client.get_object(client.put(1))
             client.persist(o.id)
@@ -369,10 +360,10 @@ def test_concurrent_persist(  # noqa: C901, pylint: disable=too-many-statements
                 client.sync_meta()
         except Exception as e:  # pylint: disable=broad-except
             pytest.fail('failed: %s' % e)
-            return False
         return True
 
     def job2(client):
+        o = None
         try:
             o = client.get_object(client.put(1.23456))
             client.persist(o.id)
@@ -382,10 +373,10 @@ def test_concurrent_persist(  # noqa: C901, pylint: disable=too-many-statements
                 client.sync_meta()
         except Exception as e:  # pylint: disable=broad-except
             pytest.fail('failed: %s' % e)
-            return False
         return True
 
     def job3(client):
+        o = None
         try:
             o = client.get_object(client.put('xxxxabcd'))
             client.persist(o.id)
@@ -395,10 +386,10 @@ def test_concurrent_persist(  # noqa: C901, pylint: disable=too-many-statements
                 client.sync_meta()
         except Exception as e:  # pylint: disable=broad-except
             pytest.fail('failed: %s' % e)
-            return False
         return True
 
     def job4(client):
+        o = None
         try:
             o = client.get_object(client.put((1, 1.2345)))
             client.persist(o.id)
@@ -408,10 +399,10 @@ def test_concurrent_persist(  # noqa: C901, pylint: disable=too-many-statements
                 client.sync_meta()
         except Exception as e:  # pylint: disable=broad-except
             pytest.fail('failed: %s' % e)
-            return False
         return True
 
     def job5(client):
+        o = None
         try:
             o = client.get_object(client.put((1, 1.2345, 'xxxxabcd')))
             client.persist(o.id)
@@ -421,7 +412,6 @@ def test_concurrent_persist(  # noqa: C901, pylint: disable=too-many-statements
                 client.sync_meta()
         except Exception as e:  # pylint: disable=broad-except
             pytest.fail('failed: %s' % e)
-            return False
         return True
 
     jobs = [job1, job2, job3, job4, job5]

--- a/setup.py
+++ b/setup.py
@@ -193,8 +193,9 @@ def load_requirements_txt(kind=""):
 
 def package_data():
     artifacts = [
-        'vineyard/deploy/*.yaml',
-        'vineyard/deploy/*.yaml.tpl',
+        '*.pyi',
+        'deploy/*.yaml',
+        'deploy/*.yaml.tpl',
     ]
     return artifacts
 

--- a/src/client/client_base.cc
+++ b/src/client/client_base.cc
@@ -357,6 +357,7 @@ Status ClientBase::MigrateObject(const ObjectID object_id,
 }
 
 Status ClientBase::Clear() {
+  ENSURE_CONNECTED(this);
   std::string message_out;
   WriteClearRequest(message_out);
   RETURN_ON_ERROR(doWrite(message_out));
@@ -368,6 +369,7 @@ Status ClientBase::Clear() {
 
 Status ClientBase::Label(const ObjectID object, std::string const& key,
                          std::string const& value) {
+  ENSURE_CONNECTED(this);
   std::string message_out;
   WriteLabelRequest(object, key, value, message_out);
   RETURN_ON_ERROR(doWrite(message_out));
@@ -379,6 +381,7 @@ Status ClientBase::Label(const ObjectID object, std::string const& key,
 
 Status ClientBase::Label(const ObjectID object,
                          std::map<std::string, std::string> const& labels) {
+  ENSURE_CONNECTED(this);
   std::string message_out;
   WriteLabelRequest(object, labels, message_out);
   RETURN_ON_ERROR(doWrite(message_out));
@@ -389,6 +392,7 @@ Status ClientBase::Label(const ObjectID object,
 }
 
 Status ClientBase::Evict(std::vector<ObjectID> const& objects) {
+  ENSURE_CONNECTED(this);
   std::string message_out;
   WriteEvictRequest(objects, message_out);
   RETURN_ON_ERROR(doWrite(message_out));
@@ -399,6 +403,7 @@ Status ClientBase::Evict(std::vector<ObjectID> const& objects) {
 }
 
 Status ClientBase::Load(std::vector<ObjectID> const& objects, const bool pin) {
+  ENSURE_CONNECTED(this);
   std::string message_out;
   WriteLoadRequest(objects, pin, message_out);
   RETURN_ON_ERROR(doWrite(message_out));
@@ -409,6 +414,7 @@ Status ClientBase::Load(std::vector<ObjectID> const& objects, const bool pin) {
 }
 
 Status ClientBase::Unpin(std::vector<ObjectID> const& objects) {
+  ENSURE_CONNECTED(this);
   std::string message_out;
   WriteUnpinRequest(objects, message_out);
   RETURN_ON_ERROR(doWrite(message_out));

--- a/src/client/client_base.h
+++ b/src/client/client_base.h
@@ -598,7 +598,7 @@ class ClientBase {
   std::string server_version_;
 
   // A mutex which protects the client.
-  std::recursive_mutex client_mutex_;
+  mutable std::recursive_mutex client_mutex_;
 };
 
 struct InstanceStatus {

--- a/src/client/ds/blob.cc
+++ b/src/client/ds/blob.cc
@@ -252,6 +252,7 @@ Status BlobWriter::_Seal(Client& client, std::shared_ptr<Object>& object) {
   // get blob and re-map
   uint8_t *mmapped_ptr = nullptr, *dist = nullptr;
   if (payload_.data_size > 0) {
+    std::lock_guard<std::recursive_mutex> __guard(client.client_mutex_);
     RETURN_ON_ERROR(client.shm_->Mmap(
         payload_.store_fd, payload_.object_id, payload_.map_size,
         payload_.data_size, payload_.data_offset,


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

- Fixes the check about memory-mapped client fd
- Add testcases for concurrent blob creation
- Add necessary locks for thread safe.

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Related to #1324

