### PR TITLE
Improve the macos CI to build the wheel packages

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,10 +14,7 @@ macosx_arm64_wheel_task:
 
   install_deps_script:
     - brew update
-    - brew install coreutils golang llvm pyenv python
-
-  install_runtime_deps_script:
-    - brew install boost lz4 openssl --build-from-source
+    - brew install coreutils golang pyenv python
 
   install_various_python_script:
     - pyenv install 3.8.16
@@ -25,61 +22,10 @@ macosx_arm64_wheel_task:
     - pyenv install 3.10.10
     - pyenv install 3.11.2
 
-  install_protobuf_grpc_script: |
-    echo "Installing protobuf & grpc ..."
-    cd /tmp
-    wget -q https://github.com/unsafecoerce/git-submodules-tarball/releases/download/grpc%2Fgrpc-v1.36.x/grpc-grpc-1.36.x.tar.gz
-    tar zxf grpc-grpc-1.36.x.tar.gz
-    cd grpc-grpc-1.36.x
-    mkdir -p cmake-build
-    cd cmake-build
-    cmake .. -DCMAKE_BUILD_TYPE=MinSizeRel \
-             -DBUILD_SHARED_LIBS=OFF \
-             -DgRPC_INSTALL=ON \
-             -DgRPC_BUILD_TESTS=OFF \
-             -DgRPC_BUILD_CSHARP_EXT=OFF \
-             -DgRPC_BUILD_GRPC_CSHARP_PLUGIN=OFF \
-             -DgRPC_BUILD_GRPC_NODE_PLUGIN=OFF \
-             -DgRPC_BUILD_GRPC_OBJECTIVE_C_PLUGIN=OFF \
-             -DgRPC_BUILD_GRPC_PHP_PLUGIN=OFF \
-             -DgRPC_BUILD_GRPC_PYTHON_PLUGIN=OFF \
-             -DgRPC_BUILD_GRPC_RUBY_PLUGIN=OFF \
-             -DgRPC_SSL_PROVIDER=package \
-             -DgRPC_ZLIB_PROVIDER=package \
-             -DOPENSSL_ROOT_DIR=$(brew --prefix openssl) \
-             -DgRPC_BACKWARDS_COMPATIBILITY_MODE=ON
-    sudo make install -j$(sysctl -n hw.ncpu)
-
-  install_gflags_script: |
-    echo "Installing gflags ..."
-    pyenv global 3.11.2
-    cd /tmp
-    curl -L https://github.com/gflags/gflags/archive/v2.2.2.tar.gz --output gflags-v2.2.2.tar.gz
-    tar zxf gflags-v2.2.2.tar.gz
-    cd gflags-2.2.2
-    mkdir -p build-dir
-    cd build-dir
-    cmake .. -DBUILD_SHARED_LIBS=OFF
-    sudo make install -j$(sysctl -n hw.ncpu)
-
-  install_glog_script: |
-    echo "Installing glog ..."
-    pyenv global 3.11.2
-    cd /tmp
-    curl -L https://github.com/google/glog/archive/v0.6.0.tar.gz --output glog-v0.6.0.tar.gz
-    tar zxf glog-v0.6.0.tar.gz
-    cd glog-0.6.0
-    mkdir -p build-dir
-    cd build-dir
-    cmake .. -DBUILD_SHARED_LIBS=OFF \
-              -DWITH_GFLAGS=OFF \
-              -DBUILD_TESTING=OFF
-    sudo make install -j$(sysctl -n hw.ncpu)
-
   install_apache_arrow_script: |
     echo "Installing apache-arrow ..."
-    pyenv global 3.11.2
-    cd /tmp
+    mkdir -p /tmp/install
+    cd /tmp/install
     curl -L https://github.com/apache/arrow/archive/refs/tags/apache-arrow-8.0.1.tar.gz --output apache-arrow-8.0.1.tar.gz
     tar zxf apache-arrow-8.0.1.tar.gz
     cd arrow-apache-arrow-8.0.1
@@ -125,6 +71,86 @@ macosx_arm64_wheel_task:
         -DARROW_BUILD_SHARED=OFF \
         -DARROW_BUILD_STATIC=ON
     sudo make install -j$(sysctl -n hw.ncpu)
+    cd /tmp
+    sudo rm -rf /tmp/install
+
+  install_boost_script: |
+    echo "Installing boost ..."
+    mkdir -p /tmp/install
+    cd /tmp/install
+    wget -q https://boostorg.jfrog.io/artifactory/main/release/1.75.0/source/boost_1_75_0.tar.gz
+    tar zxf boost_1_75_0.tar.gz
+    cd boost_1_75_0
+    ./bootstrap.sh
+    sudo ./b2 install -j`nproc` variant=release threading=multi \
+        --with-atomic \
+        --with-chrono \
+        --with-date_time \
+        --with-filesystem \
+        --with-random \
+        --with-regex \
+        --with-system \
+        --with-thread
+    cd /tmp
+    sudo rm -rf /tmp/install
+
+  install_gflags_script: |
+    echo "Installing gflags ..."
+    mkdir -p /tmp/install
+    cd /tmp/install
+    curl -L https://github.com/gflags/gflags/archive/v2.2.2.tar.gz --output gflags-v2.2.2.tar.gz
+    tar zxf gflags-v2.2.2.tar.gz
+    cd gflags-2.2.2
+    mkdir -p build-dir
+    cd build-dir
+    cmake .. -DBUILD_SHARED_LIBS=OFF
+    sudo make install -j$(sysctl -n hw.ncpu)
+    cd /tmp
+    sudo rm -rf /tmp/install
+
+  install_glog_script: |
+    echo "Installing glog ..."
+    mkdir -p /tmp/install
+    cd /tmp/install
+    curl -L https://github.com/google/glog/archive/v0.6.0.tar.gz --output glog-v0.6.0.tar.gz
+    tar zxf glog-v0.6.0.tar.gz
+    cd glog-0.6.0
+    mkdir -p build-dir
+    cd build-dir
+    cmake .. -DBUILD_SHARED_LIBS=OFF \
+              -DWITH_GFLAGS=OFF \
+              -DBUILD_TESTING=OFF
+    sudo make install -j$(sysctl -n hw.ncpu)
+    cd /tmp
+    sudo rm -rf /tmp/install
+
+  install_protobuf_grpc_script: |
+    echo "Installing protobuf & grpc ..."
+    mkdir -p /tmp/install
+    cd /tmp/install
+    wget -q https://github.com/unsafecoerce/git-submodules-tarball/releases/download/grpc%2Fgrpc-v1.36.x/grpc-grpc-1.36.x.tar.gz
+    tar zxf grpc-grpc-1.36.x.tar.gz
+    cd grpc-grpc-1.36.x
+    mkdir -p cmake-build
+    cd cmake-build
+    cmake .. -DCMAKE_BUILD_TYPE=MinSizeRel \
+             -DBUILD_SHARED_LIBS=OFF \
+             -DgRPC_INSTALL=ON \
+             -DgRPC_BUILD_TESTS=OFF \
+             -DgRPC_BUILD_CSHARP_EXT=OFF \
+             -DgRPC_BUILD_GRPC_CSHARP_PLUGIN=OFF \
+             -DgRPC_BUILD_GRPC_NODE_PLUGIN=OFF \
+             -DgRPC_BUILD_GRPC_OBJECTIVE_C_PLUGIN=OFF \
+             -DgRPC_BUILD_GRPC_PHP_PLUGIN=OFF \
+             -DgRPC_BUILD_GRPC_PYTHON_PLUGIN=OFF \
+             -DgRPC_BUILD_GRPC_RUBY_PLUGIN=OFF \
+             -DgRPC_SSL_PROVIDER=package \
+             -DgRPC_ZLIB_PROVIDER=package \
+             -DOPENSSL_ROOT_DIR=$(brew --prefix openssl) \
+             -DgRPC_BACKWARDS_COMPATIBILITY_MODE=ON
+    sudo make install -j$(sysctl -n hw.ncpu)
+    cd /tmp
+    sudo rm -rf /tmp/install
 
   build_vineyardctl_script:
     - make -C k8s vineyardctl

--- a/.github/workflows/build-vineyardd-and-wheels-macos.yaml
+++ b/.github/workflows/build-vineyardd-and-wheels-macos.yaml
@@ -25,8 +25,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # the last commit in homebrew-core tree that MacOS-10.15 has bottles, to make installing deps easier
-  HOMEBREW_REV: 01aff4dce839c54aa54ad81879ade95b7922ef6f
+  MACOSX_DEPLOYMENT_TARGET: "10.15"
 
 jobs:
   build-vineyardd:
@@ -34,7 +33,7 @@ jobs:
     if: ${{ github.repository == 'v6d-io/v6d' }}
     strategy:
       matrix:
-        os: [macos-10.15]
+        os: [macos-11]
 
     steps:
       - uses: actions/checkout@v3
@@ -56,17 +55,12 @@ jobs:
 
       - name: Install dependencies for MacOS
         run: |
-          pushd $(brew --repo homebrew/core)
-          git checkout ${{ env.HOMEBREW_REV }} || true
-          popd
-
           brew install ccache boost coreutils grpc protobuf openssl || true
 
           export CC=clang
           export CXX=clang++
 
           export PATH=/usr/local/opt/ccache/bin:/usr/local/opt/ccache/libexec:$PATH:$HOME/.local/bin
-          export MACOSX_DEPLOYMENT_TARGET=10.9
 
           echo "Installing gflags ..."
           cd /tmp
@@ -144,7 +138,6 @@ jobs:
           export CXX=clang++
 
           export PATH=/usr/local/opt/ccache/bin:/usr/local/opt/ccache/libexec:$PATH:$HOME/.local/bin
-          export MACOSX_DEPLOYMENT_TARGET=10.9
 
           # patch cpprestsdk, that is not used, and the cases cannot be handled by delocate well,
           #
@@ -206,7 +199,7 @@ jobs:
     if: ${{ github.repository == 'v6d-io/v6d' }}
     strategy:
       matrix:
-        os: [macos-10.15]
+        os: [macos-11]
 
     steps:
       - uses: actions/checkout@v3
@@ -249,7 +242,7 @@ jobs:
     if: ${{ github.repository == 'v6d-io/v6d' }}
     strategy:
       matrix:
-        os: [macos-10.15]
+        os: [macos-11]
         python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
@@ -315,7 +308,6 @@ jobs:
           export CXX=clang++
 
           export PATH=/usr/local/opt/ccache/bin:/usr/local/opt/ccache/libexec:$PATH:$HOME/.local/bin
-          export MACOSX_DEPLOYMENT_TARGET=10.9
 
           ccache --show-stats
 
@@ -398,7 +390,6 @@ jobs:
           export CXX=clang++
 
           export PATH=/usr/local/opt/ccache/bin:/usr/local/opt/ccache/libexec:$PATH:$HOME/.local/bin
-          export MACOSX_DEPLOYMENT_TARGET=10.9
 
           # run build
           mkdir -p build


### PR DESCRIPTION
What do these changes do?
-------------------------

- Github has removed the macos-10.15 runner
- There were some failures during installing boost from source using brew on M1 (cirrus-ci)
