### PR TITLE
Export the e2e test log when releasing and keep the vineyardd image consistent with the built one

### DIFF
--- a/.github/workflows/vineyard-operator.yaml
+++ b/.github/workflows/vineyard-operator.yaml
@@ -156,12 +156,10 @@ jobs:
           make -C k8s docker-build-push-multi-arch REGISTRY=${{ env.REGISTRY }} VERSION=latest
 
       - name: Generate the python and vineyardd image for tests
-        if: ${{ matrix.job != 'release' }}
         run: |
           make -C k8s/test/e2e build-base-images
 
       - name: Prepare directories for logs
-        if: ${{ matrix.job != 'release' }}
         run: |
           # create log directories for all tasks to prevent the "Path to upload does not exist" warnings
           for job in e2e-tests-airflow-integration \
@@ -186,7 +184,6 @@ jobs:
 
       - name: Start to export kubernetes logs
         uses: dashanji/kubernetes-log-export-action@v5
-        if: ${{ matrix.job != 'release'}}
         env:
           SHOW_TIMESTAMPS: 'true'
           OUTPUT_DIR: ${{ github.workspace }}/${{ matrix.job }}-logs
@@ -276,20 +273,23 @@ jobs:
 
       - name: Stop to export kubernetes logs
         uses: dashanji/kubernetes-log-export-action@v5
-        if: ${{ matrix.job != 'release' && failure() }}
+        if: ${{ failure() }}
         env:
           MODE: stop
           OUTPUT_DIR: ${{ github.workspace }}/${{ matrix.job }}-logs
           WITH_STOAT: true
 
       - uses: stoat-dev/stoat-action@v0
-        if: ${{ matrix.job != 'release' && failure() }}
+        if: ${{ failure() }}
 
       - name: Leave a message for logs URL
-        if: ${{ matrix.job != 'release' && failure() }}
+        if: ${{ failure() }}
         run: |
-          short_sha=$(git rev-parse --short ${{ github.event.pull_request.head.sha }})
-
+          if [[ -n ${{ github.event.pull_request.head.sha }} ]]; then
+              short_sha=$(git rev-parse --short ${{ github.event.pull_request.head.sha }})
+          else
+              short_sha=$(git rev-parse --short ${{ github.event.push.head.sha }})
+          fi
           case ${{ matrix.job }} in
             e2e-tests-spill)
               signed_url_key=0707

--- a/k8s/test/e2e/Makefile
+++ b/k8s/test/e2e/Makefile
@@ -361,6 +361,8 @@ e2e-tests-mars-examples: prepare-e2e-test build-local-cluster load-vineyardd-ima
 ############# vineyardctl testing ################################################
 
 e2e-tests-vineyardctl: prepare-e2e-test build-local-cluster load-vineyardd-image
+	@make -C ${K8S_DIR} install-cert-manager
+	@make -C ${E2E_DIR} install-vineyard-operator
 	@echo "Running vineyardctl e2e test..."
 	@cd ${ROOT_DIR} && ${GOBIN}/e2e run --config=${E2E_DIR}/vineyardctl/e2e.yaml
 	@echo "vineyardctl e2e test passed."

--- a/k8s/test/e2e/vineyardctl/e2e.yaml
+++ b/k8s/test/e2e/vineyardctl/e2e.yaml
@@ -20,9 +20,9 @@ setup:
     - name: download all workflow images into kind cluster
       command: |
         make -C k8s/test/e2e publish-workflow-images REGISTRY=localhost:5001
-    - name: install vineyard cluster(with operator)
+    - name: install vineyardd
       command: |
-        go run k8s/cmd/main.go deploy vineyard-cluster
+        go run k8s/cmd/main.go deploy vineyardd --vineyardd.image="localhost:5001/vineyardd:alpine-latest"
     - name: install job1
       command: |
         kubectl create namespace vineyard-job


### PR DESCRIPTION


<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

* Fix the e2e test log that can't be exported when releasing.
* Keep the vineyardd image consistent with the previously built one.


