### PR TITLE
Unify the vineyardd images in the vineyard operator e2e tests

### DIFF
--- a/docs/notes/cloud-native/deploy-kubernetes.rst
+++ b/docs/notes/cloud-native/deploy-kubernetes.rst
@@ -122,7 +122,7 @@ replicas:
         type: ClusterIP
         port: 9600
       vineyard:
-        image: vineyardcloudnative/vineyardd:alpine-latest
+        image: vineyardcloudnative/vineyardd:latest
         imagePullPolicy: IfNotPresent
     EOF
 

--- a/k8s/pkg/templates/etcd/etcd.yaml
+++ b/k8s/pkg/templates/etcd/etcd.yaml
@@ -27,6 +27,7 @@ spec:
   containers:
   - name: etcd
     image: {{ $etcd.Image }}
+    imagePullPolicy: IfNotPresent
     command:
     - etcd
     - --name

--- a/k8s/test/e2e/Makefile
+++ b/k8s/test/e2e/Makefile
@@ -25,8 +25,8 @@ push-%: %
 
 # update the docker image for vineyardd & vineyard-operator inside the kind cluster
 load-vineyardd-image:
-	@docker tag vineyardcloudnative/vineyardd:alpine-latest localhost:5001/vineyardd:alpine-latest
-	@docker push localhost:5001/vineyardd:alpine-latest
+	@docker tag vineyardcloudnative/vineyardd:latest localhost:5001/vineyardd:latest
+	@docker push localhost:5001/vineyardd:latest
 .PHONY: load-vineyardd-image
 
 load-vineyard-operator-image:
@@ -51,7 +51,7 @@ build-base-images:
 	@docker tag ghcr.io/v6d-io/v6d/vineyard-python-dev:latest_x86_64 ghcr.io/v6d-io/v6d/vineyard-python-dev:latest
 	@echo "Building the vineyardd image"
 	@make -C ${ROOT_DIR}/docker vineyardd
-	@docker tag ghcr.io/v6d-io/v6d/vineyardd:alpine-latest_x86_64 vineyardcloudnative/vineyardd:alpine-latest
+	@docker tag ghcr.io/v6d-io/v6d/vineyardd:alpine-latest_x86_64 vineyardcloudnative/vineyardd:latest
 
 # Build a 4-nodes(1 master and 3 workers) kind cluster with local registry
 build-local-cluster:

--- a/k8s/test/e2e/airflow-integration/e2e.yaml
+++ b/k8s/test/e2e/airflow-integration/e2e.yaml
@@ -20,7 +20,7 @@ setup:
     - name: create the vineyard deployment
       command: |
         go run k8s/cmd/main.go deploy vineyard-deployment \
-          --vineyardd.image="localhost:5001/vineyardd:alpine-latest" \
+          --vineyardd.image="localhost:5001/vineyardd:latest" \
           --create-namespace
     - name: deploy the airflow
       command: |

--- a/k8s/test/e2e/deploy-raw-backup-and-recover/e2e.yaml
+++ b/k8s/test/e2e/deploy-raw-backup-and-recover/e2e.yaml
@@ -25,7 +25,7 @@ setup:
     - name: deploy the vineyard deployment
       command: |
         go run k8s/cmd/main.go deploy vineyard-deployment \
-          --vineyardd.image="localhost:5001/vineyardd:alpine-latest" \
+          --vineyardd.image="localhost:5001/vineyardd:latest" \
           --pluginImage.backupImage="localhost:5001/backup-job" \
           --pluginImage.recoverImage="localhost:5001/recover-job" \
           --pluginImage.daskRepartitionImage="localhost:5001/dask-repartition" \
@@ -132,7 +132,7 @@ setup:
     - name: reinstall vineyardd
       command: |
         go run k8s/cmd/main.go deploy vineyard-deployment \
-          --vineyardd.image="localhost:5001/vineyardd:alpine-latest" \
+          --vineyardd.image="localhost:5001/vineyardd:latest" \
           --pluginImage.backupImage="localhost:5001/backup-job" \
           --pluginImage.recoverImage="localhost:5001/recover-job" \
           --pluginImage.daskRepartitionImage="localhost:5001/dask-repartition" \

--- a/k8s/test/e2e/schedule-workflow-without-crd/e2e.yaml
+++ b/k8s/test/e2e/schedule-workflow-without-crd/e2e.yaml
@@ -20,7 +20,7 @@ setup:
     - name: apply the vineyard deployment
       command: |
         go run k8s/cmd/main.go deploy vineyard-deployment \
-          --vineyardd.image="localhost:5001/vineyardd:alpine-latest" \
+          --vineyardd.image="localhost:5001/vineyardd:latest" \
           --create-namespace
     - name: scheduling workload
       command: |

--- a/k8s/test/e2e/schedule-workload/e2e.yaml
+++ b/k8s/test/e2e/schedule-workload/e2e.yaml
@@ -19,7 +19,7 @@ setup:
   steps:
     - name: deploy the vineyard deployment
       command: |
-        go run k8s/cmd/main.go deploy vineyard-deployment --vineyardd.image="localhost:5001/vineyardd:alpine-latest" --create-namespace
+        go run k8s/cmd/main.go deploy vineyard-deployment --vineyardd.image="localhost:5001/vineyardd:latest" --create-namespace
     - name: schedule the produce workload
       command: |
         kubectl create ns vineyard-job

--- a/k8s/test/e2e/sidecar-demo/sidecar-with-custom-sidecar.yaml
+++ b/k8s/test/e2e/sidecar-demo/sidecar-with-custom-sidecar.yaml
@@ -22,6 +22,7 @@ spec:
   replicas: 2
   selector: app=job-deployment-with-custom-sidecar
   vineyard:
+    image: localhost:5001/vineyardd:latest
     socket: /var/run/vineyard.sock
 ---
 apiVersion: apps/v1

--- a/k8s/test/e2e/sidecar/e2e.yaml
+++ b/k8s/test/e2e/sidecar/e2e.yaml
@@ -25,7 +25,7 @@ setup:
       command: |
         kubectl create namespace vineyard-job
         go run k8s/cmd/main.go inject -f k8s/test/e2e/sidecar-demo/sidecar-with-default-sidecar.yaml --apply-resources\
-        | kubectl apply -f -
+            --sidecar.image="localhost:5001/vineyardd:latest"| kubectl apply -f -
       wait:
         - namespace: vineyard-job
           resource: deployment/job-deployment-with-default-sidecar

--- a/k8s/test/e2e/spill-demo/vineyardd-with-spill.yaml
+++ b/k8s/test/e2e/spill-demo/vineyardd-with-spill.yaml
@@ -25,7 +25,7 @@ spec:
     type: ClusterIP
     port: 9600
   vineyard:
-    image: localhost:5001/vineyardd:alpine-latest
+    image: localhost:5001/vineyardd:latest
     imagePullPolicy: IfNotPresent
     size: "2048"
     # spill configuration

--- a/k8s/test/e2e/vineyardctl/e2e.yaml
+++ b/k8s/test/e2e/vineyardctl/e2e.yaml
@@ -22,7 +22,7 @@ setup:
         make -C k8s/test/e2e publish-workflow-images REGISTRY=localhost:5001
     - name: install vineyardd
       command: |
-        go run k8s/cmd/main.go deploy vineyardd --vineyardd.image="localhost:5001/vineyardd:alpine-latest"
+        go run k8s/cmd/main.go deploy vineyardd --vineyardd.image="localhost:5001/vineyardd:latest"
     - name: install job1
       command: |
         kubectl create namespace vineyard-job

--- a/k8s/test/e2e/vineyardd.yaml
+++ b/k8s/test/e2e/vineyardd.yaml
@@ -25,7 +25,7 @@ spec:
     type: ClusterIP
     port: 9600
   vineyard:
-    image: localhost:5001/vineyardd:alpine-latest
+    image: localhost:5001/vineyardd:latest
     imagePullPolicy: IfNotPresent
   # Users can define their own plugin image here,
   # the next images are only for kubernetes CI test.


### PR DESCRIPTION
What do these changes do?
-------------------------

As the vineyardd image is defined as `vineyardcloudnative/vineyardd:latest` in our CRD apis and the args of vineyardctl. It's better to only keep one tag `latest` rather than `alpine-latest` and `latest` in the e2e test. 



