### PR TITLE
set seed for random generator

### DIFF
--- a/modules/graph/utils/grape_utils.h
+++ b/modules/graph/utils/grape_utils.h
@@ -76,6 +76,7 @@ inline std::string normalize_datatype(const std::string& str) {
 }
 
 inline std::string random_string(size_t length) {
+  srand(rand() ^ time(0));
   auto randchar = []() -> char {
     const char charset[] =
         "0123456789"

--- a/modules/graph/utils/grape_utils.h
+++ b/modules/graph/utils/grape_utils.h
@@ -76,7 +76,7 @@ inline std::string normalize_datatype(const std::string& str) {
 }
 
 inline std::string random_string(size_t length) {
-  srand(rand() ^ time(0));
+  srand(rand() ^ time(0));  // NOLINT(runtime/threadsafe_fn)
   auto randchar = []() -> char {
     const char charset[] =
         "0123456789"


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

Set a random seed for random generator.
Previously, if we call `random_string()` multiple times, it would generate identical sequences.

```c++
  for (int i = 0; i < 3; ++i) {
    std::cout << random_string(8) << std::endl;
  }
```

```
>>> ./a.out
5PN2qmWq
BlQ9wQj9
9nsQzldV
>>> ./a.out
5PN2qmWq
BlQ9wQj9
9nsQzldV
>>> ./a.out
5PN2qmWq
BlQ9wQj9
9nsQzldV
```

After this PR, it would be

```
>>> ./a.out
MtqfRb9f
D2k0aoDW
dev7na2Y
>>> ./a.out
jZBd0Tr3
zlueuNCh
R4pewYl5
>>> ./a.out
eBpcBiLE
Fv3L36IS
oA6eo6aY
```

