### PR TITLE
Fix a bug to avoid the panic 'interger divide by zero' during scheduling

### DIFF
--- a/k8s/pkg/schedulers/scheduler_inside_cluster.go
+++ b/k8s/pkg/schedulers/scheduler_inside_cluster.go
@@ -143,7 +143,10 @@ func (vs *VineyardSchedulerInsideCluster) Schedule(nodeName string) (int, error)
 	roundRobin := NewRoundRobinStrategy(vs.config.Nodes)
 
 	if len(vs.config.Required) == 0 {
-		target, _ := roundRobin.Compute(vs.rank)
+		target, err := roundRobin.Compute(vs.rank)
+		if err != nil {
+			return 1, err
+		}
 		if target == nodeName {
 			return 100, nil
 		}

--- a/k8s/pkg/schedulers/scheduler_outside_cluster.go
+++ b/k8s/pkg/schedulers/scheduler_outside_cluster.go
@@ -85,7 +85,10 @@ func (vs *VineyardSchedulerOutsideCluster) Schedule(replica int) (string, error)
 
 	if len(vs.config.Required) == 0 {
 		for i := 0; i < replica; i++ {
-			node, _ := roundRobin.Compute(i)
+			node, err := roundRobin.Compute(i)
+			if err != nil {
+				return "", err
+			}
 			jobToNode[node]++
 		}
 		return vs.buildSchedulerOrder(jobToNode), nil

--- a/k8s/pkg/schedulers/scheduling_strategy.go
+++ b/k8s/pkg/schedulers/scheduling_strategy.go
@@ -55,7 +55,7 @@ func NewRoundRobinStrategy(nodes []string) *RoundRobinStrategy {
 func (r *RoundRobinStrategy) Compute(rank int) (string, error) {
 	l := len(r.nodes)
 	if l == 0 {
-		return "", nil
+		return "", errors.Errorf("No nodes found")
 	}
 	return r.nodes[rank%l], nil
 }

--- a/k8s/pkg/schedulers/scheduling_strategy.go
+++ b/k8s/pkg/schedulers/scheduling_strategy.go
@@ -54,6 +54,9 @@ func NewRoundRobinStrategy(nodes []string) *RoundRobinStrategy {
 // Compute returns the node by the given rank.
 func (r *RoundRobinStrategy) Compute(rank int) (string, error) {
 	l := len(r.nodes)
+	if l == 0 {
+		return "", nil
+	}
 	return r.nodes[rank%l], nil
 }
 


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

As titled.


Related issue number
--------------------

Fixes some errors during e2e test such as https://github.com/v6d-io/v6d/actions/runs/5118226798/jobs/9202046172

