### PR TITLE
Enhance the integrated hive module: add vineyard format descriptor and fixes FS.renameInternal

### DIFF
--- a/java/hive/src/main/java/io/v6d/hive/ql/io/VineyardFileStorageFormatDescriptor.java
+++ b/java/hive/src/main/java/io/v6d/hive/ql/io/VineyardFileStorageFormatDescriptor.java
@@ -1,0 +1,41 @@
+/** Copyright 2020-2023 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.v6d.hive.ql.io;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import org.apache.hadoop.hive.ql.io.AbstractStorageFormatDescriptor;
+
+public class VineyardFileStorageFormatDescriptor extends AbstractStorageFormatDescriptor {
+    @Override
+    public Set<String> getNames() {
+        return ImmutableSet.of("VineyardFile", "VineyardFile");
+    }
+
+    @Override
+    public String getInputFormat() {
+        return VineyardInputFormat.class.getName();
+    }
+
+    @Override
+    public String getOutputFormat() {
+        return VineyardOutputFormat.class.getName();
+    }
+
+    @Override
+    public String getSerde() {
+        return VineyardSerDe.class.getName();
+    }
+}

--- a/java/hive/src/main/java/io/v6d/hive/ql/io/VineyardFileStorageFormatDescriptor.java
+++ b/java/hive/src/main/java/io/v6d/hive/ql/io/VineyardFileStorageFormatDescriptor.java
@@ -21,7 +21,7 @@ import org.apache.hadoop.hive.ql.io.AbstractStorageFormatDescriptor;
 public class VineyardFileStorageFormatDescriptor extends AbstractStorageFormatDescriptor {
     @Override
     public Set<String> getNames() {
-        return ImmutableSet.of("VineyardFile", "VineyardFile");
+        return ImmutableSet.of("Vineyard", "Vineyard");
     }
 
     @Override

--- a/java/hive/src/main/java/io/v6d/hive/ql/io/VineyardOutputFormat.java
+++ b/java/hive/src/main/java/io/v6d/hive/ql/io/VineyardOutputFormat.java
@@ -206,9 +206,7 @@ class SinkRecordWriter implements FileSinkOperator.RecordWriter {
         output.write((meta.getId().toString() + "\n").getBytes(StandardCharsets.UTF_8));
         client.putName(
                 meta.getId(),
-                finalOutPath
-                        .toString()
-                        .substring(finalOutPath.toString().indexOf("vineyard:") + 1));
+                finalOutPath.toString().substring(finalOutPath.toString().indexOf(":") + 1));
         output.close();
     }
 

--- a/java/hive/src/main/java/io/v6d/hive/ql/io/VineyardStorageFormatDescriptor.java
+++ b/java/hive/src/main/java/io/v6d/hive/ql/io/VineyardStorageFormatDescriptor.java
@@ -18,7 +18,7 @@ import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 import org.apache.hadoop.hive.ql.io.AbstractStorageFormatDescriptor;
 
-public class VineyardFileStorageFormatDescriptor extends AbstractStorageFormatDescriptor {
+public class VineyardStorageFormatDescriptor extends AbstractStorageFormatDescriptor {
     @Override
     public Set<String> getNames() {
         return ImmutableSet.of("Vineyard", "Vineyard");

--- a/java/hive/src/main/resources/META-INF/services/org.apache.hadoop.hive.ql.io.StorageFormatDescriptor
+++ b/java/hive/src/main/resources/META-INF/services/org.apache.hadoop.hive.ql.io.StorageFormatDescriptor
@@ -1,0 +1,19 @@
+# Copyright 2020-2023 Alibaba Group Holding Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Register vineyard filesystem to hadoop-fs, see also:
+#  - https://stackoverflow.com/questions/17265002/hadoop-no-filesystem-for-scheme-file
+#  - https://github.com/apache/hadoop/blob/trunk/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java#L3510
+
+io.v6d.hive.ql.io.VineyardFileStorageFormatDescriptor

--- a/java/hive/src/main/resources/META-INF/services/org.apache.hadoop.hive.ql.io.StorageFormatDescriptor
+++ b/java/hive/src/main/resources/META-INF/services/org.apache.hadoop.hive.ql.io.StorageFormatDescriptor
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Register vineyard storage format descriptor to hadoop.
+# Register vineyard storage format descriptor to hive.
 
-io.v6d.hive.ql.io.VineyardFileStorageFormatDescriptor
+io.v6d.hive.ql.io.VineyardStorageFormatDescriptor

--- a/java/hive/src/main/resources/META-INF/services/org.apache.hadoop.hive.ql.io.StorageFormatDescriptor
+++ b/java/hive/src/main/resources/META-INF/services/org.apache.hadoop.hive.ql.io.StorageFormatDescriptor
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Register vineyard filesystem to hadoop-fs, see also:
-#  - https://stackoverflow.com/questions/17265002/hadoop-no-filesystem-for-scheme-file
-#  - https://github.com/apache/hadoop/blob/trunk/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java#L3510
+# Register vineyard storage format descriptor to hadoop.
 
 io.v6d.hive.ql.io.VineyardFileStorageFormatDescriptor


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

<!-- Please give a short brief about these changes. -->
- Support access to tables created by other users in the vineyard
- Support point out storage as vineyard instead of pointing out io format.
- ...
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1420 

