### PR TITLE
Fix the sidecar can't work as expected and replace the kind version with v0.19.0

### DIFF
--- a/k8s/controllers/k8s/sidecar_controller.go
+++ b/k8s/controllers/k8s/sidecar_controller.go
@@ -77,11 +77,11 @@ func (r *SidecarReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			etcdCfg.Rank = rank
 			return etcdCfg
 		}
-		if _, err := sidecarApp.Apply(ctx, "etcd/etcd.yaml", logger, false); err != nil {
+		if _, err := sidecarApp.Apply(ctx, "etcd/etcd.yaml", logger, true); err != nil {
 			logger.Error(err, "failed to apply etcd pod")
 			return ctrl.Result{}, err
 		}
-		if _, err := sidecarApp.Apply(ctx, "etcd/service.yaml", logger, false); err != nil {
+		if _, err := sidecarApp.Apply(ctx, "etcd/service.yaml", logger, true); err != nil {
 			logger.Error(err, "failed to apply etcd service")
 			return ctrl.Result{}, err
 		}

--- a/k8s/pkg/schedulers/common.go
+++ b/k8s/pkg/schedulers/common.go
@@ -69,6 +69,9 @@ func GetRequiredJob(anno map[string]string) []string {
 	if !exists {
 		return []string{}
 	}
+	if requiredJobs == "" {
+		return []string{}
+	}
 
 	return strings.Split(requiredJobs, ",")
 }

--- a/k8s/test/e2e/sidecar-demo/sidecar-with-default-sidecar.yaml
+++ b/k8s/test/e2e/sidecar-demo/sidecar-with-default-sidecar.yaml
@@ -28,6 +28,7 @@ spec:
       annotations:
         sidecar.v6d.io/name: "default"
       labels:
+        app.kubernetes.io/instance: job-deployment-with-default-sidecar
         app: job-deployment-with-default-sidecar
         sidecar.v6d.io/enabled: "true"
     spec:

--- a/k8s/test/e2e/sidecar/e2e.yaml
+++ b/k8s/test/e2e/sidecar/e2e.yaml
@@ -21,13 +21,23 @@ setup:
     - name: download all sidecar images into kind cluster
       command: |
         make -C k8s/test/e2e publish-sidecar-images REGISTRY=localhost:5001
-    - name: install app with default sidecar
+    - name: install app with default sidecar via vineyardctl
       command: |
         kubectl create namespace vineyard-job
         go run k8s/cmd/main.go inject -f k8s/test/e2e/sidecar-demo/sidecar-with-default-sidecar.yaml --apply-resources\
         | kubectl apply -f -
       wait:
         - namespace: vineyard-job
+          resource: deployment/job-deployment-with-default-sidecar
+          for: condition=Available
+    - name: install app with default sidecar via kubectl
+      command: |
+        kubectl create namespace vineyard-job1
+        kubectl label namespace vineyard-job1 sidecar-injection=enabled
+        sed -e 's/vineyard-job/vineyard-job1/g' k8s/test/e2e/sidecar-demo/sidecar-with-default-sidecar.yaml | \
+          kubectl apply -f -
+      wait:
+        - namespace: vineyard-job1
           resource: deployment/job-deployment-with-default-sidecar
           for: condition=Available
     - name: install app with custom sidecar
@@ -57,6 +67,14 @@ verify:
           awk -F '/' '{print $2}' | \
           head -n 1 | \
           xargs kubectl logs -c job -n vineyard-job | \
+          yq e '{"sum": .}' - | \
+          yq e 'to_entries' -
+      expected: ../verify/values.yaml
+    - query: |
+        kubectl get pod -l app=job-deployment-with-default-sidecar -n vineyard-job1 -oname | \
+          awk -F '/' '{print $2}' | \
+          head -n 1 | \
+          xargs kubectl logs -c job -n vineyard-job1 | \
           yq e '{"sum": .}' - | \
           yq e 'to_entries' -
       expected: ../verify/values.yaml

--- a/k8s/test/hack/prepare-e2e.sh
+++ b/k8s/test/hack/prepare-e2e.sh
@@ -58,3 +58,11 @@ if ! command -v gomplate &> /dev/null; then
     fi
 fi
 
+# v0.20.0 is not compatible on the github action
+if [ $(kind version | awk '{print $2}') == "v0.20.0" ]; then
+  curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.19.0/kind-linux-amd64
+  chmod +x ./kind
+  mv ./kind /usr/local/bin/kind
+fi
+
+


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

* Fix the bug the sidecar template is not injected into the workload yaml.
* Fix the bug the workload yaml can't contains the special character like '/' during sidecar injection.
* Add the ownerReferences to the Sidecar CR so that all injected resources will be deleted after deleting the workload.
* Add a test case for testing the vineyard sidecar via kubectl.
* Replace the kind version with v0.19.0 rather than v0.20.0.


Related issue number
--------------------

Related to #1355 

