### PR TITLE
Fix bug: Inaccurate error message

### DIFF
--- a/modules/io/io/io_factory.cc
+++ b/modules/io/io/io_factory.cc
@@ -95,7 +95,8 @@ std::unique_ptr<IIOAdaptor> IOFactory::CreateIOAdaptor(
         sub_str.erase(index, sub_str.length() - index);
         res = realpath(sub_str.c_str(), resolved_path);
       }
-      strcpy(resolved_path + strlen(resolved_path), tail.c_str());
+      strncpy(resolved_path + strlen(resolved_path), tail.c_str(),
+              tail.length());
       // Note we should not encode the leading '/' if there is one,
       // cause arrow::internal::Uri requires the path must be an absolute path.
       location_to_parse = std::string(resolved_path);

--- a/modules/io/io/io_factory.cc
+++ b/modules/io/io/io_factory.cc
@@ -82,7 +82,7 @@ std::unique_ptr<IIOAdaptor> IOFactory::CreateIOAdaptor(
       // defaulting to local file system: resolve to abs path first
       char resolved_path[PATH_MAX] = {0};
       int index = location_to_parse.length();
-      std::string sub_str = location_to_parse.c_str();
+      std::string sub_str = location_to_parse;
       std::string tail;
       char* res = realpath(sub_str.c_str(), resolved_path);
       while (!res) {


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

When the path does not exist, concatenate the missing path information after the absolute path.
<!-- Please give a short brief about these changes. -->


Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes [#2863](https://github.com/alibaba/GraphScope/issues/2863) (GraphScope)

