### PR TITLE
Support to track the chunks by local objects for kubernetes workflow.

### DIFF
--- a/k8s/test/e2e/kind-with-local-registry.yaml
+++ b/k8s/test/e2e/kind-with-local-registry.yaml
@@ -6,10 +6,10 @@ containerdConfigPatches:
     endpoint = ["http://kind-registry:5000"]
 nodes:
 - role: control-plane
-  image: kindest/node:v1.24.0
+  image: kindest/node:v1.25.11
 - role: worker
-  image: kindest/node:v1.24.0
+  image: kindest/node:v1.25.11
 - role: worker
-  image: kindest/node:v1.24.0
+  image: kindest/node:v1.25.11
 - role: worker
-  image: kindest/node:v1.24.0
+  image: kindest/node:v1.25.11

--- a/k8s/test/e2e/kind.yaml
+++ b/k8s/test/e2e/kind.yaml
@@ -17,10 +17,10 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.24.0
+  image: kindest/node:v1.25.11
 - role: worker
-  image: kindest/node:v1.24.0
+  image: kindest/node:v1.25.11
 - role: worker
-  image: kindest/node:v1.24.0
+  image: kindest/node:v1.25.11
 - role: worker
-  image: kindest/node:v1.24.0
+  image: kindest/node:v1.25.11


### PR DESCRIPTION
What do these changes do?
-------------------------

With it, we can schedule the workloads that only produce the localobjects.

