### PR TITLE
Simplify the template arguments of loader and modularize the builder

### DIFF
--- a/modules/graph/fragment/arrow_fragment.h
+++ b/modules/graph/fragment/arrow_fragment.h
@@ -82,7 +82,8 @@ class BasicArrowFragmentBuilder
       fid_t fid, fid_t fnum,
       std::vector<std::shared_ptr<arrow::Table>>&& vertex_tables,
       std::vector<std::shared_ptr<arrow::Table>>&& edge_tables,
-      bool directed = true, int concurrency = 1, bool compact_edges = false);
+      bool directed = true,
+      const int concurrency = std::thread::hardware_concurrency());
 
   boost::leaf::result<void> SetPropertyGraphSchema(
       PropertyGraphSchema&& schema) {
@@ -113,21 +114,12 @@ class BasicArrowFragmentBuilder
 
   std::vector<std::vector<std::shared_ptr<PodArrayBuilder<nbr_unit_t>>>>
       ie_lists_, oe_lists_;
-  std::vector<std::vector<std::shared_ptr<FixedInt64Builder>>>
-      ie_offsets_lists_, oe_offsets_lists_;
-
   std::vector<std::vector<std::shared_ptr<FixedUInt8Builder>>>
       compact_ie_lists_, compact_oe_lists_;
   std::vector<std::vector<std::shared_ptr<FixedInt64Builder>>>
-      compact_ie_offsets_lists_, compact_oe_offsets_lists_;
-
-  std::vector<std::vector<const uint8_t*>> compact_ie_ptr_lists_,
-      compact_oe_ptr_lists_;
-  std::vector<std::vector<const int64_t*>> compact_ie_offsets_ptr_lists_,
-      compact_oe_offsets_ptr_lists_;
+      ie_offsets_lists_, oe_offsets_lists_;
 
   std::shared_ptr<vertex_map_t> vm_ptr_;
-
   IdParser<vid_t> vid_parser_;
 };
 

--- a/modules/graph/fragment/arrow_fragment.vineyard-mod
+++ b/modules/graph/fragment/arrow_fragment.vineyard-mod
@@ -126,7 +126,13 @@ class [[vineyard]] ArrowFragment
 
   vineyard::ObjectID vertex_map_id() const override { return vm_ptr_->id(); }
 
+  bool local_vertex_map() const override { return local_vertex_map_; }
+
+  bool compact_edges() const override { return compact_edges_; }
+
   bool directed() const override { return directed_; }
+
+  const PropertyGraphSchema& schema() const override { return schema_; }
 
   bool is_multigraph() const override { return is_multigraph_; }
 
@@ -454,11 +460,8 @@ class [[vineyard]] ArrowFragment
     vid_t vid = v.GetValue();
     label_id_t v_label = vid_parser_.GetLabelId(vid);
     int64_t v_offset = vid_parser_.GetOffset(vid);
-    const int64_t* offset_array =
-        compact_ie_offsets_ptr_lists_[v_label][e_label];
-
+    const int64_t* offset_array = ie_offsets_ptr_lists_[v_label][e_label];
     const uint8_t* ptr = compact_ie_ptr_lists_[v_label][e_label];
-
     return compact_adj_list_t(ptr, offset_array[v_offset],
                               offset_array[v_offset + 1],
                               flatten_edge_tables_columns_[e_label]);
@@ -495,11 +498,8 @@ class [[vineyard]] ArrowFragment
     vid_t vid = v.GetValue();
     label_id_t v_label = vid_parser_.GetLabelId(vid);
     int64_t v_offset = vid_parser_.GetOffset(vid);
-    const int64_t* offset_array =
-        compact_oe_offsets_ptr_lists_[v_label][e_label];
-
+    const int64_t* offset_array = oe_offsets_ptr_lists_[v_label][e_label];
     const uint8_t* ptr = compact_oe_ptr_lists_[v_label][e_label];
-
     return compact_adj_list_t(ptr, offset_array[v_offset],
                               offset_array[v_offset + 1],
                               flatten_edge_tables_columns_[e_label]);
@@ -522,13 +522,15 @@ class [[vineyard]] ArrowFragment
    * later.
    */
 
-  inline const int64_t* GetIncomingOffsetArray(label_id_t v_label,
-                                               label_id_t e_label) const {
+  template <bool COMPACT_ = COMPACT>
+  inline const typename std::enable_if<!COMPACT_, int64_t*>::type
+  GetIncomingOffsetArray(label_id_t v_label, label_id_t e_label) const {
     return ie_offsets_ptr_lists_[v_label][e_label];
   }
 
-  inline const int64_t* GetOutgoingOffsetArray(label_id_t v_label,
-                                               label_id_t e_label) const {
+  template <bool COMPACT_ = COMPACT>
+  inline typename std::enable_if<!COMPACT_, const int64_t*>::type
+  GetOutgoingOffsetArray(label_id_t v_label, label_id_t e_label) const {
     return oe_offsets_ptr_lists_[v_label][e_label];
   }
 
@@ -577,8 +579,6 @@ class [[vineyard]] ArrowFragment
 
   std::shared_ptr<vertex_map_t> GetVertexMap() { return vm_ptr_; }
 
-  const PropertyGraphSchema& schema() const override { return schema_; }
-
   void PrepareToRunApp(const grape::CommSpec& comm_spec,
                        grape::PrepareConf conf);
 
@@ -589,19 +589,20 @@ class [[vineyard]] ArrowFragment
       ObjectID vm_id,
       const std::vector<std::set<std::pair<std::string, std::string>>>&
           edge_relations,
-      int concurrency);
+      const int concurrency = std::thread::hardware_concurrency()) override;
 
   boost::leaf::result<ObjectID> AddVertices(
       Client& client,
       std::map<label_id_t, std::shared_ptr<arrow::Table>>&& vertex_tables_map,
-      ObjectID vm_id);
+      ObjectID vm_id,
+      const int concurrency = std::thread::hardware_concurrency()) override;
 
   boost::leaf::result<ObjectID> AddEdges(
       Client& client,
       std::map<label_id_t, std::shared_ptr<arrow::Table>>&& edge_tables_map,
       const std::vector<std::set<std::pair<std::string, std::string>>>&
           edge_relations,
-      int concurrency);
+      const int concurrency = std::thread::hardware_concurrency()) override;
 
   /// Add a set of new vertex labels and a set of new edge labels to graph.
   /// Vertex label id started from vertex_label_num_, and edge label id
@@ -612,14 +613,15 @@ class [[vineyard]] ArrowFragment
       std::vector<std::shared_ptr<arrow::Table>>&& edge_tables, ObjectID vm_id,
       const std::vector<std::set<std::pair<std::string, std::string>>>&
           edge_relations,
-      int concurrency);
+      const int concurrency = std::thread::hardware_concurrency()) override;
 
   /// Add a set of new vertex labels to graph. Vertex label id started from
   /// vertex_label_num_.
   boost::leaf::result<ObjectID> AddNewVertexLabels(
       Client& client,
       std::vector<std::shared_ptr<arrow::Table>>&& vertex_tables,
-      ObjectID vm_id);
+      ObjectID vm_id,
+      const int concurrency = std::thread::hardware_concurrency()) override;
 
   /// Add a set of new edge labels to graph. Edge label id started from
   /// edge_label_num_.
@@ -627,7 +629,7 @@ class [[vineyard]] ArrowFragment
       Client& client, std::vector<std::shared_ptr<arrow::Table>>&& edge_tables,
       const std::vector<std::set<std::pair<std::string, std::string>>>&
           edge_relations,
-      int concurrency);
+      const int concurrency = std::thread::hardware_concurrency()) override;
 
   boost::leaf::result<vineyard::ObjectID> AddVertexColumns(
       vineyard::Client& client,
@@ -719,10 +721,11 @@ class [[vineyard]] ArrowFragment
           oe_lists,
       std::vector<std::vector<std::shared_ptr<FixedInt64Builder>>>&
           oe_offsets_lists,
-      int concurrency, bool& is_multigraph);
+      const int concurrency, bool& is_multigraph);
 
   [[shared]] fid_t fid_, fnum_;
   [[shared]] bool directed_;
+  [[shared]] bool local_vertex_map_;
   [[shared]] bool compact_edges_;
   [[shared]] bool is_multigraph_;
   [[shared]] property_graph_types::LABEL_ID_TYPE vertex_label_num_;
@@ -749,20 +752,14 @@ class [[vineyard]] ArrowFragment
   [[shared]] List<List<std::shared_ptr<FixedSizeBinaryArray>>> ie_lists_,
       oe_lists_;
   std::vector<std::vector<const nbr_unit_t*>> ie_ptr_lists_, oe_ptr_lists_;
+  [[shared]] List<List<std::shared_ptr<UInt8Array>>> compact_ie_lists_,
+      compact_oe_lists_;
+  std::vector<std::vector<const uint8_t*>> compact_ie_ptr_lists_,
+      compact_oe_ptr_lists_;
   [[shared]] List<List<std::shared_ptr<Int64Array>>> ie_offsets_lists_,
       oe_offsets_lists_;
   std::vector<std::vector<const int64_t*>> ie_offsets_ptr_lists_,
       oe_offsets_ptr_lists_;
-
-  [[shared]] List<List<std::shared_ptr<UInt8Array>>> compact_ie_lists_,
-      compact_oe_lists_;
-  [[shared]] List<List<std::shared_ptr<Int64Array>>> compact_ie_offsets_lists_,
-      compact_oe_offsets_lists_;
-
-  std::vector<std::vector<const uint8_t*>> compact_ie_ptr_lists_,
-      compact_oe_ptr_lists_;
-  std::vector<std::vector<const int64_t*>> compact_ie_offsets_ptr_lists_,
-      compact_oe_offsets_ptr_lists_;
 
   std::vector<std::vector<std::vector<fid_t>>> idst_, odst_, iodst_;
   std::vector<std::vector<std::vector<fid_t*>>> idoffset_, odoffset_,

--- a/modules/graph/fragment/arrow_fragment_base.h
+++ b/modules/graph/fragment/arrow_fragment_base.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include <cstddef>
 #include <map>
 #include <memory>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -48,6 +49,73 @@ class ArrowFragmentBase : public vineyard::Object {
   using label_id_t = property_graph_types::LABEL_ID_TYPE;
 
   virtual ~ArrowFragmentBase() = default;
+
+  virtual boost::leaf::result<ObjectID> AddVerticesAndEdges(
+      Client& client,
+      std::map<label_id_t, std::shared_ptr<arrow::Table>>&& vertex_tables_map,
+      std::map<label_id_t, std::shared_ptr<arrow::Table>>&& edge_tables_map,
+      ObjectID vm_id,
+      const std::vector<std::set<std::pair<std::string, std::string>>>&
+          edge_relations,
+      const int concurrency = std::thread::hardware_concurrency()) {
+    VINEYARD_ASSERT(false, "Not implemented");
+    return vineyard::InvalidObjectID();
+  }
+
+  virtual boost::leaf::result<ObjectID> AddVertices(
+      Client& client,
+      std::map<label_id_t, std::shared_ptr<arrow::Table>>&& vertex_tables_map,
+      ObjectID vm_id,
+      const int concurrency = std::thread::hardware_concurrency()) {
+    VINEYARD_ASSERT(false, "Not implemented");
+    return vineyard::InvalidObjectID();
+  }
+
+  virtual boost::leaf::result<ObjectID> AddEdges(
+      Client& client,
+      std::map<label_id_t, std::shared_ptr<arrow::Table>>&& edge_tables_map,
+      const std::vector<std::set<std::pair<std::string, std::string>>>&
+          edge_relations,
+      const int concurrency = std::thread::hardware_concurrency()) {
+    VINEYARD_ASSERT(false, "Not implemented");
+    return vineyard::InvalidObjectID();
+  }
+
+  /// Add a set of new vertex labels and a set of new edge labels to graph.
+  /// Vertex label id started from vertex_label_num_, and edge label id
+  /// started from edge_label_num_.
+  virtual boost::leaf::result<ObjectID> AddNewVertexEdgeLabels(
+      Client& client,
+      std::vector<std::shared_ptr<arrow::Table>>&& vertex_tables,
+      std::vector<std::shared_ptr<arrow::Table>>&& edge_tables, ObjectID vm_id,
+      const std::vector<std::set<std::pair<std::string, std::string>>>&
+          edge_relations,
+      const int concurrency = std::thread::hardware_concurrency()) {
+    VINEYARD_ASSERT(false, "Not implemented");
+    return vineyard::InvalidObjectID();
+  }
+
+  /// Add a set of new vertex labels to graph. Vertex label id started from
+  /// vertex_label_num_.
+  virtual boost::leaf::result<ObjectID> AddNewVertexLabels(
+      Client& client,
+      std::vector<std::shared_ptr<arrow::Table>>&& vertex_tables,
+      ObjectID vm_id,
+      const int concurrency = std::thread::hardware_concurrency()) {
+    VINEYARD_ASSERT(false, "Not implemented");
+    return vineyard::InvalidObjectID();
+  }
+
+  /// Add a set of new edge labels to graph. Edge label id started from
+  /// edge_label_num_.
+  virtual boost::leaf::result<ObjectID> AddNewEdgeLabels(
+      Client& client, std::vector<std::shared_ptr<arrow::Table>>&& edge_tables,
+      const std::vector<std::set<std::pair<std::string, std::string>>>&
+          edge_relations,
+      const int concurrency = std::thread::hardware_concurrency()) {
+    VINEYARD_ASSERT(false, "Not implemented");
+    return vineyard::InvalidObjectID();
+  }
 
   virtual boost::leaf::result<vineyard::ObjectID> AddVertexColumns(
       vineyard::Client& client,
@@ -94,6 +162,10 @@ class ArrowFragmentBase : public vineyard::Object {
   }
 
   virtual vineyard::ObjectID vertex_map_id() const = 0;
+
+  virtual bool local_vertex_map() const = 0;
+
+  virtual bool compact_edges() const = 0;
 
   virtual const PropertyGraphSchema& schema() const = 0;
 

--- a/modules/graph/fragment/property_graph_types.h
+++ b/modules/graph/fragment/property_graph_types.h
@@ -26,7 +26,7 @@ limitations under the License.
 
 #include "basic/ds/arrow.h"
 #include "common/util/arrow.h"
-#include "graph/fragment/varint_impl.h"
+#include "graph/utils/varint_encoding.h"
 
 namespace vineyard {
 

--- a/modules/graph/fragment/property_graph_utils.h
+++ b/modules/graph/fragment/property_graph_utils.h
@@ -166,12 +166,25 @@ boost::leaf::result<void> generate_undirected_csr_memopt(
     bool& is_multigraph);
 
 template <typename VID_T, typename EID_T>
-boost::leaf::result<void> generate_varint_edges(
-    property_graph_utils::NbrUnit<VID_T, EID_T>* e_list, size_t list_size,
-    int64_t* e_offsets_lists_, size_t e_offsets_lists_size,
-    std::vector<uint8_t>& compact_id_list,
-    std::vector<int64_t>& compact_offsets_list, int concurrency);
-
+boost::leaf::result<void> varint_encoding_edges(
+    Client& client, const bool directed,
+    const property_graph_types::LABEL_ID_TYPE vertex_label_num,
+    const property_graph_types::LABEL_ID_TYPE edge_label_num,
+    const std::vector<std::vector<std::shared_ptr<
+        PodArrayBuilder<property_graph_utils::NbrUnit<VID_T, EID_T>>>>>&
+        ie_lists,
+    const std::vector<std::vector<std::shared_ptr<
+        PodArrayBuilder<property_graph_utils::NbrUnit<VID_T, EID_T>>>>>&
+        oe_lists,
+    std::vector<std::vector<std::shared_ptr<FixedUInt8Builder>>>&
+        compact_ie_lists,
+    std::vector<std::vector<std::shared_ptr<FixedUInt8Builder>>>&
+        compact_oe_lists,
+    const std::vector<std::vector<std::shared_ptr<FixedInt64Builder>>>&
+        ie_offsets_lists,
+    const std::vector<std::vector<std::shared_ptr<FixedInt64Builder>>>&
+        oe_offsets_lists,
+    const int concurrency = std::thread::hardware_concurrency());
 }  // namespace vineyard
 
 #endif  // MODULES_GRAPH_FRAGMENT_PROPERTY_GRAPH_UTILS_H_

--- a/modules/graph/fragment/property_graph_utils_uint32.cc
+++ b/modules/graph/fragment/property_graph_utils_uint32.cc
@@ -97,10 +97,24 @@ generate_undirected_csr_memopt<uint32_t, uint64_t>(
     std::vector<std::shared_ptr<FixedInt64Builder>>& edge_offsets,
     bool& is_multigraph);
 
-template boost::leaf::result<void> generate_varint_edges<uint32_t, uint64_t>(
-    property_graph_utils::NbrUnit<uint32_t, uint64_t>* e_list, size_t list_size,
-    int64_t* e_offsets_lists_, size_t e_offsets_lists_size,
-    std::vector<uint8_t>& compact_id_list,
-    std::vector<int64_t>& compact_offsets_list, int concurrency);
+template boost::leaf::result<void> varint_encoding_edges<uint32_t, uint64_t>(
+    Client& client, const bool directed,
+    const property_graph_types::LABEL_ID_TYPE vertex_label_num,
+    const property_graph_types::LABEL_ID_TYPE edge_label_num,
+    const std::vector<std::vector<std::shared_ptr<
+        PodArrayBuilder<property_graph_utils::NbrUnit<uint32_t, uint64_t>>>>>&
+        ie_lists,
+    const std::vector<std::vector<std::shared_ptr<
+        PodArrayBuilder<property_graph_utils::NbrUnit<uint32_t, uint64_t>>>>>&
+        oe_lists,
+    std::vector<std::vector<std::shared_ptr<FixedUInt8Builder>>>&
+        compact_ie_lists,
+    std::vector<std::vector<std::shared_ptr<FixedUInt8Builder>>>&
+        compact_oe_lists,
+    const std::vector<std::vector<std::shared_ptr<FixedInt64Builder>>>&
+        ie_offsets_lists,
+    const std::vector<std::vector<std::shared_ptr<FixedInt64Builder>>>&
+        oe_offsets_lists,
+    const int concurrency);
 
 }  // namespace vineyard

--- a/modules/graph/fragment/property_graph_utils_uint64.cc
+++ b/modules/graph/fragment/property_graph_utils_uint64.cc
@@ -97,10 +97,24 @@ generate_undirected_csr_memopt<uint64_t, uint64_t>(
     std::vector<std::shared_ptr<FixedInt64Builder>>& edge_offsets,
     bool& is_multigraph);
 
-template boost::leaf::result<void> generate_varint_edges<uint64_t, uint64_t>(
-    property_graph_utils::NbrUnit<uint64_t, uint64_t>* e_list, size_t list_size,
-    int64_t* e_offsets_lists_, size_t e_offsets_lists_size,
-    std::vector<uint8_t>& compact_id_list,
-    std::vector<int64_t>& compact_offsets_list, int concurrency);
+template boost::leaf::result<void> varint_encoding_edges<uint64_t, uint64_t>(
+    Client& client, const bool directed,
+    const property_graph_types::LABEL_ID_TYPE vertex_label_num,
+    const property_graph_types::LABEL_ID_TYPE edge_label_num,
+    const std::vector<std::vector<std::shared_ptr<
+        PodArrayBuilder<property_graph_utils::NbrUnit<uint64_t, uint64_t>>>>>&
+        ie_lists,
+    const std::vector<std::vector<std::shared_ptr<
+        PodArrayBuilder<property_graph_utils::NbrUnit<uint64_t, uint64_t>>>>>&
+        oe_lists,
+    std::vector<std::vector<std::shared_ptr<FixedUInt8Builder>>>&
+        compact_ie_lists,
+    std::vector<std::vector<std::shared_ptr<FixedUInt8Builder>>>&
+        compact_oe_lists,
+    const std::vector<std::vector<std::shared_ptr<FixedInt64Builder>>>&
+        ie_offsets_lists,
+    const std::vector<std::vector<std::shared_ptr<FixedInt64Builder>>>&
+        oe_offsets_lists,
+    const int concurrency);
 
 }  // namespace vineyard

--- a/modules/graph/loader/arrow_fragment_loader.h
+++ b/modules/graph/loader/arrow_fragment_loader.h
@@ -119,13 +119,105 @@ boost::leaf::result<std::vector<std::shared_ptr<arrow::Table>>> GatherVTables(
     Client& client, const std::vector<ObjectID>& vstreams, int part_id,
     int part_num);
 
+class DataLoader {
+ public:
+  using label_id_t = property_graph_types::LABEL_ID_TYPE;
+  using table_vec_t = std::vector<std::shared_ptr<arrow::Table>>;
+
+ protected:
+  // These consts represent the key in the path of vfile/efile
+  static constexpr const char* LABEL_TAG = "label";
+  static constexpr const char* SRC_LABEL_TAG = "src_label";
+  static constexpr const char* DST_LABEL_TAG = "dst_label";
+  static constexpr const char* CONSOLIDATE_TAG = "consolidate";
+  static constexpr const char* MARKER = "PROGRESS--GRAPH-LOADING-";
+
+  static constexpr int id_column = 0;
+
+  using vertex_table_info_t =
+      std::map<std::string, std::shared_ptr<arrow::Table>>;
+  using edge_table_info_t = std::vector<InputTable>;
+
+ public:
+  /**
+   *
+   * @param client
+   * @param comm_spec
+   * @param efiles An example of efile:
+   * /data/twitter_e_0_0_0#src_label=v0&dst_label=v0&label=e0;/data/twitter_e_0_1_0#src_label=v0&dst_label=v1&label=e0;/data/twitter_e_1_0_0#src_label=v1&dst_label=v0&label=e0;/data/twitter_e_1_1_0#src_label=v1&dst_label=v1&label=e0
+   * @param vfiles An example of vfile: /data/twitter_v_0#label=v0
+   */
+  DataLoader(Client& client, const grape::CommSpec& comm_spec,
+             const std::vector<std::string>& efiles,
+             const std::vector<std::string>& vfiles)
+      : client_(client),
+        comm_spec_(comm_spec),
+        efiles_(efiles),
+        vfiles_(vfiles) {}
+
+  DataLoader(Client& client, const grape::CommSpec& comm_spec,
+             const std::vector<std::string>& efiles)
+      : client_(client), comm_spec_(comm_spec), efiles_(efiles), vfiles_() {}
+
+  DataLoader(Client& client, const grape::CommSpec& comm_spec,
+             std::vector<std::shared_ptr<arrow::Table>> const& partial_v_tables,
+             std::vector<std::vector<std::shared_ptr<arrow::Table>>> const&
+                 partial_e_tables)
+      : client_(client),
+        comm_spec_(comm_spec),
+        partial_v_tables_(partial_v_tables),
+        partial_e_tables_(partial_e_tables) {}
+
+  DataLoader(Client& client, const grape::CommSpec& comm_spec,
+             std::vector<std::vector<std::shared_ptr<arrow::Table>>> const&
+                 partial_e_tables)
+      : client_(client),
+        comm_spec_(comm_spec),
+        partial_v_tables_(),
+        partial_e_tables_(partial_e_tables) {}
+
+  ~DataLoader() = default;
+
+  boost::leaf::result<std::pair<table_vec_t, std::vector<table_vec_t>>>
+  LoadVertexEdgeTables();
+
+  boost::leaf::result<table_vec_t> LoadVertexTables();
+
+  boost::leaf::result<std::vector<table_vec_t>> LoadEdgeTables();
+
+ protected:  // for subclasses
+  boost::leaf::result<vineyard::ObjectID> resolveVineyardObject(
+      std::string const& source);
+
+  boost::leaf::result<std::vector<std::shared_ptr<arrow::Table>>>
+  loadVertexTables(const std::vector<std::string>& files, int index,
+                   int total_parts);
+
+  boost::leaf::result<std::vector<std::vector<std::shared_ptr<arrow::Table>>>>
+  loadEdgeTables(const std::vector<std::string>& files, int index,
+                 int total_parts);
+
+  /// Do some necessary sanity checks.
+  boost::leaf::result<void> sanityChecks(std::shared_ptr<arrow::Table> table);
+
+  Client& client_;
+  grape::CommSpec comm_spec_;
+  std::vector<std::string> efiles_, vfiles_;
+
+  std::vector<ObjectID> v_streams_;
+  std::vector<std::vector<ObjectID>> e_streams_;
+  std::vector<std::shared_ptr<arrow::Table>> partial_v_tables_;
+  std::vector<std::vector<std::shared_ptr<arrow::Table>>> partial_e_tables_;
+
+  std::function<void(IIOAdaptor*)> io_deleter_ = [](IIOAdaptor* adaptor) {
+    VINEYARD_DISCARD(adaptor->Close());
+    delete adaptor;
+  };
+};
+
 template <typename OID_T = property_graph_types::OID_TYPE,
-          typename VID_T = property_graph_types::VID_TYPE,
-          template <typename OID_T_ = typename InternalType<OID_T>::type,
-                    typename VID_T_ = VID_T>
-          class VERTEX_MAP_T = ArrowVertexMap,
-          bool COMPACT = false>
-class ArrowFragmentLoader {
+          typename VID_T = property_graph_types::VID_TYPE>
+class ArrowFragmentLoader : public DataLoader {
  public:
   using oid_t = OID_T;
   using vid_t = VID_T;
@@ -133,8 +225,8 @@ class ArrowFragmentLoader {
   using internal_oid_t = typename InternalType<oid_t>::type;
   using oid_array_t = ArrowArrayType<oid_t>;
   using vid_array_t = ArrowArrayType<vid_t>;
-  using vertex_map_t = VERTEX_MAP_T<internal_oid_t, vid_t>;
-  using fragment_t = ArrowFragment<OID_T, VID_T, vertex_map_t, COMPACT>;
+  using vertex_map_t = ArrowVertexMap<internal_oid_t, vid_t>;
+  using local_vertex_map_t = ArrowLocalVertexMap<internal_oid_t, vid_t>;
 
   using table_vec_t = std::vector<std::shared_ptr<arrow::Table>>;
   using oid_array_vec_t = std::vector<std::shared_ptr<oid_array_t>>;
@@ -147,7 +239,7 @@ class ArrowFragmentLoader {
 #endif
 
   using basic_fragment_loader_t =
-      BasicEVFragmentLoader<OID_T, VID_T, partitioner_t, VERTEX_MAP_T, COMPACT>;
+      BasicEVFragmentLoader<OID_T, VID_T, partitioner_t>;
 
  protected:
   // These consts represent the key in the path of vfile/efile
@@ -177,27 +269,29 @@ class ArrowFragmentLoader {
                       const std::vector<std::string>& efiles,
                       const std::vector<std::string>& vfiles,
                       bool directed = true, bool generate_eid = false,
-                      bool retain_oid = false, bool compact_edges = false)
-      : client_(client),
+                      bool retain_oid = false, bool local_vertex_map = false,
+                      bool compact_edges = false)
+      : DataLoader(client, comm_spec, efiles, vfiles),
+        client_(client),
         comm_spec_(comm_spec),
-        efiles_(efiles),
-        vfiles_(vfiles),
         directed_(directed),
         generate_eid_(generate_eid),
         retain_oid_(retain_oid),
+        local_vertex_map_(local_vertex_map),
         compact_edges_(compact_edges) {}
 
   ArrowFragmentLoader(Client& client, const grape::CommSpec& comm_spec,
                       const std::vector<std::string>& efiles,
                       bool directed = true, bool generate_eid = false,
-                      bool retain_oid = false, bool compact_edges = false)
-      : client_(client),
+                      bool retain_oid = false, bool local_vertex_map = false,
+                      bool compact_edges = false)
+      : DataLoader(client, comm_spec, efiles),
+        client_(client),
         comm_spec_(comm_spec),
-        efiles_(efiles),
-        vfiles_(),
         directed_(directed),
         generate_eid_(generate_eid),
         retain_oid_(retain_oid),
+        local_vertex_map_(local_vertex_map),
         compact_edges_(compact_edges) {}
 
   ArrowFragmentLoader(
@@ -206,14 +300,14 @@ class ArrowFragmentLoader {
       std::vector<std::vector<std::shared_ptr<arrow::Table>>> const&
           partial_e_tables,
       bool directed = true, bool generate_eid = false, bool retain_oid = false,
-      bool compact_edges = false)
-      : client_(client),
+      bool local_vertex_map = false, bool compact_edges = false)
+      : DataLoader(client, comm_spec, partial_v_tables, partial_e_tables),
+        client_(client),
         comm_spec_(comm_spec),
-        partial_v_tables_(partial_v_tables),
-        partial_e_tables_(partial_e_tables),
         directed_(directed),
         generate_eid_(generate_eid),
         retain_oid_(retain_oid),
+        local_vertex_map_(local_vertex_map),
         compact_edges_(compact_edges) {}
 
   ArrowFragmentLoader(
@@ -221,14 +315,14 @@ class ArrowFragmentLoader {
       std::vector<std::vector<std::shared_ptr<arrow::Table>>> const&
           partial_e_tables,
       bool directed = true, bool generate_eid = false, bool retain_oid = false,
-      bool compact_edges = false)
-      : client_(client),
+      bool local_vertex_map = false, bool compact_edges = false)
+      : DataLoader(client, comm_spec, partial_e_tables),
+        client_(client),
         comm_spec_(comm_spec),
-        partial_v_tables_(),
-        partial_e_tables_(partial_e_tables),
         directed_(directed),
         generate_eid_(generate_eid),
         retain_oid_(retain_oid),
+        local_vertex_map_(local_vertex_map),
         compact_edges_(compact_edges) {}
 
   ~ArrowFragmentLoader() = default;
@@ -254,26 +348,12 @@ class ArrowFragmentLoader {
   boost::leaf::result<vineyard::ObjectID> AddLabelsToFragmentAsFragmentGroup(
       vineyard::ObjectID frag_id);
 
-  boost::leaf::result<std::pair<table_vec_t, std::vector<table_vec_t>>>
-  LoadVertexEdgeTables();
-
-  boost::leaf::result<table_vec_t> LoadVertexTables();
-
-  boost::leaf::result<std::vector<table_vec_t>> LoadEdgeTables();
+  using DataLoader::LoadEdgeTables;
+  using DataLoader::LoadVertexEdgeTables;
+  using DataLoader::LoadVertexTables;
 
  protected:  // for subclasses
   boost::leaf::result<void> initPartitioner();
-
-  boost::leaf::result<vineyard::ObjectID> resolveVineyardObject(
-      std::string const& source);
-
-  boost::leaf::result<std::vector<std::shared_ptr<arrow::Table>>>
-  loadVertexTables(const std::vector<std::string>& files, int index,
-                   int total_parts);
-
-  boost::leaf::result<std::vector<std::vector<std::shared_ptr<arrow::Table>>>>
-  loadEdgeTables(const std::vector<std::string>& files, int index,
-                 int total_parts);
 
   boost::leaf::result<std::pair<vertex_table_info_t, edge_table_info_t>>
   preprocessInputs(
@@ -282,60 +362,31 @@ class ArrowFragmentLoader {
       const std::set<std::string>& previous_vertex_labels =
           std::set<std::string>());
 
-  /// Do some necessary sanity checks.
-  boost::leaf::result<void> sanityChecks(std::shared_ptr<arrow::Table> table);
-
   boost::leaf::result<vineyard::ObjectID> addVerticesAndEdges(
       vineyard::ObjectID frag_id,
       std::pair<table_vec_t, std::vector<table_vec_t>> raw_v_e_tables);
 
+  using DataLoader::loadEdgeTables;
+  using DataLoader::loadVertexTables;
+  using DataLoader::resolveVineyardObject;
+  using DataLoader::sanityChecks;
+
   Client& client_;
   grape::CommSpec comm_spec_;
-  std::vector<std::string> efiles_, vfiles_;
-
-  std::vector<ObjectID> v_streams_;
-  std::vector<std::vector<ObjectID>> e_streams_;
-  std::vector<std::shared_ptr<arrow::Table>> partial_v_tables_;
-  std::vector<std::vector<std::shared_ptr<arrow::Table>>> partial_e_tables_;
 
   partitioner_t partitioner_;
 
-  bool directed_;
+  bool directed_ = true;
   bool generate_eid_ = false;
   bool retain_oid_ = false;
-  bool compact_edges_;
+  bool local_vertex_map_ = false;
+  bool compact_edges_ = false;
 
   std::function<void(IIOAdaptor*)> io_deleter_ = [](IIOAdaptor* adaptor) {
     VINEYARD_DISCARD(adaptor->Close());
     delete adaptor;
   };
 };
-
-namespace detail {
-
-template <typename OID_T, typename VID_T, typename VERTEX_MAP_T, bool COMPACT>
-struct rebind_arrow_fragment_loader;
-
-template <typename OID_T, typename VID_T, bool COMPACT>
-struct rebind_arrow_fragment_loader<
-    OID_T, VID_T, vineyard::ArrowVertexMap<OID_T, VID_T>, COMPACT> {
-  using type =
-      ArrowFragmentLoader<OID_T, VID_T, vineyard::ArrowVertexMap, COMPACT>;
-};
-
-template <typename OID_T, typename VID_T, bool COMPACT>
-struct rebind_arrow_fragment_loader<
-    OID_T, VID_T, vineyard::ArrowLocalVertexMap<OID_T, VID_T>, COMPACT> {
-  using type =
-      ArrowFragmentLoader<OID_T, VID_T, vineyard::ArrowLocalVertexMap, COMPACT>;
-};
-
-}  // namespace detail
-
-template <typename OID_T, typename VID_T, typename VERTEX_MAP_T, bool COMPACT>
-using arrow_fragment_loader_t =
-    typename detail::rebind_arrow_fragment_loader<OID_T, VID_T, VERTEX_MAP_T,
-                                                  COMPACT>::type;
 
 }  // namespace vineyard
 

--- a/modules/graph/loader/arrow_fragment_loader_int32.cc
+++ b/modules/graph/loader/arrow_fragment_loader_int32.cc
@@ -17,24 +17,8 @@ limitations under the License.
 
 namespace vineyard {
 
-template class ArrowFragmentLoader<int32_t, uint32_t, ArrowVertexMap, false>;
+template class ArrowFragmentLoader<int32_t, uint32_t>;
 
-template class ArrowFragmentLoader<int32_t, uint32_t, ArrowLocalVertexMap,
-                                   false>;
-
-template class ArrowFragmentLoader<int32_t, uint64_t, ArrowVertexMap, false>;
-
-template class ArrowFragmentLoader<int32_t, uint64_t, ArrowLocalVertexMap,
-                                   false>;
-
-template class ArrowFragmentLoader<int32_t, uint32_t, ArrowVertexMap, true>;
-
-template class ArrowFragmentLoader<int32_t, uint32_t, ArrowLocalVertexMap,
-                                   true>;
-
-template class ArrowFragmentLoader<int32_t, uint64_t, ArrowVertexMap, true>;
-
-template class ArrowFragmentLoader<int32_t, uint64_t, ArrowLocalVertexMap,
-                                   true>;
+template class ArrowFragmentLoader<int32_t, uint64_t>;
 
 }  // namespace vineyard

--- a/modules/graph/loader/arrow_fragment_loader_int64.cc
+++ b/modules/graph/loader/arrow_fragment_loader_int64.cc
@@ -17,24 +17,8 @@ limitations under the License.
 
 namespace vineyard {
 
-template class ArrowFragmentLoader<int64_t, uint64_t, ArrowVertexMap, false>;
+template class ArrowFragmentLoader<int64_t, uint64_t>;
 
-template class ArrowFragmentLoader<int64_t, uint64_t, ArrowLocalVertexMap,
-                                   false>;
-
-template class ArrowFragmentLoader<int64_t, uint32_t, ArrowVertexMap, false>;
-
-template class ArrowFragmentLoader<int64_t, uint32_t, ArrowLocalVertexMap,
-                                   false>;
-
-template class ArrowFragmentLoader<int64_t, uint64_t, ArrowVertexMap, true>;
-
-template class ArrowFragmentLoader<int64_t, uint64_t, ArrowLocalVertexMap,
-                                   true>;
-
-template class ArrowFragmentLoader<int64_t, uint32_t, ArrowVertexMap, true>;
-
-template class ArrowFragmentLoader<int64_t, uint32_t, ArrowLocalVertexMap,
-                                   true>;
+template class ArrowFragmentLoader<int64_t, uint32_t>;
 
 }  // namespace vineyard

--- a/modules/graph/loader/arrow_fragment_loader_string.cc
+++ b/modules/graph/loader/arrow_fragment_loader_string.cc
@@ -17,26 +17,8 @@ limitations under the License.
 
 namespace vineyard {
 
-template class ArrowFragmentLoader<std::string, uint64_t, ArrowVertexMap,
-                                   false>;
+template class ArrowFragmentLoader<std::string, uint64_t>;
 
-template class ArrowFragmentLoader<std::string, uint64_t, ArrowLocalVertexMap,
-                                   false>;
-
-template class ArrowFragmentLoader<std::string, uint32_t, ArrowVertexMap,
-                                   false>;
-
-template class ArrowFragmentLoader<std::string, uint32_t, ArrowLocalVertexMap,
-                                   false>;
-
-template class ArrowFragmentLoader<std::string, uint64_t, ArrowVertexMap, true>;
-
-template class ArrowFragmentLoader<std::string, uint64_t, ArrowLocalVertexMap,
-                                   true>;
-
-template class ArrowFragmentLoader<std::string, uint32_t, ArrowVertexMap, true>;
-
-template class ArrowFragmentLoader<std::string, uint32_t, ArrowLocalVertexMap,
-                                   true>;
+template class ArrowFragmentLoader<std::string, uint32_t>;
 
 }  // namespace vineyard

--- a/modules/graph/loader/basic_ev_fragment_loader_int32.cc
+++ b/modules/graph/loader/basic_ev_fragment_loader_int32.cc
@@ -18,28 +18,10 @@ limitations under the License.
 
 namespace vineyard {
 
-template class BasicEVFragmentLoader<
-    int32_t, uint64_t, HashPartitioner<int32_t>, ArrowVertexMap, false>;
+template class BasicEVFragmentLoader<int32_t, uint64_t,
+                                     HashPartitioner<int32_t>>;
 
-template class BasicEVFragmentLoader<
-    int32_t, uint32_t, HashPartitioner<int32_t>, ArrowVertexMap, false>;
-
-template class BasicEVFragmentLoader<
-    int32_t, uint32_t, HashPartitioner<int32_t>, ArrowLocalVertexMap, false>;
-
-template class BasicEVFragmentLoader<
-    int32_t, uint64_t, HashPartitioner<int32_t>, ArrowLocalVertexMap, false>;
-
-template class BasicEVFragmentLoader<
-    int32_t, uint64_t, HashPartitioner<int32_t>, ArrowVertexMap, true>;
-
-template class BasicEVFragmentLoader<
-    int32_t, uint32_t, HashPartitioner<int32_t>, ArrowVertexMap, true>;
-
-template class BasicEVFragmentLoader<
-    int32_t, uint32_t, HashPartitioner<int32_t>, ArrowLocalVertexMap, true>;
-
-template class BasicEVFragmentLoader<
-    int32_t, uint64_t, HashPartitioner<int32_t>, ArrowLocalVertexMap, true>;
+template class BasicEVFragmentLoader<int32_t, uint32_t,
+                                     HashPartitioner<int32_t>>;
 
 }  // namespace vineyard

--- a/modules/graph/loader/basic_ev_fragment_loader_int64.cc
+++ b/modules/graph/loader/basic_ev_fragment_loader_int64.cc
@@ -18,28 +18,10 @@ limitations under the License.
 
 namespace vineyard {
 
-template class BasicEVFragmentLoader<
-    int64_t, uint32_t, HashPartitioner<int64_t>, ArrowVertexMap, false>;
+template class BasicEVFragmentLoader<int64_t, uint64_t,
+                                     HashPartitioner<int64_t>>;
 
-template class BasicEVFragmentLoader<
-    int64_t, uint64_t, HashPartitioner<int64_t>, ArrowVertexMap, false>;
-
-template class BasicEVFragmentLoader<
-    int64_t, uint32_t, HashPartitioner<int64_t>, ArrowLocalVertexMap, false>;
-
-template class BasicEVFragmentLoader<
-    int64_t, uint64_t, HashPartitioner<int64_t>, ArrowLocalVertexMap, false>;
-
-template class BasicEVFragmentLoader<
-    int64_t, uint32_t, HashPartitioner<int64_t>, ArrowVertexMap, true>;
-
-template class BasicEVFragmentLoader<
-    int64_t, uint64_t, HashPartitioner<int64_t>, ArrowVertexMap, true>;
-
-template class BasicEVFragmentLoader<
-    int64_t, uint32_t, HashPartitioner<int64_t>, ArrowLocalVertexMap, true>;
-
-template class BasicEVFragmentLoader<
-    int64_t, uint64_t, HashPartitioner<int64_t>, ArrowLocalVertexMap, true>;
+template class BasicEVFragmentLoader<int64_t, uint32_t,
+                                     HashPartitioner<int64_t>>;
 
 }  // namespace vineyard

--- a/modules/graph/loader/basic_ev_fragment_loader_string.cc
+++ b/modules/graph/loader/basic_ev_fragment_loader_string.cc
@@ -18,32 +18,10 @@ limitations under the License.
 
 namespace vineyard {
 
-template class BasicEVFragmentLoader<
-    std::string, uint32_t, HashPartitioner<std::string>, ArrowVertexMap, false>;
-
-template class BasicEVFragmentLoader<
-    std::string, uint64_t, HashPartitioner<std::string>, ArrowVertexMap, false>;
+template class BasicEVFragmentLoader<std::string, uint64_t,
+                                     HashPartitioner<std::string>>;
 
 template class BasicEVFragmentLoader<std::string, uint32_t,
-                                     HashPartitioner<std::string>,
-                                     ArrowLocalVertexMap, false>;
-
-template class BasicEVFragmentLoader<std::string, uint64_t,
-                                     HashPartitioner<std::string>,
-                                     ArrowLocalVertexMap, false>;
-
-template class BasicEVFragmentLoader<
-    std::string, uint32_t, HashPartitioner<std::string>, ArrowVertexMap, true>;
-
-template class BasicEVFragmentLoader<
-    std::string, uint64_t, HashPartitioner<std::string>, ArrowVertexMap, true>;
-
-template class BasicEVFragmentLoader<std::string, uint32_t,
-                                     HashPartitioner<std::string>,
-                                     ArrowLocalVertexMap, true>;
-
-template class BasicEVFragmentLoader<std::string, uint64_t,
-                                     HashPartitioner<std::string>,
-                                     ArrowLocalVertexMap, true>;
+                                     HashPartitioner<std::string>>;
 
 }  // namespace vineyard

--- a/modules/graph/loader/gar_fragment_loader.h
+++ b/modules/graph/loader/gar_fragment_loader.h
@@ -112,7 +112,7 @@ class GARFragmentLoader {
 
   boost::leaf::result<void> initSchema(PropertyGraphSchema& schema);
 
-  boost::leaf::result<std::shared_ptr<arrow::Table>> edgesId2Gid(
+  boost::leaf::result<std::shared_ptr<arrow::Table>> parseEdgeIdArrays(
       std::shared_ptr<arrow::Table> adj_list_table, label_id_t src_label,
       label_id_t dst_label, GraphArchive::AdjListType adj_list_type);
 

--- a/modules/graph/loader/gar_fragment_loader_impl.h
+++ b/modules/graph/loader/gar_fragment_loader_impl.h
@@ -543,9 +543,9 @@ GARFragmentLoader<OID_T, VID_T, VERTEX_MAP_T>::loadEdgeTableOfLabel(
   std::shared_ptr<arrow::Table> adj_list_table_with_gid;
   BOOST_LEAF_ASSIGN(
       adj_list_table_with_gid,
-      edgesId2Gid(std::move(adj_list_table).ValueOrDie(),
-                  vertex_label_to_index_[src_label],
-                  vertex_label_to_index_[dst_label], adj_list_type));
+      parseEdgeIdArrays(std::move(adj_list_table).ValueOrDie(),
+                        vertex_label_to_index_[src_label],
+                        vertex_label_to_index_[dst_label], adj_list_type));
 
   // process property tables
   std::shared_ptr<arrow::Table> property_table;
@@ -639,7 +639,7 @@ GARFragmentLoader<OID_T, VID_T, VERTEX_MAP_T>::initSchema(
 template <typename OID_T, typename VID_T,
           template <typename, typename> class VERTEX_MAP_T>
 boost::leaf::result<std::shared_ptr<arrow::Table>>
-GARFragmentLoader<OID_T, VID_T, VERTEX_MAP_T>::edgesId2Gid(
+GARFragmentLoader<OID_T, VID_T, VERTEX_MAP_T>::parseEdgeIdArrays(
     std::shared_ptr<arrow::Table> adj_list_table, label_id_t src_label,
     label_id_t dst_label, GraphArchive::AdjListType adj_list_type) {
   std::shared_ptr<arrow::Field> src_gid_field = std::make_shared<arrow::Field>(

--- a/modules/graph/tools/fragment_loader_impl.h
+++ b/modules/graph/tools/fragment_loader_impl.h
@@ -41,16 +41,14 @@ namespace vineyard {
 
 namespace detail {
 
-template <typename OID_T, typename VID_T,
-          template <typename, typename> class VERTEX_MAP_T,
-          bool COMPACT = false>
-ObjectID load_graph_impl(Client& client, grape::CommSpec& comm_spec,
-                         struct detail::loader_options const& options) {
-  using loader_t = ArrowFragmentLoader<OID_T, VID_T, VERTEX_MAP_T>;
-  auto loader =
-      loader_t(client, comm_spec, std::vector<std::string>{},
-               std::vector<std::string>{}, options.directed,
-               options.generate_eid, options.retain_oid, options.compact_edges);
+template <typename OID_T, typename VID_T>
+ObjectID load_graph(Client& client, grape::CommSpec& comm_spec,
+                    struct detail::loader_options const& options) {
+  using loader_t = ArrowFragmentLoader<OID_T, VID_T>;
+  auto loader = loader_t(client, comm_spec, std::vector<std::string>{},
+                         std::vector<std::string>{}, options.directed,
+                         options.generate_eid, options.retain_oid,
+                         options.local_vertex_map, options.compact_edges);
 
   MPI_Barrier(comm_spec.comm());
   auto fn = [&]() -> boost::leaf::result<ObjectID> {
@@ -108,19 +106,6 @@ ObjectID load_graph_impl(Client& client, grape::CommSpec& comm_spec,
         });
   } else {
     return loadfn().value();
-  }
-}
-
-template <typename OID_T, typename VID_T,
-          template <typename, typename> class VERTEX_MAP_T>
-ObjectID load_graph(Client& client, grape::CommSpec& comm_spec,
-                    struct detail::loader_options const& options) {
-  if (options.compact_edges) {
-    return load_graph_impl<OID_T, VID_T, VERTEX_MAP_T, true>(client, comm_spec,
-                                                             options);
-  } else {
-    return load_graph_impl<OID_T, VID_T, VERTEX_MAP_T, false>(client, comm_spec,
-                                                              options);
   }
 }
 
@@ -253,16 +238,21 @@ void dump_graph_impl(Client& client, grape::CommSpec& comm_spec,
   }
 }
 
-template <typename OID_T, typename VID_T,
-          template <typename, typename> class VERTEX_MAP_T>
+template <typename OID_T, typename VID_T>
 void dump_graph(Client& client, grape::CommSpec& comm_spec,
                 const ObjectID fragment_group_id,
                 struct detail::loader_options const& options) {
-  if (options.compact_edges) {
-    dump_graph_impl<OID_T, VID_T, VERTEX_MAP_T, true>(
+  if (!options.local_vertex_map && !options.compact_edges) {
+    dump_graph_impl<OID_T, VID_T, ArrowVertexMap, false>(
+        client, comm_spec, fragment_group_id, options);
+  } else if (!options.local_vertex_map && options.compact_edges) {
+    dump_graph_impl<OID_T, VID_T, ArrowVertexMap, true>(
+        client, comm_spec, fragment_group_id, options);
+  } else if (options.local_vertex_map && !options.compact_edges) {
+    dump_graph_impl<OID_T, VID_T, ArrowLocalVertexMap, false>(
         client, comm_spec, fragment_group_id, options);
   } else {
-    dump_graph_impl<OID_T, VID_T, VERTEX_MAP_T, false>(
+    dump_graph_impl<OID_T, VID_T, ArrowLocalVertexMap, true>(
         client, comm_spec, fragment_group_id, options);
   }
 }

--- a/modules/graph/tools/fragment_loader_int32.cc
+++ b/modules/graph/tools/fragment_loader_int32.cc
@@ -34,38 +34,20 @@ namespace vineyard {
 
 namespace detail {
 
-template ObjectID load_graph<int32_t, uint32_t, ArrowVertexMap>(
+template ObjectID load_graph<int32_t, uint32_t>(
     Client& client, grape::CommSpec& comm_spec,
     struct detail::loader_options const& options);
 
-template ObjectID load_graph<int32_t, uint32_t, ArrowLocalVertexMap>(
-    Client& client, grape::CommSpec& comm_spec,
-    struct detail::loader_options const& options);
-
-template void dump_graph<int32_t, uint32_t, ArrowVertexMap>(
+template void dump_graph<int32_t, uint32_t>(
     Client& client, grape::CommSpec& comm_spec,
     const ObjectID fragment_group_id,
     struct detail::loader_options const& options);
 
-template void dump_graph<int32_t, uint32_t, ArrowLocalVertexMap>(
-    Client& client, grape::CommSpec& comm_spec,
-    const ObjectID fragment_group_id,
-    struct detail::loader_options const& options);
-
-template ObjectID load_graph<int32_t, uint64_t, ArrowVertexMap>(
+template ObjectID load_graph<int32_t, uint64_t>(
     Client& client, grape::CommSpec& comm_spec,
     struct detail::loader_options const& options);
 
-template ObjectID load_graph<int32_t, uint64_t, ArrowLocalVertexMap>(
-    Client& client, grape::CommSpec& comm_spec,
-    struct detail::loader_options const& options);
-
-template void dump_graph<int32_t, uint64_t, ArrowVertexMap>(
-    Client& client, grape::CommSpec& comm_spec,
-    const ObjectID fragment_group_id,
-    struct detail::loader_options const& options);
-
-template void dump_graph<int32_t, uint64_t, ArrowLocalVertexMap>(
+template void dump_graph<int32_t, uint64_t>(
     Client& client, grape::CommSpec& comm_spec,
     const ObjectID fragment_group_id,
     struct detail::loader_options const& options);

--- a/modules/graph/tools/fragment_loader_int64.cc
+++ b/modules/graph/tools/fragment_loader_int64.cc
@@ -34,38 +34,20 @@ namespace vineyard {
 
 namespace detail {
 
-template ObjectID load_graph<int64_t, uint32_t, ArrowVertexMap>(
+template ObjectID load_graph<int64_t, uint32_t>(
     Client& client, grape::CommSpec& comm_spec,
     struct detail::loader_options const& options);
 
-template ObjectID load_graph<int64_t, uint32_t, ArrowLocalVertexMap>(
-    Client& client, grape::CommSpec& comm_spec,
-    struct detail::loader_options const& options);
-
-template void dump_graph<int64_t, uint32_t, ArrowVertexMap>(
+template void dump_graph<int64_t, uint32_t>(
     Client& client, grape::CommSpec& comm_spec,
     const ObjectID fragment_group_id,
     struct detail::loader_options const& options);
 
-template void dump_graph<int64_t, uint32_t, ArrowLocalVertexMap>(
-    Client& client, grape::CommSpec& comm_spec,
-    const ObjectID fragment_group_id,
-    struct detail::loader_options const& options);
-
-template ObjectID load_graph<int64_t, uint64_t, ArrowVertexMap>(
+template ObjectID load_graph<int64_t, uint64_t>(
     Client& client, grape::CommSpec& comm_spec,
     struct detail::loader_options const& options);
 
-template ObjectID load_graph<int64_t, uint64_t, ArrowLocalVertexMap>(
-    Client& client, grape::CommSpec& comm_spec,
-    struct detail::loader_options const& options);
-
-template void dump_graph<int64_t, uint64_t, ArrowVertexMap>(
-    Client& client, grape::CommSpec& comm_spec,
-    const ObjectID fragment_group_id,
-    struct detail::loader_options const& options);
-
-template void dump_graph<int64_t, uint64_t, ArrowLocalVertexMap>(
+template void dump_graph<int64_t, uint64_t>(
     Client& client, grape::CommSpec& comm_spec,
     const ObjectID fragment_group_id,
     struct detail::loader_options const& options);

--- a/modules/graph/tools/fragment_loader_string.cc
+++ b/modules/graph/tools/fragment_loader_string.cc
@@ -34,38 +34,20 @@ namespace vineyard {
 
 namespace detail {
 
-template ObjectID load_graph<std::string, uint32_t, ArrowVertexMap>(
+template ObjectID load_graph<std::string, uint32_t>(
     Client& client, grape::CommSpec& comm_spec,
     struct detail::loader_options const& options);
 
-template ObjectID load_graph<std::string, uint32_t, ArrowLocalVertexMap>(
-    Client& client, grape::CommSpec& comm_spec,
-    struct detail::loader_options const& options);
-
-template void dump_graph<std::string, uint32_t, ArrowVertexMap>(
+template void dump_graph<std::string, uint32_t>(
     Client& client, grape::CommSpec& comm_spec,
     const ObjectID fragment_group_id,
     struct detail::loader_options const& options);
 
-template void dump_graph<std::string, uint32_t, ArrowLocalVertexMap>(
-    Client& client, grape::CommSpec& comm_spec,
-    const ObjectID fragment_group_id,
-    struct detail::loader_options const& options);
-
-template ObjectID load_graph<std::string, uint64_t, ArrowVertexMap>(
+template ObjectID load_graph<std::string, uint64_t>(
     Client& client, grape::CommSpec& comm_spec,
     struct detail::loader_options const& options);
 
-template ObjectID load_graph<std::string, uint64_t, ArrowLocalVertexMap>(
-    Client& client, grape::CommSpec& comm_spec,
-    struct detail::loader_options const& options);
-
-template void dump_graph<std::string, uint64_t, ArrowVertexMap>(
-    Client& client, grape::CommSpec& comm_spec,
-    const ObjectID fragment_group_id,
-    struct detail::loader_options const& options);
-
-template void dump_graph<std::string, uint64_t, ArrowLocalVertexMap>(
+template void dump_graph<std::string, uint64_t>(
     Client& client, grape::CommSpec& comm_spec,
     const ObjectID fragment_group_id,
     struct detail::loader_options const& options);

--- a/modules/graph/tools/graph_loader.cc
+++ b/modules/graph/tools/graph_loader.cc
@@ -322,65 +322,27 @@ static void loading_vineyard_graph(
 
   MPI_Barrier(comm_spec.comm());
   vineyard::ObjectID fragment_group_id = InvalidObjectID();
-  if (options.local_vertex_map) {
-    if (options.large_vid) {
-      if (options.oid_type == "string") {
-        fragment_group_id =
-            detail::load_graph<std::string, uint64_t, ArrowLocalVertexMap>(
-                client, comm_spec, options);
-      } else if (options.oid_type == "int32") {
-        fragment_group_id =
-            detail::load_graph<int32_t, uint64_t, ArrowLocalVertexMap>(
-                client, comm_spec, options);
-      } else {
-        fragment_group_id =
-            detail::load_graph<int64_t, uint64_t, ArrowLocalVertexMap>(
-                client, comm_spec, options);
-      }
+  if (options.large_vid) {
+    if (options.oid_type == "string") {
+      fragment_group_id =
+          detail::load_graph<std::string, uint64_t>(client, comm_spec, options);
+    } else if (options.oid_type == "int32") {
+      fragment_group_id =
+          detail::load_graph<int32_t, uint64_t>(client, comm_spec, options);
     } else {
-      if (options.oid_type == "string") {
-        fragment_group_id =
-            detail::load_graph<std::string, uint32_t, ArrowLocalVertexMap>(
-                client, comm_spec, options);
-      } else if (options.oid_type == "int32") {
-        fragment_group_id =
-            detail::load_graph<int32_t, uint32_t, ArrowLocalVertexMap>(
-                client, comm_spec, options);
-      } else {
-        fragment_group_id =
-            detail::load_graph<int64_t, uint32_t, ArrowLocalVertexMap>(
-                client, comm_spec, options);
-      }
+      fragment_group_id =
+          detail::load_graph<int64_t, uint64_t>(client, comm_spec, options);
     }
   } else {
-    if (options.large_vid) {
-      if (options.oid_type == "string") {
-        fragment_group_id =
-            detail::load_graph<std::string, uint64_t, ArrowVertexMap>(
-                client, comm_spec, options);
-      } else if (options.oid_type == "int32") {
-        fragment_group_id =
-            detail::load_graph<int32_t, uint64_t, ArrowVertexMap>(
-                client, comm_spec, options);
-      } else {
-        fragment_group_id =
-            detail::load_graph<int64_t, uint64_t, ArrowVertexMap>(
-                client, comm_spec, options);
-      }
+    if (options.oid_type == "string") {
+      fragment_group_id =
+          detail::load_graph<std::string, uint32_t>(client, comm_spec, options);
+    } else if (options.oid_type == "int32") {
+      fragment_group_id =
+          detail::load_graph<int32_t, uint32_t>(client, comm_spec, options);
     } else {
-      if (options.oid_type == "string") {
-        fragment_group_id =
-            detail::load_graph<std::string, uint32_t, ArrowVertexMap>(
-                client, comm_spec, options);
-      } else if (options.oid_type == "int32") {
-        fragment_group_id =
-            detail::load_graph<int32_t, uint32_t, ArrowVertexMap>(
-                client, comm_spec, options);
-      } else {
-        fragment_group_id =
-            detail::load_graph<int64_t, uint32_t, ArrowVertexMap>(
-                client, comm_spec, options);
-      }
+      fragment_group_id =
+          detail::load_graph<int64_t, uint32_t>(client, comm_spec, options);
     }
   }
 
@@ -392,54 +354,27 @@ static void loading_vineyard_graph(
                                    options.print_memory_usage);
 
   if (!options.dump.empty() || (options.dump_dry_run_rounds > 0)) {
-    if (options.local_vertex_map) {
-      if (options.large_vid) {
-        if (options.oid_type == "string") {
-          detail::dump_graph<std::string, uint64_t, ArrowLocalVertexMap>(
-              client, comm_spec, fragment_group_id, options);
-        } else if (options.oid_type == "int32") {
-          detail::dump_graph<int32_t, uint64_t, ArrowLocalVertexMap>(
-              client, comm_spec, fragment_group_id, options);
-        } else {
-          detail::dump_graph<int64_t, uint64_t, ArrowLocalVertexMap>(
-              client, comm_spec, fragment_group_id, options);
-        }
+    if (options.large_vid) {
+      if (options.oid_type == "string") {
+        detail::dump_graph<std::string, uint64_t>(client, comm_spec,
+                                                  fragment_group_id, options);
+      } else if (options.oid_type == "int32") {
+        detail::dump_graph<int32_t, uint64_t>(client, comm_spec,
+                                              fragment_group_id, options);
       } else {
-        if (options.oid_type == "string") {
-          detail::dump_graph<std::string, uint32_t, ArrowLocalVertexMap>(
-              client, comm_spec, fragment_group_id, options);
-        } else if (options.oid_type == "int32") {
-          detail::dump_graph<int32_t, uint32_t, ArrowLocalVertexMap>(
-              client, comm_spec, fragment_group_id, options);
-        } else {
-          detail::dump_graph<int64_t, uint32_t, ArrowLocalVertexMap>(
-              client, comm_spec, fragment_group_id, options);
-        }
+        detail::dump_graph<int64_t, uint64_t>(client, comm_spec,
+                                              fragment_group_id, options);
       }
-
     } else {
-      if (options.large_vid) {
-        if (options.oid_type == "string") {
-          detail::dump_graph<std::string, uint64_t, ArrowVertexMap>(
-              client, comm_spec, fragment_group_id, options);
-        } else if (options.oid_type == "int32") {
-          detail::dump_graph<int32_t, uint64_t, ArrowVertexMap>(
-              client, comm_spec, fragment_group_id, options);
-        } else {
-          detail::dump_graph<int64_t, uint64_t, ArrowVertexMap>(
-              client, comm_spec, fragment_group_id, options);
-        }
+      if (options.oid_type == "string") {
+        detail::dump_graph<std::string, uint32_t>(client, comm_spec,
+                                                  fragment_group_id, options);
+      } else if (options.oid_type == "int32") {
+        detail::dump_graph<int32_t, uint32_t>(client, comm_spec,
+                                              fragment_group_id, options);
       } else {
-        if (options.oid_type == "string") {
-          detail::dump_graph<std::string, uint32_t, ArrowVertexMap>(
-              client, comm_spec, fragment_group_id, options);
-        } else if (options.oid_type == "int32") {
-          detail::dump_graph<int32_t, uint32_t, ArrowVertexMap>(
-              client, comm_spec, fragment_group_id, options);
-        } else {
-          detail::dump_graph<int64_t, uint32_t, ArrowVertexMap>(
-              client, comm_spec, fragment_group_id, options);
-        }
+        detail::dump_graph<int64_t, uint32_t>(client, comm_spec,
+                                              fragment_group_id, options);
       }
     }
   }

--- a/modules/graph/tools/graph_loader.h
+++ b/modules/graph/tools/graph_loader.h
@@ -62,13 +62,11 @@ struct loader_options {
   bool print_normalized_schema = false;
 };
 
-template <typename OID_T, typename VID_T,
-          template <typename, typename> class VERTEX_MAP_T>
+template <typename OID_T, typename VID_T>
 ObjectID load_graph(Client& client, grape::CommSpec& comm_spec,
                     struct detail::loader_options const& options);
 
-template <typename OID_T, typename VID_T,
-          template <typename, typename> class VERTEX_MAP_T>
+template <typename OID_T, typename VID_T>
 void dump_graph(Client& client, grape::CommSpec& comm_spec,
                 const ObjectID fragment_group_id,
                 struct detail::loader_options const& options);


### PR DESCRIPTION
What do these changes do?
-------------------------

- Optimizes the build time of fragment loader
- Use a standalone method for varint encoding to make it easy to reuse
- Add missing checks/todos to prevent misuse
- Reuse the offset array for both varint/plain CSR

Related issue number
--------------------

N/A

