### PR TITLE
Improve the performance of `initDestFidList()` when there are many fragments

### DIFF
--- a/modules/graph/fragment/arrow_fragment.vineyard-mod
+++ b/modules/graph/fragment/arrow_fragment.vineyard-mod
@@ -643,8 +643,8 @@ class [[vineyard]] ArrowFragment
 
   boost::leaf::result<vineyard::ObjectID> Project(
       vineyard::Client& client,
-      std::map<label_id_t, std::vector<label_id_t>> vertices,
-      std::map<label_id_t, std::vector<label_id_t>> edges);
+      std::map<label_id_t, std::vector<prop_id_t>> vertices,
+      std::map<label_id_t, std::vector<prop_id_t>> edges);
 
   boost::leaf::result<vineyard::ObjectID> TransformDirection(
       vineyard::Client& client, int concurrency);

--- a/modules/graph/loader/arrow_fragment_loader.cc
+++ b/modules/graph/loader/arrow_fragment_loader.cc
@@ -475,7 +475,6 @@ Status ReadTableFromLocation(const std::string& location,
   RETURN_ON_ERROR(io_adaptor->ReadTable(&table));
 
   if (table != nullptr) {  // the file may be too small
-    auto adaptor_meta = io_adaptor->GetMeta();
     auto meta = std::make_shared<arrow::KeyValueMetadata>();
     for (auto const& item : io_adaptor->GetMeta()) {
       VINEYARD_DISCARD(meta->Set(item.first, item.second));

--- a/modules/graph/vertex_map/arrow_vertex_map.h
+++ b/modules/graph/vertex_map/arrow_vertex_map.h
@@ -169,7 +169,7 @@ class BasicArrowVertexMapBuilder : public ArrowVertexMapBuilder<OID_T, VID_T> {
   using label_id_t = property_graph_types::LABEL_ID_TYPE;
 
   static_assert(!std::is_same<OID_T, std::string>::value,
-                "Expect arrow_string_view in local vertex map's OID_T");
+                "Expect arrow_string_view in vertex map's OID_T");
 
  public:
   BasicArrowVertexMapBuilder(

--- a/python/vineyard/core/codegen/cpp.py
+++ b/python/vineyard/core/codegen/cpp.py
@@ -764,6 +764,7 @@ distributed_getter_tpl = '''
                 auto const __item = std::dynamic_pointer_cast<T>(__e);
                 if (__item != nullptr) {{
                     locals.emplace_back(__item);
+                    __local_size++;
                 }}
             }}
         }}


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

<!-- Please give a short brief about these changes. -->

Optimize the func initDestFidList(),  assuming edge num is n, fragment num is m, the original algo's time complexity is O(nlogm), the optimized is O(n)


