### PR TITLE
Delete upx for vineyardctl on the macos machine as test failed.

### DIFF
--- a/.github/workflows/build-vineyardd-and-wheels-macos.yaml
+++ b/.github/workflows/build-vineyardd-and-wheels-macos.yaml
@@ -235,8 +235,6 @@ jobs:
 
           go build -a -o vineyardctl k8s/cmd/main.go
           strip ./vineyardctl || true
-          brew install upx || true
-          upx -9 ./vineyardctl || true
 
       - name: Upload wheels to tagged release
         uses: svenstaro/upload-release-action@v2

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -69,7 +69,6 @@ vineyardctl: generate fmt
 bdist_wheel:
 	@cp vineyardctl ../python/vineyard/bdist/vineyardctl
 	@strip ../python/vineyard/bdist/vineyardctl
-	@upx -9 ../python/vineyard/bdist/vineyardctl
 
 # Run vineyardctl binary
 .PHONY: run


### PR DESCRIPTION
What do these changes do?
-------------------------

As titled. Failed on the macos (arm64/amd64).

/cc @zhuyi1159 


