### PR TITLE
Use arrow's string array to place string columns in vineyard

### DIFF
--- a/.github/workflows/build-test-graph.yml
+++ b/.github/workflows/build-test-graph.yml
@@ -105,12 +105,12 @@ jobs:
           wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
           sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
           sudo apt update
-          sudo apt install -y libarrow-dev=14.0.0-1 \
-                              libarrow-dataset-dev=14.0.0-1 \
-                              libarrow-acero-dev=14.0.0-1 \
-                              libarrow-flight-dev=14.0.0-1 \
-                              libgandiva-dev=14.0.0-1 \
-                              libparquet-dev=14.0.0-1
+          sudo apt install -y libarrow-dev=14.0.1-1 \
+                              libarrow-dataset-dev=14.0.1-1 \
+                              libarrow-acero-dev=14.0.1-1 \
+                              libarrow-flight-dev=14.0.1-1 \
+                              libgandiva-dev=14.0.1-1 \
+                              libparquet-dev=14.0.1-1
 
           # install clang-format
           sudo curl -L https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-1d7ec53d/clang-format-11_linux-amd64 --output /usr/bin/clang-format

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -124,12 +124,12 @@ jobs:
           wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
           sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
           sudo apt update
-          sudo apt install -y libarrow-dev=14.0.0-1 \
-                              libarrow-dataset-dev=14.0.0-1 \
-                              libarrow-acero-dev=14.0.0-1 \
-                              libarrow-flight-dev=14.0.0-1 \
-                              libgandiva-dev=14.0.0-1 \
-                              libparquet-dev=14.0.0-1
+          sudo apt install -y libarrow-dev=14.0.1-1 \
+                              libarrow-dataset-dev=14.0.1-1 \
+                              libarrow-acero-dev=14.0.1-1 \
+                              libarrow-flight-dev=14.0.1-1 \
+                              libgandiva-dev=14.0.1-1 \
+                              libparquet-dev=14.0.1-1
 
           # install deps for java
           sudo apt install -y default-jdk-headless maven

--- a/python/vineyard/data/tests/test_dataframe.py
+++ b/python/vineyard/data/tests/test_dataframe.py
@@ -33,6 +33,13 @@ def test_pandas_dataframe(vineyard_client):
     pd.testing.assert_frame_equal(df, vineyard_client.get(object_id))
 
 
+def test_pandas_dataframe_string(vineyard_client):
+    # see gh#533
+    df = pd.DataFrame({'a': ['1', '2', '3', '4'], 'b': ['5', '6', '7', '8']})
+    object_id = vineyard_client.put(df)
+    pd.testing.assert_frame_equal(df, vineyard_client.get(object_id))
+
+
 def test_pandas_dataframe_complex_columns(vineyard_client):
     # see gh#533
     df = pd.DataFrame([1, 2, 3, 4], columns=[['x']])

--- a/rust/vineyard-integration-testing/src/ds/numpy_test.rs
+++ b/rust/vineyard-integration-testing/src/ds/numpy_test.rs
@@ -60,7 +60,6 @@ mod tests {
         return Ok(());
     }
 
-    #[ignore = "ndarray with string type in python side needs to be fixed"]
     #[test]
     fn test_numpy_string() -> Result<()> {
         use arrow_array::array::Array;

--- a/rust/vineyard-integration-testing/src/ds/pandas_test.rs
+++ b/rust/vineyard-integration-testing/src/ds/pandas_test.rs
@@ -46,7 +46,6 @@ mod tests {
         return Ok(());
     }
 
-    #[ignore = "ndarray with string type in python side needs to be fixed"]
     #[test]
     fn test_pandas_string() -> Result<()> {
         let ctx = Context::new();


### PR DESCRIPTION
The change is backwards-compatible and fixes the issue in Rust SDK.