### PR TITLE
Improve GetInnerVertex() by querying local fragment only

### DIFF
--- a/modules/graph/fragment/arrow_fragment.vineyard-mod
+++ b/modules/graph/fragment/arrow_fragment.vineyard-mod
@@ -355,11 +355,9 @@ class [[vineyard]] ArrowFragment
 
   bool GetInnerVertex(label_id_t label, const oid_t& oid, vertex_t& v) const {
     vid_t gid;
-    if (vm_ptr_->GetGid(label, internal_oid_t(oid), gid)) {
-      if (vid_parser_.GetFid(gid) == fid_) {
-        v.SetValue(vid_parser_.GetLid(gid));
-        return true;
-      }
+    if (vm_ptr_->GetGid(fid_, label, internal_oid_t(oid), gid)) {
+      v.SetValue(vid_parser_.GetLid(gid));
+      return true;
     }
     return false;
   }


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

<!-- Please give a short brief about these changes. -->
The current implementation of GetInnerVertex() is to query all the fragment, it's not needed as we only need the inner vertex

