### PR TITLE
Enable cpplint over vineyard-mod files

### DIFF
--- a/.github/workflows/vineyard-operator.yaml
+++ b/.github/workflows/vineyard-operator.yaml
@@ -139,11 +139,11 @@ jobs:
 
       - name: Upload latest docker image
         if: ${{ matrix.job == 'release' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'v6d-io/v6d' }}
-        env:
-          # pre-publish to ghcr.io to avoid the "no basic auth credentials" error
-          IMG: ghcr.io/v6d-io/v6d/vineyard-operator:latest
         run: |
+          # pre-publish to ghcr.io to avoid the "no basic auth credentials" error
+          export IMG=ghcr.io/v6d-io/v6d/vineyard-operator:${{ steps.tag.outputs.TAG }}
           make -C k8s docker-build-push-multi-arch REGISTRY=${{ env.REGISTRY }} VERSION=${{ steps.tag.outputs.TAG }}
+          export IMG=ghcr.io/v6d-io/v6d/vineyard-operator:latest
           make -C k8s docker-build-push-multi-arch REGISTRY=${{ env.REGISTRY }} VERSION=latest
 
       - name: Generate the python and vineyardd image for tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -947,13 +947,9 @@ file_glob_recurse(FILES_NEED_FORMAT DIRECTORIES      "src" "modules" "python" "t
                                     PATTERNS         ".*\\.(cc|cpp|h|hpp|vineyard-mod)$"
                                     EXCLUDE_PATTERNS ".*\\.vineyard.h$"
 )
-file_glob_recurse(FILES_NEED_LINT   DIRECTORIES      "src" "modules" "python" "test" "benchmark"
-                                    PATTERNS         ".*\\.(cc|cpp|h|hpp)$"
-                                    EXCLUDE_PATTERNS ".*\\.vineyard.h$"
-)
 
 # the `memcpy.h` is borrowed from external project
-list(REMOVE_ITEM FILES_NEED_LINT "${PROJECT_SOURCE_DIR}/src/common/memory/memcpy.h")
+list(REMOVE_ITEM FILES_NEED_FORMAT "${PROJECT_SOURCE_DIR}/src/common/memory/memcpy.h")
 
 add_custom_target(vineyard_clformat
         COMMAND clang-format --style=file -i ${FILES_NEED_FORMAT}
@@ -961,7 +957,7 @@ add_custom_target(vineyard_clformat
         VERBATIM)
 
 add_custom_target(vineyard_cpplint
-        COMMAND ${PROJECT_SOURCE_DIR}/misc/cpplint.py --root=vineyard ${FILES_NEED_LINT}
+        COMMAND ${PROJECT_SOURCE_DIR}/misc/cpplint.py --root=vineyard ${FILES_NEED_FORMAT}
         COMMENT "Running cpplint check."
         VERBATIM)
 

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,3 +1,6 @@
+# extensions=.vineyard-mod
+headers=hpp,cuh,hh,h,hxx,h++,vineyard-mod
+
 # Disable the unapproved checks, since this is a preference of the Chromium team.
 filter=-build/c++11
 

--- a/modules/basic/ds/array.vineyard-mod
+++ b/modules/basic/ds/array.vineyard-mod
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef MODULES_BASIC_DS_ARRAY_MOD_H_
-#define MODULES_BASIC_DS_ARRAY_MOD_H_
+#ifndef MODULES_BASIC_DS_ARRAY_VINEYARD_MOD_
+#define MODULES_BASIC_DS_ARRAY_VINEYARD_MOD_
 
 #include <cstdint>
 #include <memory>
@@ -81,6 +81,6 @@ class [[vineyard]] Array : public Registered<Array<T>> {
 #endif
 }  // namespace vineyard
 
-#endif  // MODULES_BASIC_DS_ARRAY_MOD_H_
+#endif  // MODULES_BASIC_DS_ARRAY_VINEYARD_MOD_
 
 // vim: syntax=cpp

--- a/modules/basic/ds/arrow.vineyard-mod
+++ b/modules/basic/ds/arrow.vineyard-mod
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef MODULES_BASIC_DS_ARROW_MOD_H_
-#define MODULES_BASIC_DS_ARROW_MOD_H_
+#ifndef MODULES_BASIC_DS_ARROW_VINEYARD_MOD_
+#define MODULES_BASIC_DS_ARROW_VINEYARD_MOD_
 
 #include <iostream>
 #include <memory>
@@ -387,6 +387,6 @@ struct collection_type<RecordBatch> {
 
 }  // namespace vineyard
 
-#endif  // MODULES_BASIC_DS_ARROW_MOD_H_
+#endif  // MODULES_BASIC_DS_ARROW_VINEYARD_MOD_
 
 // vim: syntax=cpp

--- a/modules/basic/ds/dataframe.vineyard-mod
+++ b/modules/basic/ds/dataframe.vineyard-mod
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef MODULES_BASIC_DS_DATAFRAME_MOD_H_
-#define MODULES_BASIC_DS_DATAFRAME_MOD_H_
+#ifndef MODULES_BASIC_DS_DATAFRAME_VINEYARD_MOD_
+#define MODULES_BASIC_DS_DATAFRAME_VINEYARD_MOD_
 
 #include <algorithm>
 #include <functional>
@@ -110,6 +110,6 @@ class [[vineyard(streamable)]] DataFrame : public Registered<DataFrame> {
 
 }  // namespace vineyard
 
-#endif  // MODULES_BASIC_DS_DATAFRAME_MOD_H_
+#endif  // MODULES_BASIC_DS_DATAFRAME_VINEYARD_MOD_
 
 // vim: syntax=cpp

--- a/modules/basic/ds/hashmap.vineyard-mod
+++ b/modules/basic/ds/hashmap.vineyard-mod
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef MODULES_BASIC_DS_HASHMAP_MOD_H_
-#define MODULES_BASIC_DS_HASHMAP_MOD_H_
+#ifndef MODULES_BASIC_DS_HASHMAP_VINEYARD_MOD_
+#define MODULES_BASIC_DS_HASHMAP_VINEYARD_MOD_
 
 #include <algorithm>
 #include <functional>
@@ -325,6 +325,6 @@ class [[vineyard]] Hashmap : public Registered<Hashmap<K, V, H, E>>,
 
 }  // namespace vineyard
 
-#endif  // MODULES_BASIC_DS_HASHMAP_MOD_H_
+#endif  // MODULES_BASIC_DS_HASHMAP_VINEYARD_MOD_
 
 // vim: syntax=cpp

--- a/modules/basic/ds/scalar.vineyard-mod
+++ b/modules/basic/ds/scalar.vineyard-mod
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef MODULES_BASIC_DS_SCALAR_MOD_H_
-#define MODULES_BASIC_DS_SCALAR_MOD_H_
+#ifndef MODULES_BASIC_DS_SCALAR_VINEYARD_MOD_
+#define MODULES_BASIC_DS_SCALAR_VINEYARD_MOD_
 
 #include <memory>
 #include <string>
@@ -81,6 +81,6 @@ class [[vineyard]] Scalar : public Registered<Scalar<T>> {
 
 }  // namespace vineyard
 
-#endif  // MODULES_BASIC_DS_SCALAR_MOD_H_
+#endif  // MODULES_BASIC_DS_SCALAR_VINEYARD_MOD_
 
 // vim: syntax=cpp

--- a/modules/basic/ds/sequence.vineyard-mod
+++ b/modules/basic/ds/sequence.vineyard-mod
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef MODULES_BASIC_DS_SEQUENCE_MOD_H_
-#define MODULES_BASIC_DS_SEQUENCE_MOD_H_
+#ifndef MODULES_BASIC_DS_SEQUENCE_VINEYARD_MOD_
+#define MODULES_BASIC_DS_SEQUENCE_VINEYARD_MOD_
 
 #include <memory>
 #include <string>
@@ -130,6 +130,6 @@ class [[vineyard]] Sequence : public Registered<Sequence> {
 
 }  // namespace vineyard
 
-#endif  // MODULES_BASIC_DS_SEQUENCE_MOD_H_
+#endif  // MODULES_BASIC_DS_SEQUENCE_VINEYARD_MOD_
 
 // vim: syntax=cpp

--- a/modules/basic/ds/tensor.vineyard-mod
+++ b/modules/basic/ds/tensor.vineyard-mod
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef MODULES_BASIC_DS_TENSOR_MOD_H_
-#define MODULES_BASIC_DS_TENSOR_MOD_H_
+#ifndef MODULES_BASIC_DS_TENSOR_VINEYARD_MOD_
+#define MODULES_BASIC_DS_TENSOR_VINEYARD_MOD_
 
 #include <algorithm>
 #include <functional>
@@ -295,6 +295,6 @@ class [[vineyard]] Tensor<std::string>
 
 }  // namespace vineyard
 
-#endif  // MODULES_BASIC_DS_TENSOR_MOD_H_
+#endif  // MODULES_BASIC_DS_TENSOR_VINEYARD_MOD_
 
 // vim: syntax=cpp

--- a/modules/basic/stream/parallel_stream.vineyard-mod
+++ b/modules/basic/stream/parallel_stream.vineyard-mod
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef MODULES_BASIC_STREAM_PARALLEL_STREAM_MOD_H_
-#define MODULES_BASIC_STREAM_PARALLEL_STREAM_MOD_H_
+#ifndef MODULES_BASIC_STREAM_PARALLEL_STREAM_VINEYARD_MOD_
+#define MODULES_BASIC_STREAM_PARALLEL_STREAM_VINEYARD_MOD_
 
 #include <memory>
 #include <string>
@@ -38,6 +38,6 @@ class [[vineyard]] ParallelStream : public Registered<ParallelStream>,
 
 }  // namespace vineyard
 
-#endif  // MODULES_BASIC_STREAM_PARALLEL_STREAM_MOD_H_
+#endif  // MODULES_BASIC_STREAM_PARALLEL_STREAM_VINEYARD_MOD_
 
 // vim: syntax=cpp

--- a/modules/graph/fragment/arrow_fragment.vineyard-mod
+++ b/modules/graph/fragment/arrow_fragment.vineyard-mod
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef MODULES_GRAPH_FRAGMENT_ARROW_FRAGMENT_MOD_H_
-#define MODULES_GRAPH_FRAGMENT_ARROW_FRAGMENT_MOD_H_
+#ifndef MODULES_GRAPH_FRAGMENT_ARROW_FRAGMENT_VINEYARD_MOD_
+#define MODULES_GRAPH_FRAGMENT_ARROW_FRAGMENT_VINEYARD_MOD_
 
 #include <cstddef>
 #include <map>
@@ -735,6 +735,6 @@ class [[vineyard]] ArrowFragment
 
 }  // namespace vineyard
 
-#endif  // MODULES_GRAPH_FRAGMENT_ARROW_FRAGMENT_MOD_H_
+#endif  // MODULES_GRAPH_FRAGMENT_ARROW_FRAGMENT_VINEYARD_MOD_
 
 // vim: syntax=cpp

--- a/modules/graph/tools/graph_loader.cc
+++ b/modules/graph/tools/graph_loader.cc
@@ -28,6 +28,7 @@
 #include "common/util/functions.h"
 #include "common/util/json.h"
 #include "common/util/logging.h"
+#include "common/util/version.h"
 
 #include "graph/fragment/arrow_fragment_base.h"
 #include "graph/fragment/arrow_fragment_group.h"
@@ -442,6 +443,8 @@ static void loading_vineyard_graph(
 
 int main(int argc, char** argv) {
   if (argc < 3) {
+    printf("vineyard-graph-loader version %s\n\n",
+           vineyard::vineyard_version());
     printf(R"r(Usage: loading vertices and edges as vineyard graph.
 
     -     ./vineyard-graph-loader [--socket <vineyard-ipc-socket>] \

--- a/src/server/async/socket_server.cc
+++ b/src/server/async/socket_server.cc
@@ -94,6 +94,9 @@ bool SocketConnection::Stop() {
 
 void SocketConnection::doReadHeader() {
   auto self(shared_from_this());
+  if (!running_.load()) {  // don't read if stopped
+    return;
+  }
   asio::async_read(socket_, asio::buffer(&read_msg_header_, sizeof(size_t)),
                    [this, self](boost::system::error_code ec, std::size_t) {
                      if (!ec && running_.load()) {


### PR DESCRIPTION
What do these changes do?
-------------------------

Use the same file list for `FILES_TO_FORMAT` and `FILES_TO_LINT` to avoid extra directory traverse during cmake configuration.


