### PR TITLE
Replace the limits with the objectIDs in the backup and recover of vineyard cluster.

### DIFF
--- a/charts/vineyard-operator/templates/backup-crd.yaml
+++ b/charts/vineyard-operator/templates/backup-crd.yaml
@@ -46,7 +46,9 @@ spec:
               backupPath:
                 type: string
               objecIDs:
-                type: string
+                items:
+                  type: string
+                type: array
               persistentVolumeClaimSpec:
                 properties:
                   accessModes:

--- a/charts/vineyard-operator/templates/backup-crd.yaml
+++ b/charts/vineyard-operator/templates/backup-crd.yaml
@@ -45,8 +45,8 @@ spec:
             properties:
               backupPath:
                 type: string
-              limit:
-                type: integer
+              objecIDs:
+                type: string
               persistentVolumeClaimSpec:
                 properties:
                   accessModes:

--- a/docs/notes/cloud-native/vineyard-operator.rst
+++ b/docs/notes/cloud-native/vineyard-operator.rst
@@ -1741,9 +1741,10 @@ the vineyard operator. The main fields are described as follows.
          - The namespace of vineyardd cluster.
          - nil
 
-       * - limit
-         - int
-         - The number of objects to be backed up
+       * - objectIDs
+         - string
+         - The object IDs that need to be backed up, separated by commas.
+           If it is empty, all objects will be backed up.
          - nil
 
        * - backupPath
@@ -1806,7 +1807,6 @@ up the data. The following is the yaml file of the backup:
   spec:
     vineyarddName: vineyardd-sample
     vineyarddNamespace: vineyard-system
-    limit: 1000
     backupPath: /var/vineyard/dump
     persistentVolumeSpec:
       storageClassName: manual

--- a/docs/notes/cloud-native/vineyard-operator.rst
+++ b/docs/notes/cloud-native/vineyard-operator.rst
@@ -1742,8 +1742,8 @@ the vineyard operator. The main fields are described as follows.
          - nil
 
        * - objectIDs
-         - string
-         - The object IDs that need to be backed up, separated by commas.
+         - []string
+         - The object IDs that need to be backed up.
            If it is empty, all objects will be backed up.
          - nil
 

--- a/k8s/apis/k8s/v1alpha1/backup_types.go
+++ b/k8s/apis/k8s/v1alpha1/backup_types.go
@@ -31,9 +31,10 @@ type BackupSpec struct {
 	// +kubebuilder:validation:Required
 	VineyarddNamespace string `json:"vineyarddNamespace,omitempty"`
 
-	// the number of objects to be backed up
+	// the specific objects to be backed up, separated by comma
+	// if not specified, all objects will be backed up
 	// +kubebuilder:validation:Required
-	Limit int `json:"limit,omitempty"`
+	ObjectIDs string `json:"objecIDs,omitempty"`
 
 	// the path of backup data
 	// +kubebuilder:validation:Required

--- a/k8s/apis/k8s/v1alpha1/backup_types.go
+++ b/k8s/apis/k8s/v1alpha1/backup_types.go
@@ -31,10 +31,10 @@ type BackupSpec struct {
 	// +kubebuilder:validation:Required
 	VineyarddNamespace string `json:"vineyarddNamespace,omitempty"`
 
-	// the specific objects to be backed up, separated by comma
+	// the specific objects to be backed up
 	// if not specified, all objects will be backed up
 	// +kubebuilder:validation:Required
-	ObjectIDs string `json:"objecIDs,omitempty"`
+	ObjectIDs []string `json:"objecIDs,omitempty"`
 
 	// the path of backup data
 	// +kubebuilder:validation:Required

--- a/k8s/cmd/README.md
+++ b/k8s/cmd/README.md
@@ -165,7 +165,7 @@ vineyardctl create backup [flags]
 ```
       --backup-name string           the name of backup job (default "vineyard-backup")
   -h, --help                         help for backup
-      --objectIDs string             the specific objects to be backed up, separated by comma
+      --objectIDs strings            the specific objects to be backed up
       --path string                  the path of the backup data
       --pv-pvc-spec string           the PersistentVolume and PersistentVolumeClaim of the backup data
       --vineyardd-name string        the name of vineyardd
@@ -667,6 +667,17 @@ vineyardctl deploy backup-job [flags]
     --vineyard-deployment-namespace vineyard-system  \
     --path /var/vineyard/dump  \
     --pvc-name pvc-sample
+  
+  # The namespace to deploy the backup and recover job must be the same
+  # as the vineyard cluster namespace.
+  # Assume the vineyard cluster is deployed in the namespace "test", you
+  # could deploy the backup job as follows
+  vineyardctl deploy backup-job \
+    --vineyard-deployment-name vineyardd-sample \
+    --vineyard-deployment-namespace test  \
+    --namespace test  \
+    --path /var/vineyard/dump  \
+    --pvc-name pvc-sample
 ```
 
 ### Options
@@ -674,7 +685,7 @@ vineyardctl deploy backup-job [flags]
 ```
       --backup-name string                     the name of backup job (default "vineyard-backup")
   -h, --help                                   help for backup-job
-      --objectIDs string                       the specific objects to be backed up, separated by comma
+      --objectIDs strings                      the specific objects to be backed up
       --path string                            the path of the backup data
       --pv-pvc-spec string                     the PersistentVolume and PersistentVolumeClaim of the backup data
       --pvc-name string                        the name of an existing PersistentVolumeClaim

--- a/k8s/cmd/README.md
+++ b/k8s/cmd/README.md
@@ -165,7 +165,7 @@ vineyardctl create backup [flags]
 ```
       --backup-name string           the name of backup job (default "vineyard-backup")
   -h, --help                         help for backup
-      --limit int                    the limit of objects to backup (default 1000)
+      --objectIDs string             the specific objects to be backed up, separated by comma
       --path string                  the path of the backup data
       --pv-pvc-spec string           the PersistentVolume and PersistentVolumeClaim of the backup data
       --vineyardd-name string        the name of vineyardd
@@ -594,12 +594,12 @@ vineyardctl deploy backup-job [flags]
 ### Examples
 
 ```shell
-  # deploy a backup job for the vineyard cluster on kubernetes
-  # you could define the pv and pvc spec from json string as follows
+  # deploy a backup job for all vineyard objects of the vineyard
+  # cluster on kubernetes and you could define the pv and pvc
+  # spec from json string as follows
   vineyardctl deploy backup-job \
     --vineyard-deployment-name vineyardd-sample \
     --vineyard-deployment-namespace vineyard-system  \
-    --limit 1000 \
     --path /var/vineyard/dump  \
     --pv-pvc-spec '{
       "pv-spec": {
@@ -632,7 +632,7 @@ vineyardctl deploy backup-job [flags]
   vineyardctl deploy backup-job \
     --vineyard-deployment-name vineyardd-sample \
     --vineyard-deployment-namespace vineyard-system  \
-    --limit 1000 --path /var/vineyard/dump  \
+    --path /var/vineyard/dump  \
     --pv-pvc-spec  \
     '
     pv-spec:
@@ -652,21 +652,20 @@ vineyardctl deploy backup-job [flags]
       storage: 1Gi
     '
 
-  # deploy a backup job for the vineyard cluster on kubernetes
-  # you could define the pv and pvc spec from json file as follows
-  # also you could use yaml file instead of json file
+  # deploy a backup job for specific vineyard objects of the vineyard
+  # cluster on kubernetes.
   cat pv-pvc.json | vineyardctl deploy backup-job \
     --vineyard-deployment-name vineyardd-sample \
     --vineyard-deployment-namespace vineyard-system  \
-    --limit 1000 --path /var/vineyard/dump  \
-    -
+    --objectIDs "o000018d29207fd01,o000018d80d264010"  \
+    --path /var/vineyard/dump
     
   # Assume you have already deployed a pvc named "pvc-sample", you
   # could use them as the backend storage for the backup job as follows
   vineyardctl deploy backup-job \
     --vineyard-deployment-name vineyardd-sample \
     --vineyard-deployment-namespace vineyard-system  \
-    --limit 1000 --path /var/vineyard/dump  \
+    --path /var/vineyard/dump  \
     --pvc-name pvc-sample
 ```
 
@@ -675,7 +674,7 @@ vineyardctl deploy backup-job [flags]
 ```
       --backup-name string                     the name of backup job (default "vineyard-backup")
   -h, --help                                   help for backup-job
-      --limit int                              the limit of objects to backup (default 1000)
+      --objectIDs string                       the specific objects to be backed up, separated by comma
       --path string                            the path of the backup data
       --pv-pvc-spec string                     the PersistentVolume and PersistentVolumeClaim of the backup data
       --pvc-name string                        the name of an existing PersistentVolumeClaim

--- a/k8s/cmd/commands/deploy/deploy_backup_job.go
+++ b/k8s/cmd/commands/deploy/deploy_backup_job.go
@@ -114,7 +114,17 @@ var (
 		--vineyard-deployment-namespace vineyard-system  \
 		--path /var/vineyard/dump  \
 		--pvc-name pvc-sample
-	`)
+	
+	# The namespace to deploy the backup and recover job must be the same
+	# as the vineyard cluster namespace.
+	# Assume the vineyard cluster is deployed in the namespace "test", you
+	# could deploy the backup job as follows
+	vineyardctl deploy backup-job \
+		--vineyard-deployment-name vineyardd-sample \
+		--vineyard-deployment-namespace test  \
+		--namespace test  \
+		--path /var/vineyard/dump  \
+		--pvc-name pvc-sample`)
 )
 
 // deployBackupJobCmd deploy the backup job of vineyard cluster on kubernetes

--- a/k8s/cmd/commands/deploy/deploy_backup_job.go
+++ b/k8s/cmd/commands/deploy/deploy_backup_job.go
@@ -41,12 +41,12 @@ var (
 	Also, you could also specify the existing pv and pvc name to use`)
 
 	deployBackupJobExample = util.Examples(`
-	# deploy a backup job for the vineyard cluster on kubernetes
-	# you could define the pv and pvc spec from json string as follows
+	# deploy a backup job for all vineyard objects of the vineyard 
+	# cluster on kubernetes and you could define the pv and pvc 
+	# spec from json string as follows
 	vineyardctl deploy backup-job \
 		--vineyard-deployment-name vineyardd-sample \
 		--vineyard-deployment-namespace vineyard-system  \
-		--limit 1000 \
 		--path /var/vineyard/dump  \
 		--pv-pvc-spec '{
 			"pv-spec": {
@@ -79,7 +79,7 @@ var (
 	vineyardctl deploy backup-job \
 		--vineyard-deployment-name vineyardd-sample \
 		--vineyard-deployment-namespace vineyard-system  \
-		--limit 1000 --path /var/vineyard/dump  \
+		--path /var/vineyard/dump  \
 		--pv-pvc-spec  \
 		'
 		pv-spec:
@@ -99,21 +99,20 @@ var (
 			storage: 1Gi
 		'
 
-	# deploy a backup job for the vineyard cluster on kubernetes
-	# you could define the pv and pvc spec from json file as follows
-	# also you could use yaml file instead of json file
+	# deploy a backup job for specific vineyard objects of the vineyard 
+	# cluster on kubernetes.
 	cat pv-pvc.json | vineyardctl deploy backup-job \
 		--vineyard-deployment-name vineyardd-sample \
 		--vineyard-deployment-namespace vineyard-system  \
-		--limit 1000 --path /var/vineyard/dump  \
-		-
+		--objectIDs "o000018d29207fd01,o000018d80d264010"  \
+		--path /var/vineyard/dump
 		
 	# Assume you have already deployed a pvc named "pvc-sample", you 
 	# could use them as the backend storage for the backup job as follows
 	vineyardctl deploy backup-job \
 		--vineyard-deployment-name vineyardd-sample \
 		--vineyard-deployment-namespace vineyard-system  \
-		--limit 1000 --path /var/vineyard/dump  \
+		--path /var/vineyard/dump  \
 		--pvc-name pvc-sample
 	`)
 )

--- a/k8s/cmd/commands/flags/backup_flags.go
+++ b/k8s/cmd/commands/flags/backup_flags.go
@@ -50,8 +50,8 @@ func ApplyBackupNameOpts(cmd *cobra.Command) {
 
 func ApplyBackupCommonOpts(cmd *cobra.Command) {
 	cmd.Flags().
-		IntVarP(&BackupOpts.Limit, "limit", "", 1000,
-			"the limit of objects to backup")
+		StringVarP(&BackupOpts.ObjectIDs, "objectIDs", "", "",
+			"the specific objects to be backed up, separated by comma")
 	cmd.Flags().
 		StringVarP(&BackupOpts.BackupPath, "path", "", "",
 			"the path of the backup data")

--- a/k8s/cmd/commands/flags/backup_flags.go
+++ b/k8s/cmd/commands/flags/backup_flags.go
@@ -50,8 +50,8 @@ func ApplyBackupNameOpts(cmd *cobra.Command) {
 
 func ApplyBackupCommonOpts(cmd *cobra.Command) {
 	cmd.Flags().
-		StringVarP(&BackupOpts.ObjectIDs, "objectIDs", "", "",
-			"the specific objects to be backed up, separated by comma")
+		StringSliceVarP(&BackupOpts.ObjectIDs, "objectIDs", "", []string{},
+			"the specific objects to be backed up")
 	cmd.Flags().
 		StringVarP(&BackupOpts.BackupPath, "path", "", "",
 			"the path of the backup data")

--- a/k8s/config/crd/bases/k8s.v6d.io_backups.yaml
+++ b/k8s/config/crd/bases/k8s.v6d.io_backups.yaml
@@ -33,8 +33,8 @@ spec:
             properties:
               backupPath:
                 type: string
-              limit:
-                type: integer
+              objecIDs:
+                type: string
               persistentVolumeClaimSpec:
                 properties:
                   accessModes:

--- a/k8s/config/crd/bases/k8s.v6d.io_backups.yaml
+++ b/k8s/config/crd/bases/k8s.v6d.io_backups.yaml
@@ -34,7 +34,9 @@ spec:
               backupPath:
                 type: string
               objecIDs:
-                type: string
+                items:
+                  type: string
+                type: array
               persistentVolumeClaimSpec:
                 properties:
                   accessModes:

--- a/k8s/controllers/k8s/backup_controller.go
+++ b/k8s/controllers/k8s/backup_controller.go
@@ -54,8 +54,8 @@ type FailoverConfig struct {
 
 // BackupConfig holds all configuration about backup
 type BackupConfig struct {
-	Name  string
-	Limit string
+	Name      string
+	ObjectIDs string
 	FailoverConfig
 }
 
@@ -246,7 +246,7 @@ func BuildBackupCfg(c client.Client, name string, backup *k8sv1alpha1.Backup,
 	path string, withScheduler bool) (BackupConfig, error) {
 	backupCfg := BackupConfig{}
 	backupCfg.Name = name
-	backupCfg.Limit = strconv.Itoa(backup.Spec.Limit)
+	backupCfg.ObjectIDs = backup.Spec.ObjectIDs
 	failoverCfg, err := newFailoverConfig(c, backup, path, withScheduler)
 	if err != nil {
 		return backupCfg, errors.Wrap(err, "unable to build failover config")

--- a/k8s/controllers/k8s/backup_controller.go
+++ b/k8s/controllers/k8s/backup_controller.go
@@ -19,6 +19,7 @@ package k8s
 import (
 	"context"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -246,7 +247,8 @@ func BuildBackupCfg(c client.Client, name string, backup *k8sv1alpha1.Backup,
 	path string, withScheduler bool) (BackupConfig, error) {
 	backupCfg := BackupConfig{}
 	backupCfg.Name = name
-	backupCfg.ObjectIDs = backup.Spec.ObjectIDs
+	backupCfg.ObjectIDs = strings.Join(backup.Spec.ObjectIDs, ",")
+
 	failoverCfg, err := newFailoverConfig(c, backup, path, withScheduler)
 	if err != nil {
 		return backupCfg, errors.Wrap(err, "unable to build failover config")

--- a/k8s/pkg/templates/backup/job.yaml
+++ b/k8s/pkg/templates/backup/job.yaml
@@ -41,8 +41,10 @@ spec:
         image: ghcr.io/v6d-io/v6d/backup-job
         imagePullPolicy: IfNotPresent
         env:
-        - name: LIMIT
-          value: "{{ $backupConfig.Limit }}"
+        {{- if $backupConfig.ObjectIDs }}
+        - name: ObjectIDs
+          value: "{{ $backupConfig.ObjectIDs }}"
+        {{- end }}
         - name: BACKUP_PATH
           value: {{ $failoverConfig.Path }}
         - name: ENDPOINT

--- a/k8s/test/e2e/deploy-raw-backup-and-recover/e2e.yaml
+++ b/k8s/test/e2e/deploy-raw-backup-and-recover/e2e.yaml
@@ -74,11 +74,10 @@ setup:
           for: condition=Available
     - name: install backup
       command: |
-        --objectIDs "$localobjectid,$distributedobjectid"
         go run k8s/cmd/main.go deploy backup-job \
           --vineyard-deployment-name vineyardd-sample \
           --vineyard-deployment-namespace vineyard-system  \
-          --objectIDs "o334398ae3434,o334398ae3434332" \
+          --objectIDs "$localobjectid,$distributedobjectid" \
           --path /var/vineyard/dump  \
           --pv-pvc-spec '{
           "pv-spec": {

--- a/k8s/test/e2e/deploy-raw-backup-and-recover/e2e.yaml
+++ b/k8s/test/e2e/deploy-raw-backup-and-recover/e2e.yaml
@@ -74,10 +74,11 @@ setup:
           for: condition=Available
     - name: install backup
       command: |
+        --objectIDs "$localobjectid,$distributedobjectid"
         go run k8s/cmd/main.go deploy backup-job \
           --vineyard-deployment-name vineyardd-sample \
           --vineyard-deployment-namespace vineyard-system  \
-          --limit 1000 \
+          --objectIDs "o334398ae3434,o334398ae3434332" \
           --path /var/vineyard/dump  \
           --pv-pvc-spec '{
           "pv-spec": {

--- a/k8s/test/e2e/failover-demo/backup.py
+++ b/k8s/test/e2e/failover-demo/backup.py
@@ -25,7 +25,7 @@ from kubernetes.client.rest import ApiException
 env_dist = os.environ
 
 objectids = None
-if "ObjectIDs" not in env_dist:
+if "ObjectIDs" in env_dist:
     objectids = env_dist["ObjectIDs"]
 path = env_dist['BACKUP_PATH']
 socket = '/var/run/vineyard.sock'
@@ -65,11 +65,11 @@ objIDs = []
 if objectids is not None:
     objs = objectids.split(',')
     for _,o in enumerate(objs):
-        objIDs = objIDs.append(vineyard.ObjectID(o))
+        objIDs.append(vineyard.ObjectID(o))
 else:
     objs = vineyard_client.list_objects(pattern='*')
     for _,o in enumerate(objs):
-        objIDs = objIDs.append(o.id)
+        objIDs.append(o.id)
 
 
 # serialize all persistent objects

--- a/k8s/test/e2e/failover-demo/backup.py
+++ b/k8s/test/e2e/failover-demo/backup.py
@@ -24,7 +24,9 @@ from kubernetes.client.rest import ApiException
 
 env_dist = os.environ
 
-limits = int(env_dist['LIMIT'])
+objectids = None
+if "ObjectIDs" not in env_dist:
+    objectids = env_dist["ObjectIDs"]
 path = env_dist['BACKUP_PATH']
 socket = '/var/run/vineyard.sock'
 endpoint = env_dist['ENDPOINT']
@@ -59,9 +61,14 @@ while True:
 # get instance id
 instance = vineyard_client.instance_id
 
-objs = vineyard_client.list_objects(pattern='*',limit=limits)
+objs = []
+if objectids is not None:
+    objs = objectids.split(',')
+else:
+    objs = vineyard_client.list_objects(pattern='*')
+
 # serialize all persistent objects
-for i,o in enumerate(objs):
+for _,o in enumerate(objs):
     try:
         meta = vineyard_client.get_meta(o.id, sync_remote=True)
         if not meta['transient'] and meta['typename'] not in ['vineyard::ParallelStream','vineyard::StreamCollection']:

--- a/k8s/test/e2e/failover-demo/backup.yaml
+++ b/k8s/test/e2e/failover-demo/backup.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   vineyarddName: vineyardd-sample
   vineyarddNamespace: vineyard-system
-  limit: 1000
   backupPath: /var/vineyard/dump
   persistentVolumeSpec:
     storageClassName: manual

--- a/k8s/test/e2e/failover/e2e.yaml
+++ b/k8s/test/e2e/failover/e2e.yaml
@@ -65,12 +65,14 @@ setup:
         - namespace: vineyard-job
           resource: deployment/build-distributed-object-step2
           for: condition=Available
-    - name: install backup
+    - name: install backup with the specific objects
       command: |
+        echo "localobjectid: $localobjectid"
+        echo "distributedobjectid: $distributedobjectid"
         go run k8s/cmd/main.go create backup \
           --vineyardd-name vineyardd-sample \
           --vineyardd-namespace vineyard-system  \
-          --limit 1000 \
+          --objectIDs $localobjectid,$distributedobjectid \
           --path /var/vineyard/dump  \
           --pv-pvc-spec '{
           "pv-spec": {

--- a/k8s/test/e2e/failover/e2e.yaml
+++ b/k8s/test/e2e/failover/e2e.yaml
@@ -67,8 +67,6 @@ setup:
           for: condition=Available
     - name: install backup with the specific objects
       command: |
-        echo "localobjectid: $localobjectid"
-        echo "distributedobjectid: $distributedobjectid"
         go run k8s/cmd/main.go create backup \
           --vineyardd-name vineyardd-sample \
           --vineyardd-namespace vineyard-system  \


### PR DESCRIPTION


<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

As titled. The `objectIDs` is more meaningful for users.


Related issue number
--------------------

Fixes #1322 

