### PR TITLE
Unify the log for vineyardctl and find an appropriate port for forwarding

### DIFF
--- a/go/vineyard/pkg/client/io/io.go
+++ b/go/vineyard/pkg/client/io/io.go
@@ -85,7 +85,7 @@ func ConnectRPCSocketRetry(host string, port uint16, conn *net.Conn) error {
 		if err == nil || numRetries < 0 {
 			break
 		}
-		log.Infof(
+		log.V(log.Debuglevel).Infof(
 			"Connecting to RPC socket failed for endpoint %s:%d with error %s, retrying %d more times.",
 			host,
 			port,

--- a/go/vineyard/pkg/client/io/io.go
+++ b/go/vineyard/pkg/client/io/io.go
@@ -85,7 +85,7 @@ func ConnectRPCSocketRetry(host string, port uint16, conn *net.Conn) error {
 		if err == nil || numRetries < 0 {
 			break
 		}
-		log.V(log.Debuglevel).Infof(
+		log.Infof(
 			"Connecting to RPC socket failed for endpoint %s:%d with error %s, retrying %d more times.",
 			host,
 			port,

--- a/go/vineyard/pkg/common/log/log.go
+++ b/go/vineyard/pkg/common/log/log.go
@@ -44,31 +44,26 @@ import (
 	"github.com/v6d-io/v6d/go/vineyard/pkg/common/log/zap"
 )
 
-const (
-	InfoLevel  = 0
-	Debuglevel = 1
-)
-
 var (
-	defaultLogger = makeDefaultLogger(InfoLevel)
+	defaultLogger = makeDefaultLogger(0)
 
 	dlog = NewDelegatingLogSink(defaultLogger.GetSink())
 
-	Log = Logger{logr.New(dlog)}
+	Log = Logger{logr.New(dlog).WithName("vineyard")}
 )
 
-func SetVerbose(level int) {
-	defaultLogger = makeDefaultLogger(-level)
+func SetLogLevel(level int) {
+	defaultLogger = makeDefaultLogger(level)
 	dlog.Fulfill(defaultLogger.GetSink())
-	Log = Logger{logr.New(dlog)}
 }
 
 func makeDefaultLogger(verbose int) logr.Logger {
-	return zap.New(zap.UseOptions(&zap.Options{
+	zapOpts := &zap.Options{
 		Development: true,
 		TimeEncoder: zapcore.ISO8601TimeEncoder,
 		Level:       zapcore.Level(verbose),
-	}))
+	}
+	return zap.New(zap.UseOptions(zapOpts))
 }
 
 type Logger struct {

--- a/go/vineyard/pkg/common/log/log.go
+++ b/go/vineyard/pkg/common/log/log.go
@@ -80,6 +80,10 @@ func IntoContext(ctx context.Context, log Logger) context.Context {
 	return logr.NewContext(ctx, log.Logger)
 }
 
+func Discard() {
+	SetLogger(Logger{logr.Discard()})
+}
+
 func V(level int) Logger {
 	return Logger{Log.V(level)}
 }

--- a/k8s/cmd/README.md
+++ b/k8s/cmd/README.md
@@ -29,6 +29,7 @@ drivers.
   -h, --help                help for vineyardctl
       --kubeconfig string   kubeconfig path for the kubernetes cluster (default "$HOME/.kube/config")
   -n, --namespace string    the namespace for operation (default "vineyard-system")
+      --verbose             print verbose log, default false
   -v, --version             version for vineyardctl
       --wait                wait for the kubernetes resource to be ready, default true (default true)
 ```
@@ -1507,10 +1508,6 @@ vineyardctl ls blobs [flags]
   -h, --help                     help for blobs
       --ipc-socket string        vineyard IPC socket path
   -l, --limit int                maximum number of objects to return (default 5)
-      --log-verbose int          the log level to print, default is 0, support:
-                                 - info(0): print info log.
-                                 - debug(1): print debug log.
-                                 The output will be info log by default, if you set the verbose to 1, the output will be debug log and info log.
       --port int                 the port of vineyard deployment (default 9600)
       --rpc-socket string        vineyard RPC socket path
 ```
@@ -1565,10 +1562,6 @@ vineyardctl ls metadatas [flags]
   -h, --help                     help for metadatas
       --ipc-socket string        vineyard IPC socket path
   -l, --limit int                maximum number of objects to return (default 5)
-      --log-verbose int          the log level to print, default is 0, support:
-                                 - info(0): print info log.
-                                 - debug(1): print debug log.
-                                 The output will be info log by default, if you set the verbose to 1, the output will be debug log and info log.
   -p, --pattern string           string that will be matched against the object’s typenames (default "*")
       --port int                 the port of vineyard deployment (default 9600)
   -r, --regex                    regex pattern to match the object’s typenames
@@ -1627,10 +1620,6 @@ vineyardctl ls objects [flags]
   -h, --help                     help for objects
       --ipc-socket string        vineyard IPC socket path
   -l, --limit int                maximum number of objects to return (default 5)
-      --log-verbose int          the log level to print, default is 0, support:
-                                 - info(0): print info log.
-                                 - debug(1): print debug log.
-                                 The output will be info log by default, if you set the verbose to 1, the output will be debug log and info log.
   -p, --pattern string           string that will be matched against the object’s typenames (default "*")
       --port int                 the port of vineyard deployment (default 9600)
   -r, --regex                    regex pattern to match the object’s typenames

--- a/k8s/cmd/README.md
+++ b/k8s/cmd/README.md
@@ -1507,6 +1507,10 @@ vineyardctl ls blobs [flags]
   -h, --help                     help for blobs
       --ipc-socket string        vineyard IPC socket path
   -l, --limit int                maximum number of objects to return (default 5)
+      --log-verbose int          the log level to print, default is 0, support:
+                                 - info(0): print info log.
+                                 - debug(1): print debug log.
+                                 The output will be info log by default, if you set the verbose to 1, the output will be debug log and info log.
       --port int                 the port of vineyard deployment (default 9600)
       --rpc-socket string        vineyard RPC socket path
 ```
@@ -1561,6 +1565,10 @@ vineyardctl ls metadatas [flags]
   -h, --help                     help for metadatas
       --ipc-socket string        vineyard IPC socket path
   -l, --limit int                maximum number of objects to return (default 5)
+      --log-verbose int          the log level to print, default is 0, support:
+                                 - info(0): print info log.
+                                 - debug(1): print debug log.
+                                 The output will be info log by default, if you set the verbose to 1, the output will be debug log and info log.
   -p, --pattern string           string that will be matched against the object’s typenames (default "*")
       --port int                 the port of vineyard deployment (default 9600)
   -r, --regex                    regex pattern to match the object’s typenames
@@ -1619,6 +1627,10 @@ vineyardctl ls objects [flags]
   -h, --help                     help for objects
       --ipc-socket string        vineyard IPC socket path
   -l, --limit int                maximum number of objects to return (default 5)
+      --log-verbose int          the log level to print, default is 0, support:
+                                 - info(0): print info log.
+                                 - debug(1): print debug log.
+                                 The output will be info log by default, if you set the verbose to 1, the output will be debug log and info log.
   -p, --pattern string           string that will be matched against the object’s typenames (default "*")
       --port int                 the port of vineyard deployment (default 9600)
   -r, --regex                    regex pattern to match the object’s typenames

--- a/k8s/cmd/commands/client/ls.go
+++ b/k8s/cmd/commands/client/ls.go
@@ -22,8 +22,7 @@ import (
 	"github.com/v6d-io/v6d/k8s/cmd/commands/util"
 )
 
-var (
-	lsExample = util.Examples(`
+var lsExample = util.Examples(`
 	# Connect the vineyardd server with IPC client
 	# List the vineyard objects no more than 10
 	vineyardctl ls objects --limit 10 --ipc-socket /var/run/vineyard.sock
@@ -37,17 +36,26 @@ var (
 	# Connect the vineyardd server with RPC client
 	# List the vineyard metadatas no more than 1000
 	vineyardctl ls metadatas --rpc-socket 127.0.0.1:9600 --limit 1000
-	
+
 	# Connect the vineyard deployment with PRC client
 	# List the vineyard objects no more than 1000
 	vineyardctl ls objects --deployment-name vineyardd-sample -n vineyard-system`)
-)
+
+var stdout = os.Stdout
 
 // lsCmd is to list vineyard objects
 var lsCmd = &cobra.Command{
 	Use:     "ls",
 	Short:   "List vineyard objects, metadatas or blobs",
 	Example: lsExample,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		// disable stdout
+		os.Stdout, _ = os.Open(os.DevNull)
+	},
+	PersistentPostRun: func(cmd *cobra.Command, args []string) {
+		// enable stdout
+		os.Stdout = stdout
+	},
 }
 
 func NewLsCmd() *cobra.Command {
@@ -58,17 +66,4 @@ func init() {
 	lsCmd.AddCommand(NewLsMetadatasCmd())
 	lsCmd.AddCommand(NewLsObjectsCmd())
 	lsCmd.AddCommand(NewLsBlobsCmd())
-	DisableStdout()
-}
-
-var (
-	originalStdout = os.Stdout
-)
-
-func DisableStdout() {
-	os.Stdout, _ = os.Open(os.DevNull)
-}
-
-func EnableStdout() {
-	os.Stdout = originalStdout
 }

--- a/k8s/cmd/commands/client/ls.go
+++ b/k8s/cmd/commands/client/ls.go
@@ -41,7 +41,10 @@ var lsExample = util.Examples(`
 	# List the vineyard objects no more than 1000
 	vineyardctl ls objects --deployment-name vineyardd-sample -n vineyard-system`)
 
-var stdout = os.Stdout
+var (
+	stdout = os.Stdout
+	Output *util.Output
+)
 
 // lsCmd is to list vineyard objects
 var lsCmd = &cobra.Command{
@@ -55,6 +58,7 @@ var lsCmd = &cobra.Command{
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {
 		// enable stdout
 		os.Stdout = stdout
+		Output.Print()
 	},
 }
 

--- a/k8s/cmd/commands/client/ls.go
+++ b/k8s/cmd/commands/client/ls.go
@@ -16,6 +16,8 @@ limitations under the License.
 package client
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 	"github.com/v6d-io/v6d/k8s/cmd/commands/util"
 )
@@ -56,4 +58,17 @@ func init() {
 	lsCmd.AddCommand(NewLsMetadatasCmd())
 	lsCmd.AddCommand(NewLsObjectsCmd())
 	lsCmd.AddCommand(NewLsBlobsCmd())
+	DisableStdout()
+}
+
+var (
+	originalStdout = os.Stdout
+)
+
+func DisableStdout() {
+	os.Stdout, _ = os.Open(os.DevNull)
+}
+
+func EnableStdout() {
+	os.Stdout = originalStdout
 }

--- a/k8s/cmd/commands/client/ls_blobs.go
+++ b/k8s/cmd/commands/client/ls_blobs.go
@@ -70,7 +70,7 @@ var lsBlobs = &cobra.Command{
 		output.WithFilter(false).
 			SortedKey(flags.SortedKey).
 			SetFormat(flags.Format)
-		output.Print()
+		Output = output
 	},
 }
 

--- a/k8s/cmd/commands/client/ls_blobs.go
+++ b/k8s/cmd/commands/client/ls_blobs.go
@@ -70,8 +70,6 @@ var lsBlobs = &cobra.Command{
 		output.WithFilter(false).
 			SortedKey(flags.SortedKey).
 			SetFormat(flags.Format)
-
-		EnableStdout()
 		output.Print()
 	},
 }

--- a/k8s/cmd/commands/client/ls_blobs.go
+++ b/k8s/cmd/commands/client/ls_blobs.go
@@ -16,11 +16,12 @@ limitations under the License.
 package client
 
 import (
-	"log"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/v6d-io/v6d/k8s/cmd/commands/flags"
 	"github.com/v6d-io/v6d/k8s/cmd/commands/util"
+	"github.com/v6d-io/v6d/k8s/pkg/log"
 )
 
 var (
@@ -54,6 +55,7 @@ var lsBlobs = &cobra.Command{
 	Example: lsBlobsExample,
 	Run: func(cmd *cobra.Command, args []string) {
 		util.AssertNoArgs(cmd, args)
+		stdout := DisableStdout()
 		// check the client socket
 		util.CheckClientSocket(cmd, args)
 
@@ -72,6 +74,7 @@ var lsBlobs = &cobra.Command{
 			SortedKey(flags.SortedKey).
 			SetFormat(flags.Format)
 
+		os.Stdout = stdout
 		output.Print()
 	},
 }

--- a/k8s/cmd/commands/client/ls_blobs.go
+++ b/k8s/cmd/commands/client/ls_blobs.go
@@ -16,8 +16,6 @@ limitations under the License.
 package client
 
 import (
-	"os"
-
 	"github.com/spf13/cobra"
 	"github.com/v6d-io/v6d/k8s/cmd/commands/flags"
 	"github.com/v6d-io/v6d/k8s/cmd/commands/util"
@@ -55,7 +53,6 @@ var lsBlobs = &cobra.Command{
 	Example: lsBlobsExample,
 	Run: func(cmd *cobra.Command, args []string) {
 		util.AssertNoArgs(cmd, args)
-		stdout := DisableStdout()
 		// check the client socket
 		util.CheckClientSocket(cmd, args)
 
@@ -74,7 +71,7 @@ var lsBlobs = &cobra.Command{
 			SortedKey(flags.SortedKey).
 			SetFormat(flags.Format)
 
-		os.Stdout = stdout
+		EnableStdout()
 		output.Print()
 	},
 }

--- a/k8s/cmd/commands/client/ls_metadatas.go
+++ b/k8s/cmd/commands/client/ls_metadatas.go
@@ -95,10 +95,9 @@ func init() {
 
 func DisableStdout() *os.File {
 	stdout := os.Stdout
-	if !flags.Debug {
-		os.Stdout, _ = os.Open(os.DevNull)
-		log.Discard()
-		gosdklog.Discard()
-	}
+	os.Stdout, _ = os.Open(os.DevNull)
+	log.SetVerbose(flags.Verbose)
+	gosdklog.SetVerbose(flags.Verbose)
+
 	return stdout
 }

--- a/k8s/cmd/commands/client/ls_metadatas.go
+++ b/k8s/cmd/commands/client/ls_metadatas.go
@@ -72,7 +72,7 @@ var lsMetadatas = &cobra.Command{
 		output.WithFilter(false).
 			SortedKey(flags.SortedKey).
 			SetFormat(flags.Format)
-		output.Print()
+		Output = output
 	},
 }
 

--- a/k8s/cmd/commands/client/ls_metadatas.go
+++ b/k8s/cmd/commands/client/ls_metadatas.go
@@ -16,10 +16,7 @@ limitations under the License.
 package client
 
 import (
-	"os"
-
 	"github.com/spf13/cobra"
-	gosdklog "github.com/v6d-io/v6d/go/vineyard/pkg/common/log"
 	"github.com/v6d-io/v6d/k8s/cmd/commands/flags"
 	"github.com/v6d-io/v6d/k8s/cmd/commands/util"
 	"github.com/v6d-io/v6d/k8s/pkg/log"
@@ -59,7 +56,6 @@ var lsMetadatas = &cobra.Command{
 	Long:    lsMetadatasLong,
 	Example: lsMetadatasExample,
 	Run: func(cmd *cobra.Command, args []string) {
-		stdout := DisableStdout()
 		util.AssertNoArgs(cmd, args)
 		// check the client socket
 		util.CheckClientSocket(cmd, args)
@@ -72,13 +68,12 @@ var lsMetadatas = &cobra.Command{
 			log.Fatal(err, "failed to list vineyard objects")
 		}
 		output := util.NewOutput(&metas, nil)
-		// set the oxutput options
+		// set the output options
 		output.WithFilter(false).
 			SortedKey(flags.SortedKey).
 			SetFormat(flags.Format)
 
-		// enable stdout
-		os.Stdout = stdout
+		EnableStdout()
 		output.Print()
 	},
 }
@@ -91,13 +86,4 @@ func init() {
 	flags.ApplyConnectOpts(lsMetadatas)
 	flags.ApplyLsOpts(lsMetadatas)
 	flags.ApplyOutputOpts(lsMetadatas)
-}
-
-func DisableStdout() *os.File {
-	stdout := os.Stdout
-	os.Stdout, _ = os.Open(os.DevNull)
-	log.SetVerbose(flags.Verbose)
-	gosdklog.SetVerbose(flags.Verbose)
-
-	return stdout
 }

--- a/k8s/cmd/commands/client/ls_metadatas.go
+++ b/k8s/cmd/commands/client/ls_metadatas.go
@@ -72,8 +72,6 @@ var lsMetadatas = &cobra.Command{
 		output.WithFilter(false).
 			SortedKey(flags.SortedKey).
 			SetFormat(flags.Format)
-
-		EnableStdout()
 		output.Print()
 	},
 }

--- a/k8s/cmd/commands/client/ls_objects.go
+++ b/k8s/cmd/commands/client/ls_objects.go
@@ -16,11 +16,12 @@ limitations under the License.
 package client
 
 import (
-	"log"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/v6d-io/v6d/k8s/cmd/commands/flags"
 	"github.com/v6d-io/v6d/k8s/cmd/commands/util"
+	"github.com/v6d-io/v6d/k8s/pkg/log"
 )
 
 var (
@@ -54,6 +55,7 @@ var lsObjects = &cobra.Command{
 	Example: lsObjectsExample,
 	Run: func(cmd *cobra.Command, args []string) {
 		util.AssertNoArgs(cmd, args)
+		stdout := DisableStdout()
 		// check the client socket
 		util.CheckClientSocket(cmd, args)
 
@@ -71,6 +73,7 @@ var lsObjects = &cobra.Command{
 			SortedKey(flags.SortedKey).
 			SetFormat(flags.Format)
 
+		os.Stdout = stdout
 		output.Print()
 	},
 }

--- a/k8s/cmd/commands/client/ls_objects.go
+++ b/k8s/cmd/commands/client/ls_objects.go
@@ -16,8 +16,6 @@ limitations under the License.
 package client
 
 import (
-	"os"
-
 	"github.com/spf13/cobra"
 	"github.com/v6d-io/v6d/k8s/cmd/commands/flags"
 	"github.com/v6d-io/v6d/k8s/cmd/commands/util"
@@ -55,7 +53,6 @@ var lsObjects = &cobra.Command{
 	Example: lsObjectsExample,
 	Run: func(cmd *cobra.Command, args []string) {
 		util.AssertNoArgs(cmd, args)
-		stdout := DisableStdout()
 		// check the client socket
 		util.CheckClientSocket(cmd, args)
 
@@ -73,7 +70,7 @@ var lsObjects = &cobra.Command{
 			SortedKey(flags.SortedKey).
 			SetFormat(flags.Format)
 
-		os.Stdout = stdout
+		EnableStdout()
 		output.Print()
 	},
 }

--- a/k8s/cmd/commands/client/ls_objects.go
+++ b/k8s/cmd/commands/client/ls_objects.go
@@ -25,22 +25,22 @@ import (
 var (
 	lsObjectsLong = util.LongDesc(`List vineyard objects and support IPC socket,
 	RPC socket and vineyard deployment. If you don't specify the ipc socket or rpc socket
-	every time, you can set it as the environment variable VINEYARD_IPC_SOCKET or 
+	every time, you can set it as the environment variable VINEYARD_IPC_SOCKET or
 	VINEYARD_RPC_SOCKET.`)
 
 	lsObjectsExample = util.Examples(`
 	# List no more than 10 vineyard objects
 	vineyardctl ls objects --limit 10 --ipc-socket /var/run/vineyard.sock
-	
+
 	# List any vineyard objects and no more than 1000 objects
 	vineyardctl ls objects --pattern "*" --ipc-socket /var/run/vineyard.sock --limit 1000
-	
+
 	# List vineyard objects with the name matching the regex pattern
 	vineyardctl ls objects --pattern "vineyard::Tensor<.*>" --regex --ipc-socket /var/run/vineyard.sock
-	
+
 	# List vineyard objects and output as json format
 	vineyardctl ls objects --format json --ipc-socket /var/run/vineyard.sock
-	
+
 	# List vineyard objects sorted by the typename
 	vineyardctl ls objects --sorted-key typename --limit 1000 --ipc-socket /var/run/vineyard.sock`)
 )
@@ -69,8 +69,6 @@ var lsObjects = &cobra.Command{
 		output.WithFilter(true).
 			SortedKey(flags.SortedKey).
 			SetFormat(flags.Format)
-
-		EnableStdout()
 		output.Print()
 	},
 }

--- a/k8s/cmd/commands/client/ls_objects.go
+++ b/k8s/cmd/commands/client/ls_objects.go
@@ -69,7 +69,7 @@ var lsObjects = &cobra.Command{
 		output.WithFilter(true).
 			SortedKey(flags.SortedKey).
 			SetFormat(flags.Format)
-		output.Print()
+		Output = output
 	},
 }
 

--- a/k8s/cmd/commands/create/create_backup.go
+++ b/k8s/cmd/commands/create/create_backup.go
@@ -119,10 +119,13 @@ var createBackupCmd = &cobra.Command{
 		util.AssertNoArgsOrInput(cmd, args)
 
 		client := util.KubernetesClient()
+		log.Info("building Backup cr")
 		backup, err := BuildBackup(client, args)
 		if err != nil {
 			log.Fatal(err, "failed to build backup cr")
 		}
+
+		log.Info("creating Backup cr")
 		if err := util.Create(client, backup, func(backup *v1alpha1.Backup) bool {
 			return backup.Status.State != k8s.SucceedState
 		}); err != nil {

--- a/k8s/cmd/commands/create/create_operation.go
+++ b/k8s/cmd/commands/create/create_operation.go
@@ -69,6 +69,7 @@ var createOperationCmd = &cobra.Command{
 		util.CreateNamespaceIfNotExist(client)
 		operation := buildOperation()
 
+		log.Info("creating Operation cr")
 		if err := util.Create(client, operation, func(operation *v1alpha1.Operation) bool {
 			return operation.Status.State != v1alpha1.OperationSucceeded
 		}); err != nil {

--- a/k8s/cmd/commands/create/create_recover.go
+++ b/k8s/cmd/commands/create/create_recover.go
@@ -59,6 +59,7 @@ var createRecoverCmd = &cobra.Command{
 			log.Fatal(err, "failed to build recover cr")
 		}
 
+		log.Info("creating Recover cr")
 		if err := util.Create(client, recover, func(*v1alpha1.Recover) bool {
 			return recover.Status.State != k8s.SucceedState
 		}); err != nil {

--- a/k8s/cmd/commands/delete/delete_backup.go
+++ b/k8s/cmd/commands/delete/delete_backup.go
@@ -45,6 +45,7 @@ var deleteBackupCmd = &cobra.Command{
 		util.AssertNoArgs(cmd, args)
 		client := util.KubernetesClient()
 
+		log.Info("deleting Backup cr")
 		backup := &v1alpha1.Backup{}
 		if err := util.Delete(client, types.NamespacedName{
 			Name:      flags.BackupName,

--- a/k8s/cmd/commands/delete/delete_certmanager.go
+++ b/k8s/cmd/commands/delete/delete_certmanager.go
@@ -42,11 +42,13 @@ var deleteCertManagerCmd = &cobra.Command{
 		util.AssertNoArgs(cmd, args)
 		client := util.KubernetesClient()
 
+		log.Info("get Cert-Manager manifests from local")
 		certManagerManifests, err := util.GetCertManager()
 		if err != nil {
 			log.Fatal(err, "failed to get cert-manager manifests")
 		}
 
+		log.Info("deleting Cert-Manager manifests")
 		if err := util.DeleteManifests(client, certManagerManifests,
 			""); err != nil {
 			log.Fatal(err, "failed to delete cert-manager manifests")

--- a/k8s/cmd/commands/delete/delete_operation.go
+++ b/k8s/cmd/commands/delete/delete_operation.go
@@ -40,6 +40,7 @@ var deleteOperationCmd = &cobra.Command{
 
 		client := util.KubernetesClient()
 
+		log.Info("deleting Operation cr")
 		operation := &vineyardV1alpha1.Operation{}
 		if err := util.Delete(client, types.NamespacedName{
 			Name:      flags.OperationName,

--- a/k8s/cmd/commands/delete/delete_operator.go
+++ b/k8s/cmd/commands/delete/delete_operator.go
@@ -43,11 +43,13 @@ var deleteOperatorCmd = &cobra.Command{
 		util.AssertNoArgs(cmd, args)
 		client := util.KubernetesClient()
 
+		log.Info("building operator manifests from kustomize dir")
 		operatorManifests, err := util.BuildKustomizeInDir(util.GetKustomizeDir())
 		if err != nil {
 			log.Fatal(err, "failed to build kustomize dir")
 		}
 
+		log.Info("deleting operator manifests")
 		if err := util.DeleteManifests(client, operatorManifests,
 			flags.GetDefaultVineyardNamespace()); err != nil {
 			log.Fatal(err, "failed to delete operator manifests")

--- a/k8s/cmd/commands/delete/delete_recover.go
+++ b/k8s/cmd/commands/delete/delete_recover.go
@@ -39,6 +39,7 @@ var deleteRecoverCmd = &cobra.Command{
 		util.AssertNoArgs(cmd, args)
 		client := util.KubernetesClient()
 
+		log.Info("deleting Recover cr")
 		recover := &v1alpha1.Recover{}
 		if err := util.Delete(client, types.NamespacedName{
 			Name:      flags.RecoverName,

--- a/k8s/cmd/commands/delete/delete_vineyard_deployment.go
+++ b/k8s/cmd/commands/delete/delete_vineyard_deployment.go
@@ -44,6 +44,7 @@ var deleteVineyardDeploymentCmd = &cobra.Command{
 		util.AssertNoArgs(cmd, args)
 		client := util.KubernetesClient()
 
+		log.Info("deleting vineyardd resources from template")
 		if err := deleteVineyarddFromTemplate(client); err != nil {
 			log.Fatal(err, "failed to delete vineyardd resources from template")
 		}

--- a/k8s/cmd/commands/delete/delete_vineyardd.go
+++ b/k8s/cmd/commands/delete/delete_vineyardd.go
@@ -42,6 +42,7 @@ var deleteVineyarddCmd = &cobra.Command{
 		util.AssertNoArgs(cmd, args)
 		client := util.KubernetesClient()
 
+		log.Info("deleting Vineyardd cluster")
 		vineyardd := &vineyardv1alpha1.Vineyardd{}
 		if err := util.Delete(client, types.NamespacedName{
 			Name:      flags.VineyarddName,

--- a/k8s/cmd/commands/deploy/deploy_backup_job.go
+++ b/k8s/cmd/commands/deploy/deploy_backup_job.go
@@ -143,10 +143,12 @@ var deployBackupJobCmd = &cobra.Command{
 			log.Fatal(err, "failed to get backup objects from template")
 		}
 
+		log.Info("applying backup manifests with owner reference")
 		if err := util.ApplyManifestsWithOwnerRef(c, objs, "Job", "Role,Rolebinding"); err != nil {
 			log.Fatal(err, "failed to apply backup objects")
 		}
 
+		log.Info("waiting backup job for ready")
 		if err := waitBackupJobReady(c); err != nil {
 			log.Fatal(err, "failed to wait backup job ready")
 		}

--- a/k8s/cmd/commands/deploy/deploy_certmanager.go
+++ b/k8s/cmd/commands/deploy/deploy_certmanager.go
@@ -65,12 +65,14 @@ var deployCertManagerCmd = &cobra.Command{
 			log.Fatal(err, "failed to get cert-manager manifests")
 		}
 
+		log.Info("applying cert-manager manifests")
 		if err := util.ApplyManifests(client, certManagerManifests,
 			""); err != nil {
 			log.Fatal(err, "failed to apply cert-manager manifests")
 		}
 
 		if flags.Wait {
+			log.Info("waiting for cert-manager ready")
 			if err := waitCertManagerReady(client); err != nil {
 				log.Fatal(err, "failed to wait cert-manager ready")
 			}

--- a/k8s/cmd/commands/deploy/deploy_operator.go
+++ b/k8s/cmd/commands/deploy/deploy_operator.go
@@ -75,12 +75,14 @@ var deployOperatorCmd = &cobra.Command{
 			log.Fatal(err, "failed to build kustomize dir")
 		}
 
+		log.Info("applying operator manifests")
 		if err := util.ApplyManifests(client, operatorManifests,
 			flags.GetDefaultVineyardNamespace()); err != nil {
 			log.Fatal(err, "failed to apply operator manifests")
 		}
 
 		if flags.Wait {
+			log.Info("waiting for the vineyard operator to be ready")
 			if err := waitOperatorReady(client); err != nil {
 				log.Fatal(err, "failed to wait operator ready")
 			}

--- a/k8s/cmd/commands/deploy/deploy_recover_job.go
+++ b/k8s/cmd/commands/deploy/deploy_recover_job.go
@@ -77,10 +77,12 @@ var deployRecoverJobCmd = &cobra.Command{
 			log.Fatal(err, "failed to get recover objects from template")
 		}
 
+		log.Info("applying recover objects with owner ref")
 		if err := util.ApplyManifestsWithOwnerRef(client, objs, "Job", "Role,Rolebinding"); err != nil {
 			log.Fatal(err, "failed to apply recover objects")
 		}
 
+		log.Info("waiting recover job for ready")
 		if err := waitRecoverJobReady(client); err != nil {
 			log.Fatal(err, "failed to wait recover job ready")
 		}

--- a/k8s/cmd/commands/deploy/deploy_vineyard_deployment.go
+++ b/k8s/cmd/commands/deploy/deploy_vineyard_deployment.go
@@ -70,6 +70,7 @@ var deployVineyardDeploymentCmd = &cobra.Command{
 			log.Fatal(err, "failed to apply vineyardd resources from template")
 		}
 
+		log.Info("waiting for vineyard deployment ready")
 		if err := waitVineyardDeploymentReady(client); err != nil {
 			log.Fatal(err, "failed to wait vineyard deployment for ready")
 		}

--- a/k8s/cmd/commands/deploy/deploy_vineyardd.go
+++ b/k8s/cmd/commands/deploy/deploy_vineyardd.go
@@ -138,6 +138,7 @@ var deployVineyarddCmd = &cobra.Command{
 			log.Fatal(err, "failed to build vineyardd")
 		}
 
+		log.Info("wait for the vineyardd to be ready")
 		var waitVineyarddFuc func(vineyardd *v1alpha1.Vineyardd) bool
 		if flags.Wait {
 			waitVineyarddFuc = func(vineyardd *v1alpha1.Vineyardd) bool {

--- a/k8s/cmd/commands/flags/client_flags.go
+++ b/k8s/cmd/commands/flags/client_flags.go
@@ -38,8 +38,8 @@ var (
 	// ForwardPort is the forward port of vineyard deployment
 	ForwardPort int
 
-	// Debug represents whether to enable debug mode
-	Debug bool
+	// Verbose represents the log level to print
+	Verbose int
 )
 
 // ls options
@@ -108,5 +108,10 @@ func ApplyConnectOpts(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&DeploymentName, "deployment-name", "", "", "the name of vineyard deployment")
 	cmd.Flags().IntVarP(&Port, "port", "", 9600, "the port of vineyard deployment")
 	cmd.Flags().IntVarP(&ForwardPort, "forward-port", "", 9600, "the forward port of vineyard deployment")
-	cmd.Flags().BoolVarP(&Debug, "debug", "", false, "enable debug mode")
+	cmd.Flags().IntVarP(&Verbose, "log-verbose", "", 0,
+		"the log level to print, default is 0, support:"+"\n"+
+			"- info(0): print info log."+"\n"+
+			"- debug(1): print debug log."+"\n"+
+			"The output will be info log by default, if you set the verbose to 1, "+
+			"the output will be debug log and info log.")
 }

--- a/k8s/cmd/commands/flags/client_flags.go
+++ b/k8s/cmd/commands/flags/client_flags.go
@@ -37,9 +37,6 @@ var (
 
 	// ForwardPort is the forward port of vineyard deployment
 	ForwardPort int
-
-	// Verbose represents the log level to print
-	Verbose int
 )
 
 // ls options
@@ -108,10 +105,4 @@ func ApplyConnectOpts(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&DeploymentName, "deployment-name", "", "", "the name of vineyard deployment")
 	cmd.Flags().IntVarP(&Port, "port", "", 9600, "the port of vineyard deployment")
 	cmd.Flags().IntVarP(&ForwardPort, "forward-port", "", 9600, "the forward port of vineyard deployment")
-	cmd.Flags().IntVarP(&Verbose, "log-verbose", "", 0,
-		"the log level to print, default is 0, support:"+"\n"+
-			"- info(0): print info log."+"\n"+
-			"- debug(1): print debug log."+"\n"+
-			"The output will be info log by default, if you set the verbose to 1, "+
-			"the output will be debug log and info log.")
 }

--- a/k8s/cmd/commands/flags/client_flags.go
+++ b/k8s/cmd/commands/flags/client_flags.go
@@ -37,6 +37,9 @@ var (
 
 	// ForwardPort is the forward port of vineyard deployment
 	ForwardPort int
+
+	// Debug represents whether to enable debug mode
+	Debug bool
 )
 
 // ls options
@@ -105,4 +108,5 @@ func ApplyConnectOpts(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&DeploymentName, "deployment-name", "", "", "the name of vineyard deployment")
 	cmd.Flags().IntVarP(&Port, "port", "", 9600, "the port of vineyard deployment")
 	cmd.Flags().IntVarP(&ForwardPort, "forward-port", "", 9600, "the forward port of vineyard deployment")
+	cmd.Flags().BoolVarP(&Debug, "debug", "", false, "enable debug mode")
 }

--- a/k8s/cmd/commands/flags/global_flags.go
+++ b/k8s/cmd/commands/flags/global_flags.go
@@ -43,6 +43,9 @@ var (
 	// DumpUsage
 	DumpUsage bool
 
+	// Verbose indicates whether to print verbose log
+	Verbose bool
+
 	GenDoc bool
 )
 
@@ -72,6 +75,8 @@ func ApplyGlobalFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().
 		BoolVarP(&CreateNamespace, "create-namespace", "", false,
 			"create the namespace if it does not exist, default false")
+	cmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "", false,
+		"print verbose log, default false")
 	cmd.Flags().BoolVarP(&DumpUsage, "dump-usage", "j", false, "Dump usage in JSON")
 	cmd.Flags().
 		BoolVarP(&GenDoc, "gen-doc", "g", false, "Generate reference docs, e.g., \"./cmd/README.md\"")

--- a/k8s/cmd/commands/util/connect.go
+++ b/k8s/cmd/commands/util/connect.go
@@ -48,7 +48,7 @@ func NewClient() (Client, chan struct{}) {
 		}
 		client.rpcClient = rpcClient
 	} else if flags.DeploymentName != "" && flags.Namespace != "" {
-		log.Info("Connecting to vineyardd deployment via rpc...")
+		log.V(log.Debuglevel).Info("Connecting to vineyardd deployment via rpc...")
 		stopChannel = make(chan struct{})
 		readyChannel := make(chan struct{}, 1)
 		rpcClient, err := ConnectDeployment(flags.DeploymentName, flags.Namespace, readyChannel, stopChannel)
@@ -56,7 +56,7 @@ func NewClient() (Client, chan struct{}) {
 			log.Fatal(err, "failed to connect vineyard deployment via rpc")
 		}
 		<-readyChannel
-		log.Info("Connected to vineyardd deployment via rpc")
+		log.V(log.Debuglevel).Info("Connected to vineyardd deployment via rpc")
 		client.rpcClient = rpcClient
 	}
 	if client.ipcClient == nil && client.rpcClient == nil {

--- a/k8s/cmd/commands/util/connect.go
+++ b/k8s/cmd/commands/util/connect.go
@@ -86,6 +86,12 @@ func ConnectViaRPC(rpcSocket string) (*client.RPCClient, error) {
 // ConnectDeployment connects to the vineyardd deployment via rpc
 func ConnectDeployment(deployment, namespace string, readyChannel, stopChannel chan struct{}) (*client.RPCClient, error) {
 	if deployment != "" && namespace != "" {
+		// check if the port is available, if not, generate a new one
+		port, err := GetValidForwardPort(flags.ForwardPort)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get a valid forward port")
+		}
+		flags.ForwardPort = port
 		go func() {
 			PortforwardDeployment(deployment, namespace, flags.ForwardPort, flags.Port, readyChannel, stopChannel)
 			defer close(stopChannel)

--- a/k8s/cmd/commands/util/connect.go
+++ b/k8s/cmd/commands/util/connect.go
@@ -48,7 +48,7 @@ func NewClient() (Client, chan struct{}) {
 		}
 		client.rpcClient = rpcClient
 	} else if flags.DeploymentName != "" && flags.Namespace != "" {
-		log.V(log.Debuglevel).Info("Connecting to vineyardd deployment via rpc...")
+		log.Info("Connecting to vineyardd deployment via rpc...")
 		stopChannel = make(chan struct{})
 		readyChannel := make(chan struct{}, 1)
 		rpcClient, err := ConnectDeployment(flags.DeploymentName, flags.Namespace, readyChannel, stopChannel)
@@ -56,7 +56,7 @@ func NewClient() (Client, chan struct{}) {
 			log.Fatal(err, "failed to connect vineyard deployment via rpc")
 		}
 		<-readyChannel
-		log.V(log.Debuglevel).Info("Connected to vineyardd deployment via rpc")
+		log.Info("Connected to vineyardd deployment via rpc")
 		client.rpcClient = rpcClient
 	}
 	if client.ipcClient == nil && client.rpcClient == nil {
@@ -94,7 +94,6 @@ func ConnectDeployment(deployment, namespace string, readyChannel, stopChannel c
 		flags.ForwardPort = port
 		go func() {
 			PortforwardDeployment(deployment, namespace, flags.ForwardPort, flags.Port, readyChannel, stopChannel)
-			defer close(stopChannel)
 		}()
 	}
 	return ConnectViaRPC("localhost" + ":" + strconv.Itoa(flags.ForwardPort))

--- a/k8s/cmd/commands/util/connect.go
+++ b/k8s/cmd/commands/util/connect.go
@@ -93,7 +93,7 @@ func ConnectDeployment(deployment, namespace string, readyChannel, stopChannel c
 		}
 		flags.ForwardPort = port
 		go func() {
-			PortforwardDeployment(deployment, namespace, flags.ForwardPort, flags.Port, readyChannel, stopChannel)
+			PortForwardDeployment(deployment, namespace, flags.ForwardPort, flags.Port, readyChannel, stopChannel)
 		}()
 	}
 	return ConnectViaRPC("localhost" + ":" + strconv.Itoa(flags.ForwardPort))

--- a/k8s/cmd/commands/util/output.go
+++ b/k8s/cmd/commands/util/output.go
@@ -18,7 +18,6 @@ package util
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"sort"
 	"strconv"
@@ -27,6 +26,7 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"github.com/v6d-io/v6d/go/vineyard/pkg/client"
 	"github.com/v6d-io/v6d/go/vineyard/pkg/common/types"
+	"github.com/v6d-io/v6d/k8s/pkg/log"
 )
 
 var (
@@ -125,7 +125,7 @@ func (o *Output) SortBy() *Output {
 		}
 	}
 	if !valid {
-		log.Fatal("invalid sorted key")
+		log.Fatal(fmt.Errorf("invalid sorted key: %s", sortedKey), "failed to sort the output")
 	}
 	data := []KeyValue{}
 	for k, v := range *o.metadatas {
@@ -159,7 +159,7 @@ func (o *Output) Format() {
 		}
 	}
 	if !valid {
-		log.Fatal("invalid output format")
+		log.Fatal(fmt.Errorf("invalid output format: %s", format), "failed to format the output")
 	}
 	if format == "table" {
 		o.formatAsTable()
@@ -180,7 +180,7 @@ func (o *Output) formatAsJson() {
 		if err != nil {
 			log.Fatal(err, "failed to marshal metadata")
 		}
-		log.Println(string(jsonMeta))
+		log.Output(string(jsonMeta))
 	}
 
 	type Object struct {
@@ -205,7 +205,7 @@ func (o *Output) formatAsJson() {
 		if err != nil {
 			log.Fatal(err, "failed to marshal buffers")
 		}
-		log.Println(string(jsonBuf))
+		log.Output(string(jsonBuf))
 	}
 }
 

--- a/k8s/cmd/commands/util/output.go
+++ b/k8s/cmd/commands/util/output.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/olekukonko/tablewriter"
+	"github.com/pkg/errors"
 	"github.com/v6d-io/v6d/go/vineyard/pkg/client"
 	"github.com/v6d-io/v6d/go/vineyard/pkg/common/types"
 	"github.com/v6d-io/v6d/k8s/pkg/log"
@@ -79,7 +80,8 @@ func (o *Output) SetFormat(format string) *Output {
 }
 
 func NewOutput(metadatas *map[string]map[string]any,
-	buffers *map[types.ObjectID]client.Blob) *Output {
+	buffers *map[types.ObjectID]client.Blob,
+) *Output {
 	return &Output{
 		Options:   Options{},
 		metadatas: metadatas,
@@ -125,7 +127,7 @@ func (o *Output) SortBy() *Output {
 		}
 	}
 	if !valid {
-		log.Fatal(fmt.Errorf("invalid sorted key: %s", sortedKey), "failed to sort the output")
+		log.Fatal(errors.Errorf("invalid sorted key: %s", sortedKey), "failed to sort the output")
 	}
 	data := []KeyValue{}
 	for k, v := range *o.metadatas {
@@ -159,7 +161,7 @@ func (o *Output) Format() {
 		}
 	}
 	if !valid {
-		log.Fatal(fmt.Errorf("invalid output format: %s", format), "failed to format the output")
+		log.Fatal(errors.Errorf("invalid output format: %s", format), "failed to format the output")
 	}
 	if format == "table" {
 		o.formatAsTable()

--- a/k8s/cmd/commands/util/portforward.go
+++ b/k8s/cmd/commands/util/portforward.go
@@ -61,7 +61,7 @@ func PortforwardDeployment(deploymentName, namespace string, forwardPort, port i
 
 	req := clientSet.CoreV1().RESTClient().Post().Namespace(namespace).
 		Resource("pods").Name(podName).SubResource("portforward")
-	log.Infof("porforward url is: ", req.URL())
+	log.V(log.Debuglevel).Info("req ", "url:", req.URL())
 	signals := make(chan os.Signal, 1)
 
 	defer signal.Stop(signals)

--- a/k8s/cmd/commands/util/portforward.go
+++ b/k8s/cmd/commands/util/portforward.go
@@ -44,7 +44,7 @@ const (
 	DeploymentLabel = "app.vineyard.io/name"
 )
 
-func PortforwardDeployment(deploymentName, namespace string, forwardPort, port int, readyChannel, stopChannel chan struct{}) {
+func PortForwardDeployment(deploymentName, namespace string, forwardPort, port int, readyChannel, stopChannel chan struct{}) {
 	restConfig := GetKubernetesConfig()
 	clientSet := KubernetesClientset()
 

--- a/k8s/cmd/commands/util/portforward.go
+++ b/k8s/cmd/commands/util/portforward.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"syscall"
 
+	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
@@ -54,7 +55,7 @@ func PortforwardDeployment(deploymentName, namespace string, forwardPort, port i
 		log.Fatalf(err, "failed to get pods for deployment %s", deploymentName)
 	}
 	if len(podList.Items) == 0 {
-		log.Fatalf(fmt.Errorf("no pods found for deployment %s in namespace %s", deploymentName, namespace), "failed to get pods")
+		log.Fatalf(errors.Errorf("no pods found for deployment %s in namespace %s", deploymentName, namespace), "failed to get pods")
 	}
 
 	podName := podList.Items[0].Name
@@ -75,7 +76,6 @@ func PortforwardDeployment(deploymentName, namespace string, forwardPort, port i
 	if err := forwardPorts("POST", req.URL(), restConfig, stopChannel, readyChannel, forwardPort, port); err != nil {
 		log.Fatal(err, "Fail to forward ports")
 	}
-
 }
 
 func isPortAvailable(port int) bool {

--- a/k8s/cmd/commands/util/portforward.go
+++ b/k8s/cmd/commands/util/portforward.go
@@ -61,7 +61,7 @@ func PortforwardDeployment(deploymentName, namespace string, forwardPort, port i
 
 	req := clientSet.CoreV1().RESTClient().Post().Namespace(namespace).
 		Resource("pods").Name(podName).SubResource("portforward")
-	log.V(log.Debuglevel).Info("req ", "url:", req.URL())
+	log.Info(fmt.Sprintf("req is: %s", req.URL()))
 	signals := make(chan os.Signal, 1)
 
 	defer signal.Stop(signals)

--- a/k8s/cmd/main.go
+++ b/k8s/cmd/main.go
@@ -75,11 +75,22 @@ func init() {
 }
 
 func main() {
-	tryUsageAndDocs()
+	parseFlags()
 	setLogLevel()
+	tryUsageAndDocs()
 	if err := cmd.Execute(); err != nil {
 		log.Fatal(err, "Failed to execute root command")
 	}
+}
+
+func parseFlags() {
+	cmd.FParseErrWhitelist.UnknownFlags = true
+	if err := cmd.ParseFlags(os.Args); err != nil {
+		_ = cmd.Usage()
+		cmd.PrintErrf("\nError when parsing flags: %v\n", err)
+		os.Exit(-1)
+	}
+	cmd.FParseErrWhitelist.UnknownFlags = false
 }
 
 func setLogLevel() {
@@ -90,14 +101,6 @@ func setLogLevel() {
 }
 
 func tryUsageAndDocs() {
-	cmd.FParseErrWhitelist.UnknownFlags = true
-	if err := cmd.ParseFlags(os.Args); err != nil {
-		_ = cmd.Usage()
-		cmd.PrintErrf("\nError when parsing flags: %v\n", err)
-		os.Exit(-1)
-	}
-	cmd.FParseErrWhitelist.UnknownFlags = false
-
 	if flags.DumpUsage {
 		cmd.SetUsageFunc(usage.UsageJson)
 		if err := cmd.Usage(); err != nil {

--- a/k8s/cmd/main.go
+++ b/k8s/cmd/main.go
@@ -24,6 +24,7 @@ import (
 	// import as early as possible to introduce the "version" global flag
 	_ "k8s.io/component-base/version/verflag"
 
+	gosdklog "github.com/v6d-io/v6d/go/vineyard/pkg/common/log"
 	"github.com/v6d-io/v6d/k8s/cmd/commands/client"
 	"github.com/v6d-io/v6d/k8s/cmd/commands/create"
 	"github.com/v6d-io/v6d/k8s/cmd/commands/delete"
@@ -75,8 +76,16 @@ func init() {
 
 func main() {
 	tryUsageAndDocs()
+	setLogLevel()
 	if err := cmd.Execute(); err != nil {
 		log.Fatal(err, "Failed to execute root command")
+	}
+}
+
+func setLogLevel() {
+	if !flags.Verbose {
+		log.SetLogLevel(1)
+		gosdklog.SetLogLevel(1)
 	}
 }
 

--- a/k8s/config/manager/kustomization.yaml
+++ b/k8s/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: vineyardcloudnative/vineyard-operator
+  newName: localhost:5001/vineyard-operator
   newTag: latest

--- a/k8s/pkg/log/log.go
+++ b/k8s/pkg/log/log.go
@@ -31,19 +31,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-const (
-	InfoLevel  = 0
-	Debuglevel = 1
-)
-
 var (
-	defaultLogger = makeDefaultLogger(InfoLevel)
+	defaultLogger = makeDefaultLogger(0)
 	dlog          = log.NewDelegatingLogSink(defaultLogger.GetSink())
 	Log           = Logger{logr.New(dlog).WithName("vineyard")}
 )
 
-func SetVerbose(level int) {
-	defaultLogger = makeDefaultLogger(-level)
+func SetLogLevel(level int) {
+	defaultLogger = makeDefaultLogger(level)
 	dlog.Fulfill(defaultLogger.GetSink())
 }
 

--- a/k8s/pkg/log/log.go
+++ b/k8s/pkg/log/log.go
@@ -105,6 +105,11 @@ func V(level int) Logger {
 	return Logger{Log.V(level)}
 }
 
+// return a logger that discards all logs
+func Discard() {
+	SetLogger(Logger{logr.Discard()})
+}
+
 func WithValues(keysAndValues ...any) Logger {
 	return Logger{Log.WithValues(keysAndValues...)}
 }


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

- Unify the log for vineyardctl
- Add a flag `--debug` in the command `vineyardctl ls` for printing debug info.
- Find an appropriate port for forwarding if it's bound.


Related issue number
--------------------

Fixes part of #1503.

