### PR TITLE
Add a chunk_hook support for vineyard.{read/write} in io adaptors

### DIFF
--- a/docs/_static/css/index.css
+++ b/docs/_static/css/index.css
@@ -42,6 +42,10 @@ a {
   font-size: 0.95rem;
 }
 
+.button:hover {
+  cursor: pointer;
+}
+
 .background-gradient-color {
   background: linear-gradient(
       270deg,
@@ -180,11 +184,6 @@ a {
 
 .hero-container {
   padding: 100px 3% 100px;
-}
-
-.hero-section {
-  position: relative;
-  z-index: -1;
 }
 
 .hero-text {

--- a/docs/tutorials/kubernetes/ml-pipeline-mars-pytorch.rst
+++ b/docs/tutorials/kubernetes/ml-pipeline-mars-pytorch.rst
@@ -184,10 +184,12 @@ the job, follow the steps below:
     The `prepare-data` job needs to exec into the other pods. Therefore, you need to
     create a service account and bind it to the role under the namespace.
     Please make sure you can have permission to create the following role.
-    
-    - apiGroups: [""]
-      resources: ["pods", "pods/log", "pods/exec"]
-      verbs: ["get", "patch", "delete", "create", "watch", "list"]
+
+    .. code:: text
+
+      - apiGroups: [""]
+        resources: ["pods", "pods/log", "pods/exec"]
+        verbs: ["get", "patch", "delete", "create", "watch", "list"]
 
 .. code:: bash
 
@@ -212,21 +214,23 @@ the job, follow the steps below:
     The `process-data` job needs to create a new namespace and deploy several kubernetes 
     resources in it. Please make sure you can have permission to create the following role.
 
-    - apiGroups: [""]
-      resources: ["pods", "pods/exec", "pods/log", "endpoints", "services"]
-      verbs: ["get", "patch", "delete", "create", "watch", "list"]
-    - apiGroups: [""]
-      resources: ["namespaces"]
-      verbs: ["get", "create", "delete"]
-    - apiGroups: [""]
-      resources: ["nodes"]
-      verbs: ["get", "list"]
-    - apiGroups: ["rbac.authorization.k8s.io"]
-      resources: ["roles", "rolebindings"]
-      verbs: ["patch", "get", "create", "delete"]
-    - apiGroups: ["apps"]
-      resources: ["deployments"]
-      verbs: ["create"]
+    .. code:: text
+
+        - apiGroups: [""]
+          resources: ["pods", "pods/exec", "pods/log", "endpoints", "services"]
+          verbs: ["get", "patch", "delete", "create", "watch", "list"]
+        - apiGroups: [""]
+          resources: ["namespaces"]
+          verbs: ["get", "create", "delete"]
+        - apiGroups: [""]
+          resources: ["nodes"]
+          verbs: ["get", "list"]
+        - apiGroups: ["rbac.authorization.k8s.io"]
+          resources: ["roles", "rolebindings"]
+          verbs: ["patch", "get", "create", "delete"]
+        - apiGroups: ["apps"]
+          resources: ["deployments"]
+          verbs: ["create"]
 
     Notice, the `process-data` job will require lots of permissions to deal 
     kubernetes resources, so please check the image of `process-data` job 
@@ -239,7 +243,7 @@ code`_. Apply the `process-data` job as follows:
 .. code:: bash
 
     $ kubectl apply -f showcase/vineyard-mars-pytorch/process-data/resources && \
-    kubectl wait job -n vineyard-job -l app=process-data --for condition=complete --timeout=1200s
+      kubectl wait job -n vineyard-job -l app=process-data --for condition=complete --timeout=1200s
 
 Finally, apply the `train-data` job to obtain the fraudulent transaction classifier. You can
 also view the `train data code`_.
@@ -247,7 +251,7 @@ also view the `train data code`_.
 .. code:: bash
 
     $ kubectl apply -f k8s/showcase/vineyard-mars-pytorch/train-data/resources && \
-    kubectl wait pods -n vineyard-job -l app=train-data --for condition=Ready --timeout=1200s
+      kubectl wait pods -n vineyard-job -l app=train-data --for condition=Ready --timeout=1200s
 
 If any of the above steps fail, please refer to the `mars showcase e2e test`_ for further guidance.
 

--- a/setup_io.py
+++ b/setup_io.py
@@ -109,6 +109,8 @@ setup(
         's3fs',
         'vineyard',
         'zstd',
+        'cloudpickle>=2.2.1; python_version>="3.11"',
+        'cloudpickle>=1.5.0; python_version<"3.11"',
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
What do these changes do?
-------------------------

```python
  chunk_hook: callable, optional
        If the read/write target is a global dataframe (e.g., csv,
        orc, parquet, etc.), the hook will be called for each chunk
        to be read or write (usually a :code:`pyarrow.RecordBatch`).
        The hook should return a :code:`pyarrow.RecordBatch` object
        and should be stateless as the invoke order is not guaranteed.
        E.g.,

        .. code:: python

            def exchange_column(batch):
                import pyarrow as pa

                columns = batch.columns
                first = columns[0]
                second = columns[1]
                columns = [second, first] + columns[2:]
                return pa.RecordBatch.from_arrays(columns, schema=batch.schema)
```


Related issue number
--------------------

Fixes #1321

