### PR TITLE
Fixes referenced before assignment error

### DIFF
--- a/python/vineyard/deploy/utils.py
+++ b/python/vineyard/deploy/utils.py
@@ -196,6 +196,7 @@ def find_vineyardctl_path():
 
     # find vineyardctl in the package
     resource_path = None
+    vineyardctl_path = None
     try:
         # `pkg_resources.resource_filename` may causing `TypeError`
         resource_path = pkg_resources.resource_filename('vineyard.bdist', 'vineyardctl')


### PR DESCRIPTION
vineyardctl_path was reference before assignment in  https://github.com/v6d-io/v6d/blob/b55b7393aefc874b3c539b883a7b79f5ebebb456/python/vineyard/deploy/utils.py#L206
