### PR TITLE
Fix the error in the helm chart e2e test and the sha not exposed in the push event

### DIFF
--- a/.github/workflows/vineyard-operator.yaml
+++ b/.github/workflows/vineyard-operator.yaml
@@ -297,11 +297,8 @@ jobs:
       - name: Leave a message for logs URL
         if: ${{ failure() }}
         run: |
-          if [[ -n ${{ github.event.pull_request.head.sha }} ]]; then
-              short_sha=$(git rev-parse --short ${{ github.event.pull_request.head.sha }})
-          else
-              short_sha=$(git rev-parse --short ${{ github.event.push.head.sha }})
-          fi
+          sha=${{ github.event.pull_request.head.sha || github.sha }}
+          short_sha=$(git rev-parse --short $sha)
           case ${{ matrix.job }} in
             e2e-tests-spill)
               signed_url_key=0707

--- a/k8s/test/e2e/autogenerated-helm-chart/e2e.yaml
+++ b/k8s/test/e2e/autogenerated-helm-chart/e2e.yaml
@@ -27,7 +27,8 @@ setup:
         helm install vineyard-operator charts/vineyard-operator \
             --create-namespace \
             --namespace vineyard-system \
-            --set controllerManager.manager.image.repository=localhost:5001/vineyard-operator
+            --set controllerManager.manager.image.repository=localhost:5001/vineyard-operator \
+            --set controllerManager.manager.image.tag=latest
       wait:
         - namespace: vineyard-system
           resource: deployment/vineyard-operator-controller-manager


### PR DESCRIPTION
What do these changes do?
-------------------------

* Use the latest tag for the vineyard operator image in the generated helm chart e2e test.
* Fix the sha not exposed in the push event.


