### PR TITLE
Add OwnerReferences for all resource created during deploying vineyard-deployment and support default namespace

### DIFF
--- a/k8s/cmd/README.md
+++ b/k8s/cmd/README.md
@@ -710,6 +710,7 @@ vineyardctl deploy vineyard-deployment [flags]
   -f, --file string                                   the path of vineyardd
   -h, --help                                          help for vineyard-deployment
       --name string                                   the name of vineyardd (default "vineyardd-sample")
+      --owner-references string                       The owner reference of all vineyard deployment resources
       --pluginImage.backupImage string                the backup image of vineyardd (default "ghcr.io/v6d-io/v6d/backup-job")
       --pluginImage.daskRepartitionImage string       the dask repartition image of vineyardd workflow (default "ghcr.io/v6d-io/v6d/dask-repartition")
       --pluginImage.distributedAssemblyImage string   the distributed image of vineyard workflow (default "ghcr.io/v6d-io/v6d/distributed-assembly")
@@ -725,9 +726,10 @@ vineyardctl deploy vineyard-deployment [flags]
       --vineyardd.metric.enable                       enable metrics of vineyardd
       --vineyardd.metric.image string                 the metic image of vineyardd (default "vineyardcloudnative/vineyard-grok-exporter:latest")
       --vineyardd.metric.imagePullPolicy string       the imagePullPolicy of the metric image (default "IfNotPresent")
+      --vineyardd.reserve_memory                      Reserving enough physical memory pages for vineyardd
       --vineyardd.service.port int                    the service port of vineyard service (default 9600)
       --vineyardd.service.type string                 the service type of vineyard service (default "ClusterIP")
-      --vineyardd.size string                         The size of vineyardd. You can use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki.  (default "256Mi")
+      --vineyardd.size string                         The size of vineyardd. You can use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki. (default "256Mi")
       --vineyardd.socket string                       The directory on host for the IPC socket file. The namespace and name will be replaced with your vineyard config (default "/var/run/vineyard-kubernetes/{{.Namespace}}/{{.Name}}")
       --vineyardd.spill.config string                 If you want to enable the spill mechanism, please set the name of spill config
       --vineyardd.spill.path string                   The path of spill config
@@ -857,9 +859,10 @@ vineyardctl deploy vineyardd [flags]
       --vineyardd.metric.enable                       enable metrics of vineyardd
       --vineyardd.metric.image string                 the metic image of vineyardd (default "vineyardcloudnative/vineyard-grok-exporter:latest")
       --vineyardd.metric.imagePullPolicy string       the imagePullPolicy of the metric image (default "IfNotPresent")
+      --vineyardd.reserve_memory                      Reserving enough physical memory pages for vineyardd
       --vineyardd.service.port int                    the service port of vineyard service (default 9600)
       --vineyardd.service.type string                 the service type of vineyard service (default "ClusterIP")
-      --vineyardd.size string                         The size of vineyardd. You can use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki.  (default "256Mi")
+      --vineyardd.size string                         The size of vineyardd. You can use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki. (default "256Mi")
       --vineyardd.socket string                       The directory on host for the IPC socket file. The namespace and name will be replaced with your vineyard config (default "/var/run/vineyard-kubernetes/{{.Namespace}}/{{.Name}}")
       --vineyardd.spill.config string                 If you want to enable the spill mechanism, please set the name of spill config
       --vineyardd.spill.path string                   The path of spill config
@@ -1043,9 +1046,10 @@ vineyardctl inject [flags]
       --sidecar.metric.enable                   enable metrics of vineyardd
       --sidecar.metric.image string             the metic image of vineyardd (default "vineyardcloudnative/vineyard-grok-exporter:latest")
       --sidecar.metric.imagePullPolicy string   the imagePullPolicy of the metric image (default "IfNotPresent")
+      --sidecar.reserve_memory                  Reserving enough physical memory pages for vineyardd
       --sidecar.service.port int                the service port of vineyard service (default 9600)
       --sidecar.service.type string             the service type of vineyard service (default "ClusterIP")
-      --sidecar.size string                     The size of vineyardd. You can use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki.  (default "256Mi")
+      --sidecar.size string                     The size of vineyardd. You can use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki. (default "256Mi")
       --sidecar.socket string                   The directory on host for the IPC socket file. The namespace and name will be replaced with your vineyard config (default "/var/run/vineyard-kubernetes/{{.Namespace}}/{{.Name}}")
       --sidecar.spill.config string             If you want to enable the spill mechanism, please set the name of spill config
       --sidecar.spill.path string               The path of spill config

--- a/k8s/cmd/commands/flags/global_flags.go
+++ b/k8s/cmd/commands/flags/global_flags.go
@@ -57,10 +57,6 @@ func defaultKubeConfig() string {
 
 // GetDefaultVineyardNamespace return the default vineyard namespace
 func GetDefaultVineyardNamespace() string {
-	// we don't use the default namespace for vineyard
-	if Namespace == "default" {
-		return defaultNamespace
-	}
 	return Namespace
 }
 

--- a/k8s/cmd/commands/sidecar/inject.go
+++ b/k8s/cmd/commands/sidecar/inject.go
@@ -305,7 +305,7 @@ func GetWorkloadObj(workload string) (*unstructured.Unstructured, error) {
 func GetManifestFromTemplate(workload string) (OutputManifests, error) {
 	var om OutputManifests
 
-	ownerRef, err := getOwnerRefFromInput()
+	ownerRef, err := util.ParseOwnerRef(flags.OwnerReference)
 	if err != nil {
 		return om, errors.Wrap(err, "failed to get owner reference from input")
 	}
@@ -399,19 +399,6 @@ func GetManifestFromTemplate(workload string) (OutputManifests, error) {
 	}
 
 	return om, nil
-}
-
-func getOwnerRefFromInput() ([]metav1.OwnerReference, error) {
-	ownerRef := []metav1.OwnerReference{}
-
-	if flags.OwnerReference != "" {
-		ownerRef = make([]metav1.OwnerReference, 1)
-		if err := json.Unmarshal([]byte(flags.OwnerReference), &ownerRef); err != nil {
-			return nil, errors.Wrap(err, "failed to unmarshal the owner reference")
-		}
-	}
-
-	return ownerRef, nil
 }
 
 func parseManifestsAsYAML(om OutputManifests) ([]string, error) {

--- a/k8s/cmd/commands/util/parse.go
+++ b/k8s/cmd/commands/util/parse.go
@@ -22,7 +22,9 @@ import (
 	"github.com/ghodss/yaml"
 
 	"github.com/pkg/errors"
+
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -163,4 +165,17 @@ func GetPVAndPVC(pVAndPVC string) (*corev1.PersistentVolumeSpec,
 		}
 	}
 	return pv, pvc, nil
+}
+
+func ParseOwnerRef(of string) ([]metav1.OwnerReference, error) {
+	ownerRef := []metav1.OwnerReference{}
+
+	if of != "" {
+		ownerRef = make([]metav1.OwnerReference, 1)
+		if err := json.Unmarshal([]byte(of), &ownerRef); err != nil {
+			return nil, errors.Wrap(err, "failed to unmarshal the owner reference")
+		}
+	}
+
+	return ownerRef, nil
 }

--- a/k8s/cmd/commands/util/parse.go
+++ b/k8s/cmd/commands/util/parse.go
@@ -167,6 +167,7 @@ func GetPVAndPVC(pVAndPVC string) (*corev1.PersistentVolumeSpec,
 	return pv, pvc, nil
 }
 
+// ParseOwnerRef parse the string to metav1.OwnerReference
 func ParseOwnerRef(of string) ([]metav1.OwnerReference, error) {
 	ownerRef := []metav1.OwnerReference{}
 


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

* Add OwnerReferences for all resource created during deploying vineyard-deployment
* Support deploying vineyard resources in the default namespace.

