### PR TITLE
Fixes vineyardd crash caused by empty environment variable

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,7 +16,8 @@ install-docker-gsa/
 .vscode
 .idea
 .DS_store
-cmake-build-debug
+cmake-build-debug/
+modules/graph/thirdparty/**/build/
 
 # for python packaging
 dist/
@@ -41,7 +42,10 @@ docker/dist/
 docs/_build/
 
 # go vendor
-vendor/
+/**/vendor/
+
+# Rust build
+/**/target/
 
 # k8s
 k8s/bin/

--- a/docker/Dockerfile.vineyardd
+++ b/docker/Dockerfile.vineyardd
@@ -45,6 +45,16 @@ RUN cd /work/v6d && \
     sed -i 's/Boost::regex//g' thirdparty/cpprestsdk/Release/cmake/cpprest_find_boost.cmake && \
     sed -i 's/regex//g' thirdparty/cpprestsdk/Release/cmake/cpprest_find_boost.cmake
 
+# Install libunwind, static linked
+RUN cd /tmp && \
+    curl -LO https://github.com/libunwind/libunwind/releases/download/v1.7.2/libunwind-1.7.2.tar.gz && \
+    tar zxf libunwind-1.7.2.tar.gz && \
+    cd libunwind-1.7.2 && \
+    ./configure --enable-static --disable-shared --enable-debug-frame && \
+    make install -j`nproc` && \
+    cd /tmp && \
+    rm -rf libunwind-1.7.2.tar.gz libunwind-1.7.2/
+
 RUN cd /work/v6d && \
     mkdir -p /work/v6d/build && \
     cd /work/v6d/build && \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -36,6 +36,8 @@ PYTHON_DEV_REGISTRY			:= $(REGISTRY)
 PYTHON_DEV_IMAGE			:= vineyard-python-dev
 PYTHON_DEV_TAG				:= latest_$(PLATFORM)
 
+BUILD_PROGRESS  			?= auto
+
 all: docker-build docker-push
 
 # builder for building standalone vineyardd binary
@@ -43,6 +45,7 @@ builder:
 	docker build ./vineyardd/ \
 		-f ./vineyardd/Dockerfile.alpine-builder \
 		-t $(BUILDER_REGISTRY)/$(BUILDER_IMAGE):$(BUILDER_TAG) \
+		--progress=$(BUILD_PROGRESS) \
 		--build-arg PLATFORM=$(PLATFORM) \
 		--build-arg ARCH=$(ARCH)
 .PHONY: builder
@@ -56,6 +59,7 @@ builder-manifest:
 # building standalone vineyardd
 vineyardd:
 	docker buildx build ../ \
+		--progress=$(BUILD_PROGRESS) \
 		--file ./Dockerfile.vineyardd \
 		-t ghcr.io/v6d-io/v6d/vineyardd:$(ALPINE_TAG) \
 		--load \
@@ -71,6 +75,7 @@ vineyardd-manifest:
 # builder for building python wheel packages
 wheel-builder:
 	docker build ./pypa/ \
+		--progress=$(BUILD_PROGRESS) \
 		-f ./pypa/Dockerfile.manylinux1 \
 		-t $(WHEEL_BUILDER_REGISTRY)/$(WHEEL_BUILDER_IMAGE):$(WHEEL_BUILDER_TAG) \
 		--build-arg PLATFORM=$(PLATFORM) \
@@ -86,6 +91,7 @@ wheel-builder-manifest:
 # building python wheel packages
 python-wheel:
 	docker buildx build ../ \
+		--progress=$(BUILD_PROGRESS) \
 		-f ./pypa/Dockerfile.manylinux1-wheel \
     	-t $(WHEEL_REGISTRY)/$(WHEEL_IMAGE):$(WHEEL_TAG) \
         --build-arg BASE_VERSION=$(WHEEL_BUILDER_MANIFEST_TAG) \
@@ -97,6 +103,7 @@ python-wheel:
 # build dev image
 build-dev:
 	docker build ./dev/ \
+		--progress=$(BUILD_PROGRESS) \
 		-f ./dev/Dockerfile.dev \
 		-t $(DEV_REGISTRY)/$(DEV_IMAGE):$(DEV_TAG)
 .PHONY: build-dev
@@ -104,6 +111,7 @@ build-dev:
 # build python-dev image
 build-python-dev:
 	docker build ../ \
+		--progress=$(BUILD_PROGRESS) \
 		-f ./Dockerfile.vineyard-python-dev \
 		-t $(PYTHON_DEV_REGISTRY)/$(PYTHON_DEV_IMAGE):$(PYTHON_DEV_TAG)
 .PHONY: build-python-dev

--- a/src/server/util/kubectl.cc
+++ b/src/server/util/kubectl.cc
@@ -25,6 +25,7 @@ limitations under the License.
 #include "gulrak/filesystem.hpp"
 
 #include "common/util/asio.h"
+#include "common/util/env.h"
 
 namespace vineyard {
 
@@ -44,9 +45,9 @@ static std::string generate_local_object(
   std::string client_pod_namespace = object.value("POD_NAMESPACE", "\"\"");
 
   InstanceID instance_id = object["instance_id"].get<InstanceID>();
-  std::string vineyardd_name = getenv("VINEYARDD_NAME");
-  std::string namespace_ = getenv("VINEYARDD_NAMESPACE");
-  std::string uid = getenv("VINEYARDD_UID");
+  std::string vineyardd_name = read_env("VINEYARDD_NAME");
+  std::string namespace_ = read_env("VINEYARDD_NAMESPACE");
+  std::string uid = read_env("VINEYARDD_UID");
 
   std::string hostname = "0.0.0.0";
   if (instances.find(instance_id) != instances.end()) {
@@ -97,9 +98,9 @@ static std::string generate_global_object(
   std::string client_pod_name = object.value("POD_NAME", "\"\"");
   std::string client_pod_namespace = object.value("POD_NAMESPACE", "\"\"");
 
-  std::string vineyardd_name = getenv("VINEYARDD_NAME");
-  std::string namespace_ = getenv("VINEYARDD_NAMESPACE");
-  std::string uid = getenv("VINEYARDD_UID");
+  std::string vineyardd_name = read_env("VINEYARDD_NAME");
+  std::string namespace_ = read_env("VINEYARDD_NAMESPACE");
+  std::string uid = read_env("VINEYARDD_UID");
 
   std::string crds;
   for (auto const& kv : object.items()) {
@@ -182,7 +183,7 @@ void Kubectl::Create(const std::string& content, callback_t<> callback) {
     // TODO: improve the error diagnostic
     if (!status.ok()) {
       for (auto const& line : Diagnostic()) {
-        VLOG(10) << "kubectl: " << line;
+        VLOG(10) << "kubectl apply output: " << line;
       }
     }
     return callback(status);
@@ -196,7 +197,7 @@ void Kubectl::Delete(const std::string& content, callback_t<> callback) {
     // TODO: improve the error diagnostic
     if (!status.ok()) {
       for (auto const& line : Diagnostic()) {
-        VLOG(10) << "kubectl: " << line;
+        VLOG(10) << "kubectl delete output: " << line;
       }
     }
     return callback(status);
@@ -206,7 +207,7 @@ void Kubectl::Delete(const std::string& content, callback_t<> callback) {
 void Kubectl::Finish() {
   proc_->Finish();
   for (auto const& line : Diagnostic()) {
-    VLOG(10) << "kubectl apply: " << line;
+    VLOG(10) << "kubectl output: " << line;
   }
   proc_->Wait();
   VLOG(10) << "kubectl exit with: " << proc_->ExitCode();


### PR DESCRIPTION
What do these changes do?
-------------------------

Add libunwind to the vineyardd as well during docker build.

Related issue number
--------------------

Fixes #1535

