### PR TITLE
Fixes the io adaptor parameters: the key should be string

### DIFF
--- a/modules/graph/loader/arrow_fragment_loader.cc
+++ b/modules/graph/loader/arrow_fragment_loader.cc
@@ -149,7 +149,9 @@ Status ReadRecordBatchesFromVineyard(
     int part_num) {
   VLOG(10) << "loading table from vineyard: " << ObjectIDToString(object_id)
            << ", part id = " << part_id << ", part num = " << part_num;
-  auto source = client.GetObject(object_id);
+
+  std::shared_ptr<Object> source;
+  RETURN_ON_ERROR(client.GetObject(object_id, source));
   RETURN_ON_ASSERT(source != nullptr,
                    "Object not exists: " + ObjectIDToString(object_id));
   if (auto pstream = std::dynamic_pointer_cast<ParallelStream>(source)) {

--- a/python/vineyard/drivers/io/adaptors/read_bytes.py
+++ b/python/vineyard/drivers/io/adaptors/read_bytes.py
@@ -150,10 +150,12 @@ def read_bytes(  # noqa: C901, pylint: disable=too-many-statements
     # when reading from directories
     first_header_row = read_options.get("first_header_row", False)
     for k, v in read_options.items():
-        if k in ("header_row", "first_header_row", "include_all_columns"):
+        if k in ("header_row", "first_header_row", "include_all_columns", "accumulate"):
             params[k] = "1" if v else "0"
         elif k == "delimiter":
             params[k] = bytes(v, "utf-8").decode("unicode_escape")
+        elif not isinstance(v, str):
+            params[k] = repr(v)
         else:
             params[k] = v
 


### PR DESCRIPTION
In C++ the parameters is `std::map<std::string, std::string>` so any key and value must be in form of string.

Fixes #1494.