### PR TITLE
Improve the varint encoding for edges by avoiding copy and extra memory

### DIFF
--- a/modules/graph/fragment/arrow_fragment_builder_impl.h
+++ b/modules/graph/fragment/arrow_fragment_builder_impl.h
@@ -1353,11 +1353,11 @@ BasicArrowFragmentBuilder<OID_T, VID_T, VERTEX_MAP_T, COMPACT>::initEdges(
             << (vineyard::GetCurrentTime() - gen_edge_start_time) << " seconds";
 
   if (this->compact_edges_) {
-    varint_encoding_edges(client_, this->directed_, this->vertex_label_num_,
-                          this->edge_label_num_, ie_lists_, oe_lists_,
-                          compact_ie_lists_, compact_oe_lists_,
-                          ie_offsets_lists_, oe_offsets_lists_,
-                          ie_boffsets_lists_, oe_boffsets_lists_, concurrency);
+    BOOST_LEAF_CHECK(varint_encoding_edges(
+        client_, this->directed_, this->vertex_label_num_,
+        this->edge_label_num_, ie_lists_, oe_lists_, compact_ie_lists_,
+        compact_oe_lists_, ie_offsets_lists_, oe_offsets_lists_,
+        ie_boffsets_lists_, oe_boffsets_lists_, concurrency));
   }
   return {};
 }

--- a/modules/graph/fragment/property_graph_utils.h
+++ b/modules/graph/fragment/property_graph_utils.h
@@ -139,10 +139,10 @@ boost::leaf::result<void> varint_encoding_edges(
     Client& client, const bool directed,
     const property_graph_types::LABEL_ID_TYPE vertex_label_num,
     const property_graph_types::LABEL_ID_TYPE edge_label_num,
-    const std::vector<std::vector<std::shared_ptr<
+    std::vector<std::vector<std::shared_ptr<
         PodArrayBuilder<property_graph_utils::NbrUnit<VID_T, EID_T>>>>>&
         ie_lists,
-    const std::vector<std::vector<std::shared_ptr<
+    std::vector<std::vector<std::shared_ptr<
         PodArrayBuilder<property_graph_utils::NbrUnit<VID_T, EID_T>>>>>&
         oe_lists,
     std::vector<std::vector<std::shared_ptr<FixedUInt8Builder>>>&

--- a/modules/graph/fragment/property_graph_utils_uint32.cc
+++ b/modules/graph/fragment/property_graph_utils_uint32.cc
@@ -101,10 +101,10 @@ template boost::leaf::result<void> varint_encoding_edges<uint32_t, uint64_t>(
     Client& client, const bool directed,
     const property_graph_types::LABEL_ID_TYPE vertex_label_num,
     const property_graph_types::LABEL_ID_TYPE edge_label_num,
-    const std::vector<std::vector<std::shared_ptr<
+    std::vector<std::vector<std::shared_ptr<
         PodArrayBuilder<property_graph_utils::NbrUnit<uint32_t, uint64_t>>>>>&
         ie_lists,
-    const std::vector<std::vector<std::shared_ptr<
+    std::vector<std::vector<std::shared_ptr<
         PodArrayBuilder<property_graph_utils::NbrUnit<uint32_t, uint64_t>>>>>&
         oe_lists,
     std::vector<std::vector<std::shared_ptr<FixedUInt8Builder>>>&

--- a/modules/graph/fragment/property_graph_utils_uint64.cc
+++ b/modules/graph/fragment/property_graph_utils_uint64.cc
@@ -101,10 +101,10 @@ template boost::leaf::result<void> varint_encoding_edges<uint64_t, uint64_t>(
     Client& client, const bool directed,
     const property_graph_types::LABEL_ID_TYPE vertex_label_num,
     const property_graph_types::LABEL_ID_TYPE edge_label_num,
-    const std::vector<std::vector<std::shared_ptr<
+    std::vector<std::vector<std::shared_ptr<
         PodArrayBuilder<property_graph_utils::NbrUnit<uint64_t, uint64_t>>>>>&
         ie_lists,
-    const std::vector<std::vector<std::shared_ptr<
+    std::vector<std::vector<std::shared_ptr<
         PodArrayBuilder<property_graph_utils::NbrUnit<uint64_t, uint64_t>>>>>&
         oe_lists,
     std::vector<std::vector<std::shared_ptr<FixedUInt8Builder>>>&


### PR DESCRIPTION
What do these changes do?
-------------------------

This pull request enhances the previous varint encoding implementation by:

- use serialized, batch encoding (not slow than previous implementation, thanks to batching)
- reuse the ie list when encoding, avoid extra memory allocation and copy
- use the shrink API to adjust the size of the encoded blob writer.

After this pull request, compacting edges with varint no longer requires extra memory, and the encoding execution time has been optimized (almost half) as well.

Fixes #1373