### PR TITLE
Add the enable-certificate-owner-ref to the subchart of cert-manager.

### DIFF
--- a/charts/vineyard-operator/values.yaml
+++ b/charts/vineyard-operator/values.yaml
@@ -1,6 +1,8 @@
 cert-manager:
   enabled: true
   installCRDs: true
+  extraArgs:
+    - --enable-certificate-owner-ref=true
 controllerManager:
   kubeRbacProxy:
     containerSecurityContext:

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -272,4 +272,8 @@ generate-helm-chart: helmify kustomize
 	cd ../charts && $(KUSTOMIZE) build ../k8s/config/default | $(HELMIFY) --cert-manager-as-subchart vineyard-operator && \
 	sed -i 's/\/var\/run\/vineyard-kubernetes\/{{.Namespace}}\/{{.Name}}/\/var\/run\/vineyard-kubernetes\/{{ \"{{.Namespace}}\/{{.Name}}\" }}/g' \
 	vineyard-operator/templates/vineyardd-crd.yaml && \
-	sed -i 's/certManager/cert-manager/g' vineyard-operator/values.yaml
+	sed -i 's/certManager/cert-manager/g' vineyard-operator/values.yaml && \
+	sed -i '4i\  extraArgs:\n    - --enable-certificate-owner-ref=true' vineyard-operator/values.yaml
+	
+
+


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

As titled. After uninstalling the vineyard operator, the secret for related webhooks will be deleted automatically.


