### PR TITLE
Specify the required version of libgrape-lite

### DIFF
--- a/modules/graph/CMakeLists.txt
+++ b/modules/graph/CMakeLists.txt
@@ -76,7 +76,7 @@ else()
     )
 endif()
 
-find_package(libgrapelite QUIET)
+find_package(libgrapelite 0.2.3 QUIET)
 if(LIBGRAPELITE_INCLUDE_DIRS)
     message(STATUS "-- Found libgrape-lite: ${LIBGRAPELITE_INCLUDE_DIRS}")
     target_include_directories(vineyard_graph PUBLIC ${LIBGRAPELITE_INCLUDE_DIRS})


### PR DESCRIPTION
What do these changes do?
-------------------------

Vineyard requires libgrape-lite after version https://github.com/alibaba/libgrape-lite/commit/3d2fe9cc28e126231c1e9ce3fa12d815b0ec28ba

