### PR TITLE
Implement cluster-info API of Golang SDK and add the vineyardctl get cluster-info subcommand 

### DIFF
--- a/go/vineyard/pkg/client/client_base.go
+++ b/go/vineyard/pkg/client/client_base.go
@@ -194,6 +194,21 @@ func (c *ClientBase) GetData(
 	return objects, nil
 }
 
+func (c *ClientBase) GetClusterMeta() (map[string]any, error) {
+	if !c.connected {
+		return nil, NOT_CONNECTED_ERR
+	}
+	messageOut := common.WriteClusterMetaRequest()
+	if err := c.doWrite(messageOut); err != nil {
+		return nil, err
+	}
+	var reply common.ClusterMetaReply
+	if err := c.doReadReply(&reply); err != nil {
+		return nil, err
+	}
+	return reply.Meta.(map[string]any), nil
+}
+
 func (c *ClientBase) Delete(ids []types.ObjectID) error {
 	if !c.connected {
 		return NOT_CONNECTED_ERR

--- a/go/vineyard/pkg/client/ipc_client.go
+++ b/go/vineyard/pkg/client/ipc_client.go
@@ -228,6 +228,13 @@ func (c *IPCClient) GetObject(id types.ObjectID, object IObject) error {
 	return object.Construct(c, meta)
 }
 
+func (c *IPCClient) GetClusterInfo() (map[string]any, error) {
+	if !c.connected {
+		return nil, NOT_CONNECTED_ERR
+	}
+	return c.GetClusterMeta()
+}
+
 func (c *IPCClient) ListMetadata(pattern string, regex bool, limit int) (map[string]map[string]any, error) {
 	if !c.connected {
 		return nil, NOT_CONNECTED_ERR

--- a/go/vineyard/pkg/client/rpc_client.go
+++ b/go/vineyard/pkg/client/rpc_client.go
@@ -117,6 +117,13 @@ func (c *RPCClient) GetMetaData(id types.ObjectID, syncRemote bool) (meta *Objec
 	return meta, nil
 }
 
+func (c *RPCClient) GetClusterInfo() (map[string]any, error) {
+	if !c.connected {
+		return nil, NOT_CONNECTED_ERR
+	}
+	return c.GetClusterMeta()
+}
+
 func (c *RPCClient) ListMetaData(pattern string, regex bool, limit int) (map[string]map[string]any, error) {
 	if !c.connected {
 		return nil, NOT_CONNECTED_ERR

--- a/go/vineyard/pkg/common/protocol.go
+++ b/go/vineyard/pkg/common/protocol.go
@@ -132,8 +132,8 @@ const (
 	IS_IN_USE_REQUEST  = "is_in_use_request"
 	IS_IN_USE_REPLY    = "is_in_use_reply"
 
-	CLUSTER_META_REQUEST    = "cluster_meta_request"
-	CLUSTER_META_REPLY      = "cluster_meta_reply"
+	CLUSTER_META_REQUEST    = "cluster_meta"
+	CLUSTER_META_REPLY      = "cluster_meta"
 	INSTANCE_STATUS_REQUEST = "instance_status_request"
 	INSTANCE_STATUS_REPLY   = "instance_status_reply"
 	MIGRATE_OBJECT_REQUEST  = "migrate_object_request"

--- a/k8s/cmd/README.md
+++ b/k8s/cmd/README.md
@@ -15,6 +15,7 @@ drivers.
 * [vineyardctl create](#vineyardctl-create)	 - Create a vineyard jobs on kubernetes
 * [vineyardctl delete](#vineyardctl-delete)	 - Delete the vineyard components from kubernetes
 * [vineyardctl deploy](#vineyardctl-deploy)	 - Deploy the vineyard components on kubernetes
+* [vineyardctl get](#vineyardctl-get)	 - Get vineyard objects, metadatas, blobs or cluster-info
 * [vineyardctl inject](#vineyardctl-inject)	 - Inject the vineyard sidecar container into a workload
 * [vineyardctl ls](#vineyardctl-ls)	 - List vineyard objects, metadatas or blobs
 * [vineyardctl manager](#vineyardctl-manager)	 - Start the manager of vineyard operator
@@ -1034,6 +1035,85 @@ vineyardctl deploy vineyardd [flags]
       --vineyardd.syncCRDs                            enable metrics of vineyardd (default true)
       --vineyardd.volume.mountPath string             Set the mount path for the pvc
       --vineyardd.volume.pvcname string               Set the pvc name for storing the vineyard objects persistently
+```
+
+## `vineyardctl get`
+
+Get vineyard objects, metadatas, blobs or cluster-info
+
+**SEE ALSO**
+
+* [vineyardctl](#vineyardctl)	 - vineyardctl is the command-line tool for interact with the Vineyard Operator.
+* [vineyardctl get cluster-info](#vineyardctl-get-cluster-info)	 - Get vineyard cluster info
+
+### Examples
+
+```shell
+  # Connect the vineyardd server with IPC client
+  # List the vineyard objects no more than 10
+  vineyardctl ls objects --limit 10 --ipc-socket /var/run/vineyard.sock
+
+  # List the vineyard blobs no more than 10
+  vineyardctl ls blobs --limit 10 --ipc-socket /var/run/vineyard.sock
+
+  # List the vineyard objects with the specified pattern
+  vineyardctl ls objects --pattern "vineyard::Tensor<.*>" --regex --ipc-socket /var/run/vineyard.sock
+
+  # Connect the vineyardd server with RPC client
+  # List the vineyard metadatas no more than 1000
+  vineyardctl ls metadatas --rpc-socket 127.0.0.1:9600 --limit 1000
+
+  # Connect the vineyard deployment with PRC client
+  # List the vineyard objects no more than 1000
+  vineyardctl ls objects --deployment-name vineyardd-sample -n vineyard-system
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+## `vineyardctl get cluster-info`
+
+Get vineyard cluster info
+
+### Synopsis
+
+Get vineyard cluster info, including
+the instanceId, hostName, node name and so on.
+
+```
+vineyardctl get cluster-info [flags]
+```
+
+**SEE ALSO**
+
+* [vineyardctl get](#vineyardctl-get)	 - Get vineyard objects, metadatas, blobs or cluster-info
+
+### Examples
+
+```shell
+  # Get the cluster info of vineyard deployment and output as table
+  vineyardctl get cluster-info --deployment-name vineyardd-sample -n vineyard-system
+
+  # Get the cluster info of vineyard deployment and output as json
+  vineyardctl get cluster-info --deployment-name vineyardd-sample -n vineyard-system -o json
+  
+  # Get the cluster info via IPC socket
+  vineyardctl get cluster-info --ipc-socket /var/run/vineyard.sock
+```
+
+### Options
+
+```
+      --deployment-name string   the name of vineyard deployment
+  -o, --format string            the output format, support table or json, default is table (default "table")
+      --forward-port int         the forward port of vineyard deployment (default 9600)
+  -h, --help                     help for cluster-info
+      --ipc-socket string        vineyard IPC socket path
+      --port int                 the port of vineyard deployment (default 9600)
+      --rpc-socket string        vineyard RPC socket path
 ```
 
 ## `vineyardctl inject`

--- a/k8s/cmd/commands/client/get.go
+++ b/k8s/cmd/commands/client/get.go
@@ -1,0 +1,54 @@
+/*
+* Copyright 2020-2023 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package client
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/v6d-io/v6d/k8s/cmd/commands/util"
+)
+
+var (
+	getExample = util.Examples(`
+	# Connect the vineyardd deployment with IPC client
+	# Get the cluster info and output as table
+	vineyardctl get cluster-info --deployment-name vineyardd-sample -n vineyard-system`)
+)
+
+// getCmd is to get vineyard objects, metadatas, blobs or cluster-info
+var getCmd = &cobra.Command{
+	Use:     "get",
+	Short:   "Get vineyard objects, metadatas, blobs or cluster-info",
+	Example: getExample,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		// disable stdout
+		os.Stdout, _ = os.Open(os.DevNull)
+	},
+	PersistentPostRun: func(cmd *cobra.Command, args []string) {
+		// enable stdout
+		os.Stdout = Stdout
+		Output.Print()
+	},
+}
+
+func NewGetCmd() *cobra.Command {
+	return getCmd
+}
+
+func init() {
+	getCmd.AddCommand(NewGetClusterInfoCmd())
+}

--- a/k8s/cmd/commands/client/get_cluster_info.go
+++ b/k8s/cmd/commands/client/get_cluster_info.go
@@ -1,0 +1,78 @@
+/*
+* Copyright 2020-2023 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package client
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/v6d-io/v6d/k8s/cmd/commands/flags"
+	"github.com/v6d-io/v6d/k8s/cmd/commands/util"
+	"github.com/v6d-io/v6d/k8s/pkg/log"
+)
+
+var (
+	getClusterInfoLong = util.LongDesc(`Get vineyard cluster info, including
+	the instanceId, hostName, node name and so on.`)
+
+	getClusterInfoExample = util.Examples(`
+	# Get the cluster info of vineyard deployment and output as table
+	vineyardctl get cluster-info --deployment-name vineyardd-sample -n vineyard-system
+
+	# Get the cluster info of vineyard deployment and output as json
+	vineyardctl get cluster-info --deployment-name vineyardd-sample -n vineyard-system -o json
+	
+	# Get the cluster info via IPC socket
+	vineyardctl get cluster-info --ipc-socket /var/run/vineyard.sock`)
+)
+
+// getClusterInfo is to get vineyard cluster info
+var getClusterInfo = &cobra.Command{
+	Use:     "cluster-info",
+	Short:   "Get vineyard cluster info",
+	Long:    getClusterInfoLong,
+	Example: getClusterInfoExample,
+	Run: func(cmd *cobra.Command, args []string) {
+		util.AssertNoArgs(cmd, args)
+		// check the client socket
+		util.CheckClientSocket(cmd, args)
+
+		client, ch := util.NewClient()
+		if ch != nil {
+			defer close(ch)
+		}
+
+		// get the cluster info
+		clusterInfo, err := client.GetClusterInfo()
+		if err != nil {
+			log.Fatal(err, "failed to get vineyard cluster info")
+		}
+		output := util.NewOutput(nil, nil, &clusterInfo)
+		// set the output options
+		output.WithFilter(false).
+			SortedKey(flags.SortedKey).
+			SetFormat(flags.Format)
+
+		Output = output
+	},
+}
+
+func NewGetClusterInfoCmd() *cobra.Command {
+	return getClusterInfo
+}
+
+func init() {
+	flags.ApplyConnectOpts(getClusterInfo)
+	flags.ApplyOutputOpts(getClusterInfo)
+}

--- a/k8s/cmd/commands/client/ls.go
+++ b/k8s/cmd/commands/client/ls.go
@@ -42,7 +42,7 @@ var lsExample = util.Examples(`
 	vineyardctl ls objects --deployment-name vineyardd-sample -n vineyard-system`)
 
 var (
-	stdout = os.Stdout
+	Stdout = os.Stdout
 	Output *util.Output
 )
 
@@ -57,7 +57,7 @@ var lsCmd = &cobra.Command{
 	},
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {
 		// enable stdout
-		os.Stdout = stdout
+		os.Stdout = Stdout
 		Output.Print()
 	},
 }

--- a/k8s/cmd/commands/client/ls_blobs.go
+++ b/k8s/cmd/commands/client/ls_blobs.go
@@ -65,7 +65,7 @@ var lsBlobs = &cobra.Command{
 		if err != nil {
 			log.Fatal(err, "failed to list vineyard blobs")
 		}
-		output := util.NewOutput(nil, &blobs)
+		output := util.NewOutput(nil, &blobs, nil)
 		// set the output options
 		output.WithFilter(false).
 			SortedKey(flags.SortedKey).

--- a/k8s/cmd/commands/client/ls_metadatas.go
+++ b/k8s/cmd/commands/client/ls_metadatas.go
@@ -56,18 +56,21 @@ var lsMetadatas = &cobra.Command{
 	Long:    lsMetadatasLong,
 	Example: lsMetadatasExample,
 	Run: func(cmd *cobra.Command, args []string) {
+		//stdout := DisableStdout()
 		util.AssertNoArgs(cmd, args)
+
 		// check the client socket
 		util.CheckClientSocket(cmd, args)
 		client, ch := util.NewClient()
 		if ch != nil {
 			defer close(ch)
 		}
+
 		metas, err := client.ListMetadatas(flags.Pattern, flags.Regex, flags.Limit)
 		if err != nil {
 			log.Fatal(err, "failed to list vineyard objects")
 		}
-		output := util.NewOutput(&metas, nil)
+		output := util.NewOutput(&metas, nil, nil)
 		// set the output options
 		output.WithFilter(false).
 			SortedKey(flags.SortedKey).

--- a/k8s/cmd/commands/client/ls_objects.go
+++ b/k8s/cmd/commands/client/ls_objects.go
@@ -64,7 +64,7 @@ var lsObjects = &cobra.Command{
 		if err != nil {
 			log.Fatal(err, "failed to list vineyard objects")
 		}
-		output := util.NewOutput(&metas, nil)
+		output := util.NewOutput(&metas, nil, nil)
 		// set the output options
 		output.WithFilter(true).
 			SortedKey(flags.SortedKey).

--- a/k8s/cmd/commands/util/objects.go
+++ b/k8s/cmd/commands/util/objects.go
@@ -26,6 +26,7 @@ import (
 type Objects interface {
 	ListMetadatas(string, bool, int) (map[string]map[string]any, error)
 	ListBlobs() (map[types.ObjectID]client.Blob, error)
+	GetClusterInfo() (map[string]map[string]string, error)
 }
 
 // ListMetadatas lists all vineyard metadata
@@ -63,4 +64,15 @@ func (c *Client) ListBlobs(limit int) (map[types.ObjectID]client.Blob, error) {
 		return buffers, nil
 	}
 	return data, errors.Errorf("no ipc client")
+}
+
+// GetClusterInfo returns the cluster info
+func (c *Client) GetClusterInfo() (map[string]any, error) {
+	if c.ipcClient != nil {
+		return c.ipcClient.GetClusterInfo()
+	}
+	if c.rpcClient != nil {
+		return c.rpcClient.GetClusterInfo()
+	}
+	return nil, nil
 }

--- a/k8s/cmd/commands/util/portforward.go
+++ b/k8s/cmd/commands/util/portforward.go
@@ -27,12 +27,12 @@ import (
 	"strconv"
 	"syscall"
 
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
 
+	"github.com/pkg/errors"
 	"github.com/v6d-io/v6d/k8s/pkg/log"
 )
 

--- a/k8s/cmd/main.go
+++ b/k8s/cmd/main.go
@@ -72,6 +72,7 @@ func init() {
 	cmd.AddCommand(schedule.NewScheduleCmd())
 	cmd.AddCommand(sidecar.NewInjectCmd())
 	cmd.AddCommand(client.NewLsCmd())
+	cmd.AddCommand(client.NewGetCmd())
 }
 
 func main() {

--- a/python/pybind11_docs.cc
+++ b/python/pybind11_docs.cc
@@ -785,7 +785,7 @@ The instance id of the connected vineyard server.
 )doc";
 
 const char* ClientBase_meta = R"doc(
-The metadata information of the vineyard server. The value is a  nested dict, the
+The metadata information of the vineyard server. The value is a nested dict, the
 first-level key is the instance id, and the second-level key is the cluster metadata
 fields.
 


### PR DESCRIPTION
What do these changes do?
-------------------------

* Add the get cluster-info API for the golang sdk.
* Add the get cluster-info subcommand for vineyardctl.
* Generate the relevant doc.

Related issue number
--------------------

Fixes part of #1503 

