### PR TITLE
Delete the latest tag so that the helm chart use the Chart.AppVersion as the image tag

### DIFF
--- a/charts/vineyard-operator/values.yaml
+++ b/charts/vineyard-operator/values.yaml
@@ -23,7 +23,6 @@ controllerManager:
   manager:
     image:
       repository: vineyardcloudnative/vineyard-operator
-      tag: latest
     imagePullPolicy: IfNotPresent
     resources:
       limits:

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -287,5 +287,6 @@ generate-helm-chart: helmify kustomize
 	cd ../charts && $(KUSTOMIZE) build ../k8s/config/default | $(HELMIFY) --cert-manager-as-subchart vineyard-operator && \
 	sed -i 's/\/var\/run\/vineyard-kubernetes\/{{.Namespace}}\/{{.Name}}/\/var\/run\/vineyard-kubernetes\/{{ \"{{.Namespace}}\/{{.Name}}\" }}/g' \
 	vineyard-operator/templates/vineyardd-crd.yaml && \
+	sed -i '/tag: latest/d' vineyard-operator/values.yaml && \
 	sed -i 's/certManager/cert-manager/g' vineyard-operator/values.yaml && \
 	sed -i '4i\  extraArgs:\n    - --enable-certificate-owner-ref=true' vineyard-operator/values.yaml


### PR DESCRIPTION
What do these changes do?
-------------------------

As titled.


Related issue number
--------------------

Fixes #1571 

