### PR TITLE
Bump up k8s logs exporter to v6 for debugging

### DIFF
--- a/.github/workflows/vineyard-operator.yaml
+++ b/.github/workflows/vineyard-operator.yaml
@@ -183,11 +183,12 @@ jobs:
           done
 
       - name: Start to export kubernetes logs
-        uses: dashanji/kubernetes-log-export-action@v5
+        uses: dashanji/kubernetes-log-export-action@v6
         env:
           SHOW_TIMESTAMPS: 'true'
           OUTPUT_DIR: ${{ github.workspace }}/${{ matrix.job }}-logs
           NAMESPACES: vineyard*
+          RESOURCES: configmap
           MODE: start
 
       - name: e2e-tests-airflow-integration
@@ -272,7 +273,7 @@ jobs:
           make -C k8s/test/e2e e2e-tests-deploy-raw-backup-and-recover
 
       - name: Stop to export kubernetes logs
-        uses: dashanji/kubernetes-log-export-action@v5
+        uses: dashanji/kubernetes-log-export-action@v6
         if: ${{ failure() }}
         env:
           MODE: stop


### PR DESCRIPTION
What do these changes do?
-------------------------

Debug such error https://github.com/v6d-io/v6d/actions/runs/5960338972/job/16167472211



