### PR TITLE
[GraphAr] Align the vertices of fragment to vertex chunk size & Fix the shuffle array multi-thread bug & Bump up GraphAr 

### DIFF
--- a/modules/graph/fragment/gar_fragment_builder.h
+++ b/modules/graph/fragment/gar_fragment_builder.h
@@ -53,7 +53,9 @@ class GARFragmentBuilder
                               std::shared_ptr<vertex_map_t> vm_ptr)
       : ArrowFragmentBaseBuilder<oid_t, vid_t, vertex_map_t>(client),
         client_(client),
-        vm_ptr_(vm_ptr) {}
+        vm_ptr_(vm_ptr) {
+    Base::set_compact_edges_(false);
+  }
 
   vineyard::Status Build(vineyard::Client& client) override;
 

--- a/modules/graph/fragment/gar_fragment_builder.h
+++ b/modules/graph/fragment/gar_fragment_builder.h
@@ -55,6 +55,9 @@ class GARFragmentBuilder
         client_(client),
         vm_ptr_(vm_ptr) {
     Base::set_compact_edges_(false);
+    VINEYARD_ASSERT(
+        !Base::compact_edges_,
+        "Compacting edges is not supported when loading from GraphAr.");
   }
 
   vineyard::Status Build(vineyard::Client& client) override;

--- a/modules/graph/fragment/gar_fragment_builder_impl.h
+++ b/modules/graph/fragment/gar_fragment_builder_impl.h
@@ -146,8 +146,8 @@ boost::leaf::result<void> generate_csr(
       memcpy(offsets_buffer->mutable_data(),
              reinterpret_cast<const uint8_t*>(offset_array->raw_values()),
              offset_array->length() * sizeof(int64_t));
-      // we not store the edge offset of outer vertices, so fill edge_num of the
-      // outer vertices
+      // we do not store the edge offset of outer vertices, so fill edge_num
+      // to the outer vertices offset
       std::fill_n(
           reinterpret_cast<int64_t*>(offsets_buffer->mutable_data() +
                                      offset_array->length() * sizeof(int64_t)),
@@ -468,10 +468,6 @@ GARFragmentBuilder<OID_T, VID_T, VERTEX_MAP_T>::initEdges(
             client_, vid_parser_, std::move(csc_edge_dst[e_label]),
             std::move(csc_edge_src[e_label]), tvnums_, this->vertex_label_num_,
             concurrency, sub_ie_lists, sub_ie_offset_lists);
-        LOG(INFO) << "reuse the offset array: tvnum_" << tvnums_[1]
-                  << ", edge_label: " << e_label
-                  << " sub_oe_offset_lists size: "
-                  << sub_ie_offset_lists[1]->length();
       } else {
         generate_csr<vid_t, eid_t>(
             client_, vid_parser_, std::move(csc_edge_dst[e_label]),

--- a/modules/graph/loader/gar_fragment_loader.cc
+++ b/modules/graph/loader/gar_fragment_loader.cc
@@ -1,0 +1,37 @@
+/** Copyright 2020-2023 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifdef ENABLE_GAR
+
+#include "graph/loader/gar_fragment_loader.h"
+
+#include "arrow/api.h"
+#include "gar/graph_info.h"
+
+namespace vineyard {
+
+std::shared_ptr<arrow::Schema> ConstructSchemaFromPropertyGroup(
+    const GraphArchive::PropertyGroup& property_group) {
+  std::vector<std::shared_ptr<arrow::Field>> fields;
+  for (const auto& prop : property_group.GetProperties()) {
+    fields.emplace_back(arrow::field(
+        prop.name, GraphArchive::DataType::DataTypeToArrowDataType(prop.type)));
+  }
+  return arrow::schema(fields);
+}
+
+}  // namespace vineyard
+
+#endif  // ENABLE_GAR

--- a/modules/graph/loader/gar_fragment_loader.h
+++ b/modules/graph/loader/gar_fragment_loader.h
@@ -44,10 +44,14 @@ limitations under the License.
 namespace GraphArchive {
 class GraphInfo;
 class EdgeInfo;
+class PropertyGroup;
 enum class AdjListType : std::uint8_t;
 }  // namespace GraphArchive
 
 namespace vineyard {
+
+std::shared_ptr<arrow::Schema> ConstructSchemaFromPropertyGroup(
+    const GraphArchive::PropertyGroup& property_group);
 
 template <typename OID_T = property_graph_types::OID_TYPE,
           typename VID_T = property_graph_types::VID_TYPE,

--- a/modules/graph/writer/arrow_fragment_writer.h
+++ b/modules/graph/writer/arrow_fragment_writer.h
@@ -64,6 +64,9 @@ void InitializeArrayArrayBuilders(
     const property_graph_types::LABEL_ID_TYPE edge_label,
     const PropertyGraphSchema& graph_schema);
 
+std::shared_ptr<arrow::Table> AppendNullsToArrowTable(
+    const std::shared_ptr<arrow::Table>& table, size_t num_rows_to_append);
+
 template <typename FRAG_T>
 class ArrowFragmentWriter {
   using oid_t = typename FRAG_T::oid_t;
@@ -118,6 +121,7 @@ class ArrowFragmentWriter {
   std::shared_ptr<ArrowFragment<oid_t, vid_t>> frag_;
   grape::CommSpec comm_spec_;
   std::shared_ptr<GraphArchive::GraphInfo> graph_info_;
+  std::map<label_id_t, int64_t> label_id_to_vnum_;
 };
 
 }  // namespace vineyard

--- a/modules/graph/writer/arrow_fragment_writer_impl.h
+++ b/modules/graph/writer/arrow_fragment_writer_impl.h
@@ -110,6 +110,7 @@ boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::WriteVertex(
   auto num_rows = vertex_table->num_rows();
   if (frag_->fid() != frag_->fnum() - 1 &&
       num_rows % vertex_info.GetChunkSize() != 0) {
+    // Append nulls if the number of rows is not a multiple of chunk size.
     vertex_table = AppendNullsToArrowTable(
         vertex_table,
         vertex_info.GetChunkSize() - num_rows % vertex_info.GetChunkSize());

--- a/modules/graph/writer/arrow_fragment_writer_impl.h
+++ b/modules/graph/writer/arrow_fragment_writer_impl.h
@@ -65,6 +65,7 @@ template <typename FRAG_T>
 boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::WriteFragment() {
   BOOST_LEAF_CHECK(WriteVertices());
   BOOST_LEAF_CHECK(WriteEdges());
+  MPI_Barrier(comm_spec_.comm());
   return {};
 }
 
@@ -106,14 +107,24 @@ boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::WriteVertex(
                                             graph_info_->GetPrefix());
   // write vertex data start from chunk index begin
   auto vertex_table = frag_->vertex_data_table(label_id);
+  auto num_rows = vertex_table->num_rows();
+  if (frag_->fid() != frag_->fnum() - 1 &&
+      num_rows % vertex_info.GetChunkSize() != 0) {
+    vertex_table = AppendNullsToArrowTable(
+        vertex_table,
+        vertex_info.GetChunkSize() - num_rows % vertex_info.GetChunkSize());
+  }
   auto st = writer.WriteTable(vertex_table, chunk_index_begin);
   if (!st.ok()) {
     RETURN_GS_ERROR(ErrorCode::kGraphArError, st.message());
   }
 
-  if (comm_spec_.worker_id() == 0) {
+  if (frag_->fid() == frag_->fnum() - 1) {
     // write vertex number
-    auto st = writer.WriteVerticesNum(vm_ptr->GetTotalNodesNum(label_id));
+    auto total_vertices_num = chunk_index_begin * vertex_info.GetChunkSize() +
+                              vertex_table->num_rows();
+    label_id_to_vnum_[label_id] = total_vertices_num;
+    auto st = writer.WriteVerticesNum(total_vertices_num);
     if (!st.ok()) {
       RETURN_GS_ERROR(ErrorCode::kGraphArError, st.message());
     }
@@ -381,10 +392,9 @@ boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::writeEdgeImpl(
           "GAR error: " + std::to_string(static_cast<int>(st.code())) + ", " +
           st.message());
     }
-    if (comm_spec_.worker_id() == 0) {
+    if (frag_->fid() == frag_->fnum() - 1) {
       // write vertex number
-      auto st = writer.WriteVerticesNum(
-          frag_->GetVertexMap()->GetTotalNodesNum(main_label_id));
+      auto st = writer.WriteVerticesNum(label_id_to_vnum_.at(main_label_id));
       if (!st.ok()) {
         return Status::IOError(
             "GAR error: " + std::to_string(static_cast<int>(st.code())) + ", " +

--- a/modules/graph/writer/arrow_fragment_writer_string.cc
+++ b/modules/graph/writer/arrow_fragment_writer_string.cc
@@ -1,0 +1,26 @@
+/** Copyright 2020-2023 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifdef ENABLE_GAR
+
+#include "graph/writer/arrow_fragment_writer_impl.h"
+
+namespace vineyard {
+
+template class ArrowFragmentWriter<ArrowFragment<std::string, uint64_t>>;
+
+}  // namespace vineyard
+
+#endif  // ENABLE_GA


### PR DESCRIPTION

What do these changes do?
-------------------------
- Align the vertices of fragment to vertex chunk size by append nulls, so the multi-fragment writer out to gar format also correct
- Fix the gar loader shuffle oid array bug: remove the multi-thread implementation since that shuffle already use thread to send/recv, that would make message conflict
- Bump up GraphAr to support build with local installed arrow.


Related issue number
--------------------
TBF

Fixes #issue number

