### PR TITLE
Remove the validation about inconsitent property type between different labels

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -118,9 +118,7 @@ jobs:
                               protobuf-compiler-grpc \
                               python3-pip \
                               uuid-dev \
-                              wget\
-                              default-jdk\
-                              maven
+                              wget
 
           # install apache-arrow
           wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
@@ -133,6 +131,9 @@ jobs:
                               libparquet-dev=11.0.0-1 \
                               libplasma-dev=11.0.0-1 \
                               libarrow-cuda-dev=11.0.0-1
+
+          # install deps for java
+          sudo apt install -y default-jdk-headless maven
 
           # install clang-format
           sudo curl -L https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-1d7ec53d/clang-format-11_linux-amd64 --output /usr/bin/clang-format

--- a/modules/graph/fragment/graph_schema.cc
+++ b/modules/graph/fragment/graph_schema.cc
@@ -693,22 +693,6 @@ bool PropertyGraphSchema::Validate(std::string& message) {
   std::sort(
       all_props.begin(), all_props.end(),
       [](const auto& lhs, const auto& rhs) { return lhs.name < rhs.name; });
-
-  for (size_t i = 1; i < all_props.size(); ++i) {
-    if (all_props[i].name == all_props[i - 1].name &&
-        !all_props[i].type->Equals(all_props[i - 1].type)) {
-      std::stringstream ss;
-      ss << "The <property_name, property_type> pair should be unique across "
-            "the Graph";
-      ss << " Found two pairs <" << all_props[i].name << ", "
-         << all_props[i].type->ToString();
-      ss << "> and <" << all_props[i - 1].name << ", "
-         << all_props[i - 1].type->ToString();
-      ss << ">.";
-      message = ss.str();
-      return false;
-    }
-  }
   return true;
 }
 const std::map<std::string, int>&


### PR DESCRIPTION
As GIE no longer requires it and it causes some trouble for GAE users.