### PR TITLE
Fix ConcatenateTables()

### DIFF
--- a/modules/basic/ds/arrow_utils.cc
+++ b/modules/basic/ds/arrow_utils.cc
@@ -556,6 +556,7 @@ Status ConcatenateTables(
     return Status::OK();
   }
   std::vector<std::shared_ptr<arrow::Table>> out_tables(tables.size());
+  out_tables[0] = tables[0];
   auto col_names = tables[0]->ColumnNames();
   for (size_t i = 1; i < tables.size(); ++i) {
     RETURN_ON_ARROW_ERROR_AND_ASSIGN(out_tables[i],


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

<!-- Please give a short brief about these changes. -->
When calling ConcatenateTables(), the process will core as the out_tables[0] is not initialized.



