### PR TITLE
Support to use RPC to get object and improve the resolver and builder of python

### DIFF
--- a/python/core.cc
+++ b/python/core.cc
@@ -605,7 +605,7 @@ void bind_blobs(py::module& mod) {
       });
 
   // RemoteBlob
-  py::class_<RemoteBlob, std::shared_ptr<RemoteBlob>>(
+  py::class_<RemoteBlob, std::shared_ptr<RemoteBlob>, Object>(
       mod, "RemoteBlob", py::buffer_protocol(), doc::RemoteBlob)
       .def_property_readonly(
           "id", [](RemoteBlob* self) -> ObjectIDWrapper { return self->id(); },

--- a/python/vineyard/contrib/ml/tests/test_dali.py
+++ b/python/vineyard/contrib/ml/tests/test_dali.py
@@ -32,6 +32,10 @@ def vineyard_for_dali():
         yield
 
 
+def test_dali_tensor_with_rpc_client(vineyard_rpc_client):
+    test_dali_tensor(vineyard_rpc_client)
+
+
 def test_dali_tensor(vineyard_client):
     @dali.pipeline_def()
     def pipe():

--- a/python/vineyard/contrib/ml/tests/test_mxnet.py
+++ b/python/vineyard/contrib/ml/tests/test_mxnet.py
@@ -34,6 +34,10 @@ def vineyard_for_mxnet():
         yield
 
 
+def test_mxnet_tensor_with_rpc_client(vineyard_rpc_client):
+    test_mxnet_tensor(vineyard_rpc_client)
+
+
 def test_mxnet_tensor(vineyard_client):
     data = [np.random.rand(2, 3) for i in range(10)]
     label = [np.random.rand(2, 3) for i in range(10)]
@@ -43,6 +47,10 @@ def test_mxnet_tensor(vineyard_client):
     assert len(dataset[0]) == len(dtrain[0])
     assert dataset[0][0].shape == dtrain[0][0].shape
     assert dataset[1][0].shape == dtrain[1][0].shape
+
+
+def test_mxnet_dataframe_with_rpc_client(vineyard_rpc_client):
+    test_mxnet_dataframe(vineyard_rpc_client)
 
 
 def test_mxnet_dataframe(vineyard_client):
@@ -59,6 +67,10 @@ def test_mxnet_dataframe(vineyard_client):
     assert dataset[1].shape == dtrain[1].shape
 
 
+def test_mxnet_record_batch_with_rpc_client(vineyard_rpc_client):
+    test_mxnet_record_batch(vineyard_rpc_client)
+
+
 def test_mxnet_record_batch(vineyard_client):
     arrays = [
         pa.array([1, 2, 3, 4]),
@@ -70,6 +82,10 @@ def test_mxnet_record_batch(vineyard_client):
     dtrain = vineyard_client.get(object_id, label='target')
     assert len(dtrain[0]) == 4
     assert len(dtrain[0][0]) == 2
+
+
+def test_mxnet_table_with_rpc_client(vineyard_rpc_client):
+    test_mxnet_table(vineyard_rpc_client)
 
 
 def test_mxnet_table(vineyard_client):

--- a/python/vineyard/contrib/ml/tests/test_tensorflow.py
+++ b/python/vineyard/contrib/ml/tests/test_tensorflow.py
@@ -36,6 +36,10 @@ def vineyard_for_tensorflow():
         yield
 
 
+def test_tensorflow_tensor_with_rpc_client(vineyard_rpc_client):
+    test_tensorflow_tensor(vineyard_rpc_client)
+
+
 def test_tensorflow_tensor(vineyard_client):
     data = [np.random.rand(2, 3) for i in range(10)]
     label = [np.random.rand(2, 3) for i in range(10)]
@@ -51,6 +55,10 @@ def test_tensorflow_tensor(vineyard_client):
     assert xdata == xdtrain
     assert ydata == ydtrain
     assert len(dataset) == len(dtrain)
+
+
+def test_tensorflow_dataframe_with_rpc_client(vineyard_rpc_client):
+    test_tensorflow_dataframe(vineyard_rpc_client)
 
 
 def test_tensorflow_dataframe(vineyard_client):
@@ -69,6 +77,10 @@ def test_tensorflow_dataframe(vineyard_client):
     assert data_ncols == dtrain_ncols
 
 
+def test_tensorflow_record_batch_with_rpc_client(vineyard_rpc_client):
+    test_tensorflow_record_batch(vineyard_rpc_client)
+
+
 def test_tensorflow_record_batch(vineyard_client):
     arrays = [
         pa.array([1, 2, 3, 4]),
@@ -82,6 +94,10 @@ def test_tensorflow_record_batch(vineyard_client):
         ncols = len(list(x.keys()))
     assert ncols == 2
     assert len(dtrain) == 4
+
+
+def test_tensorflow_table_with_rpc_client(vineyard_rpc_client):
+    test_tensorflow_table(vineyard_rpc_client)
 
 
 def test_tensorflow_table(vineyard_client):

--- a/python/vineyard/contrib/ml/tests/test_torch.py
+++ b/python/vineyard/contrib/ml/tests/test_torch.py
@@ -36,6 +36,10 @@ def vineyard_for_torch():
         yield
 
 
+def test_torch_tensor_with_rpc_client(vineyard_rpc_client):
+    test_torch_tensor(vineyard_rpc_client)
+
+
 def test_torch_tensor(vineyard_client):
     tensor = torch.ones(5, 2)
     object_id = vineyard_client.put(tensor)
@@ -45,6 +49,10 @@ def test_torch_tensor(vineyard_client):
     assert value.shape == tensor.shape
     assert value.dtype == tensor.dtype
     assert torch.equal(value, tensor)
+
+
+def test_torch_dataset_with_rpc_client(vineyard_rpc_client):
+    test_torch_dataset(vineyard_rpc_client)
 
 
 def test_torch_dataset(vineyard_client):
@@ -62,6 +70,10 @@ def test_torch_dataset(vineyard_client):
         assert torch.isclose(t1, t2).all()
 
 
+def test_torch_dataset_dataframe_with_rpc_client(vineyard_rpc_client):
+    test_torch_dataset_dataframe(vineyard_rpc_client)
+
+
 def test_torch_dataset_dataframe(vineyard_client):
     df = pd.DataFrame({'a': [1, 2, 3, 4], 'b': [5, 6, 7, 8], 'c': [1.0, 2.0, 3.0, 4.0]})
     object_id = vineyard_client.put(df)
@@ -75,6 +87,10 @@ def test_torch_dataset_dataframe(vineyard_client):
     assert torch.isclose(
         value.tensors[2], torch.tensor([1.0, 2.0, 3.0, 4.0], dtype=torch.float64)
     ).all()
+
+
+def test_torch_dataset_dataframe_multidimensional_with_rpc_client(vineyard_rpc_client):
+    test_torch_dataset_dataframe_multidimensional(vineyard_rpc_client)
 
 
 def test_torch_dataset_dataframe_multidimensional(vineyard_client):
@@ -91,6 +107,10 @@ def test_torch_dataset_dataframe_multidimensional(vineyard_client):
     assert len(df.columns) == len(value.tensors)
 
 
+def test_torch_dataset_recordbatch_with_rpc_client(vineyard_rpc_client):
+    test_torch_dataset_recordbatch(vineyard_rpc_client)
+
+
 def test_torch_dataset_recordbatch(vineyard_client):
     df = pd.DataFrame({'a': [1, 2, 3, 4], 'b': [5, 6, 7, 8], 'c': [1.0, 2.0, 3.0, 4.0]})
     batch = pa.RecordBatch.from_pandas(df)
@@ -105,6 +125,10 @@ def test_torch_dataset_recordbatch(vineyard_client):
     assert torch.isclose(
         value.tensors[2], torch.tensor([1.0, 2.0, 3.0, 4.0], dtype=torch.float64)
     ).all()
+
+
+def test_torch_dataset_table_with_rpc_client(vineyard_rpc_client):
+    test_torch_dataset_table(vineyard_rpc_client)
 
 
 def test_torch_dataset_table(vineyard_client):

--- a/python/vineyard/contrib/ml/tests/test_torcharrow.py
+++ b/python/vineyard/contrib/ml/tests/test_torcharrow.py
@@ -30,6 +30,10 @@ def vineyard_for_torcharrow():
         yield
 
 
+def test_torch_arrow_column_with_rpc_client(vineyard_rpc_client):
+    test_torch_arrow_column(vineyard_rpc_client)
+
+
 def test_torch_arrow_column(vineyard_client):
     s = ta.column([1, 2, None, 4])
     assert s.sum() == 7
@@ -37,6 +41,10 @@ def test_torch_arrow_column(vineyard_client):
     s = vineyard_client.get(vineyard_client.put(s))
     assert isinstance(s, ta.Column)
     assert s.sum() == 7
+
+
+def test_torch_arrow_dataframe_with_rpc_client(vineyard_rpc_client):
+    test_torch_arrow_dataframe(vineyard_rpc_client)
 
 
 def test_torch_arrow_dataframe(vineyard_client):

--- a/python/vineyard/contrib/ml/tests/test_xgboost.py
+++ b/python/vineyard/contrib/ml/tests/test_xgboost.py
@@ -31,12 +31,20 @@ def vineyard_for_xgboost():
         yield
 
 
+def test_numpy_ndarray_with_rpc_client(vineyard_rpc_client):
+    test_numpy_ndarray(vineyard_rpc_client)
+
+
 def test_numpy_ndarray(vineyard_client):
     arr = np.random.rand(4, 5)
     object_id = vineyard_client.put(arr)
     dtrain = vineyard_client.get(object_id)
     assert dtrain.num_col() == 5
     assert dtrain.num_row() == 4
+
+
+def test_pandas_dataframe_specify_label_with_rpc_client(vineyard_rpc_client):
+    test_pandas_dataframe_specify_label(vineyard_rpc_client)
 
 
 def test_pandas_dataframe_specify_label(vineyard_client):
@@ -50,6 +58,10 @@ def test_pandas_dataframe_specify_label(vineyard_client):
     assert dtrain.feature_names == ['b', 'c']
 
 
+def test_pandas_dataframe_specify_data_with_rpc_client(vineyard_rpc_client):
+    test_pandas_dataframe_specify_data(vineyard_rpc_client)
+
+
 def test_pandas_dataframe_specify_data(vineyard_client):
     df = pd.DataFrame(
         {'a': [1, 2, 3, 4], 'b': [[5, 1.0], [6, 2.0], [7, 3.0], [8, 9.0]]}
@@ -60,6 +72,10 @@ def test_pandas_dataframe_specify_data(vineyard_client):
     assert dtrain.num_row() == 4
     arr = np.array([1, 2, 3, 4])
     assert np.allclose(arr, dtrain.get_label())
+
+
+def test_record_batch_xgb_resolver_with_rpc_client(vineyard_rpc_client):
+    test_record_batch_xgb_resolver(vineyard_rpc_client)
 
 
 def test_record_batch_xgb_resolver(vineyard_client):
@@ -76,6 +92,10 @@ def test_record_batch_xgb_resolver(vineyard_client):
     arr = np.array([0, 1, 0, 1])
     assert np.allclose(arr, dtrain.get_label())
     assert dtrain.feature_names == ['f0', 'f1']
+
+
+def test_table_xgb_resolver_with_rpc_client(vineyard_rpc_client):
+    test_table_xgb_resolver(vineyard_rpc_client)
 
 
 def test_table_xgb_resolver(vineyard_client):

--- a/python/vineyard/core/resolver.py
+++ b/python/vineyard/core/resolver.py
@@ -230,12 +230,11 @@ def get(
         object_id = client.get_name(name)
 
     # run resolver
-    obj = client.get_object(object_id, fetch=fetch)
-    meta = obj.meta
-    if not meta.islocal and not meta.isglobal:
-        raise ValueError(
-            "Not a local object: for remote object, you can only get its metadata"
-        )
+    if isinstance(client, RPCClient):
+        obj = client.get_object(object_id)
+    else:
+        obj = client.get_object(object_id, fetch=fetch)
+
     if resolver is None:
         resolver = get_current_resolvers()
     return resolver(obj, __vineyard_client=client, **kw)

--- a/python/vineyard/core/tests/test_rpc_client.py
+++ b/python/vineyard/core/tests/test_rpc_client.py
@@ -115,15 +115,6 @@ def test_remote_blob_create_and_get_large_object(vineyard_endpoint):
     assert memoryview(remote_blob) == memoryview(large_payload)
 
 
-def test_remote_blob_error(vineyard_endpoint):
-    vineyard_rpc_client = vineyard.connect(*vineyard_endpoint.split(':'))
-
-    with pytest.raises(
-        ValueError, match="Vineyard RPC client cannot be used to create local blobs"
-    ):
-        vineyard_rpc_client.put(np.ones((2, 3, 4)))
-
-
 def test_multiple_remote_blobs(vineyard_endpoint):
     vineyard_rpc_client = vineyard.connect(*vineyard_endpoint.split(':'))
 

--- a/python/vineyard/data/arrow.py
+++ b/python/vineyard/data/arrow.py
@@ -31,16 +31,16 @@ except ImportError:
 from vineyard._C import Blob
 from vineyard._C import IPCClient
 from vineyard._C import Object
+from vineyard._C import ObjectID
 from vineyard._C import ObjectMeta
+from vineyard._C import RemoteBlob
 from vineyard.core.builder import BuilderContext
 from vineyard.core.resolver import ResolverContext
 from vineyard.data.utils import build_buffer
 from vineyard.data.utils import normalize_dtype
 
 
-def buffer_builder(
-    client: IPCClient, buffer: Union[bytes, memoryview], builder: BuilderContext
-):
+def buffer_builder(client, buffer: Union[bytes, memoryview], builder: BuilderContext):
     if buffer is None:
         address = None
         size = 0
@@ -51,7 +51,16 @@ def buffer_builder(
 
 
 def as_arrow_buffer(blob: Blob):
-    buffer = blob.buffer
+    if isinstance(blob, Blob):
+        buffer = blob.buffer
+    else:
+        if (
+            blob.id == ObjectID("o8000000000000000")
+            or (int(blob.id) & int(ObjectID("o8000000000000000"))) == 0
+        ):
+            buffer = b''
+        else:
+            buffer = memoryview(blob)
     if buffer is None:
         return pa.py_buffer(bytearray())
     return pa.py_buffer(buffer)

--- a/python/vineyard/data/arrow.py
+++ b/python/vineyard/data/arrow.py
@@ -33,7 +33,6 @@ from vineyard._C import IPCClient
 from vineyard._C import Object
 from vineyard._C import ObjectID
 from vineyard._C import ObjectMeta
-from vineyard._C import RemoteBlob
 from vineyard.core.builder import BuilderContext
 from vineyard.core.resolver import ResolverContext
 from vineyard.data.utils import build_buffer

--- a/python/vineyard/data/base.py
+++ b/python/vineyard/data/base.py
@@ -130,6 +130,7 @@ def register_base_types(
 
     if resolver_ctx is not None:
         resolver_ctx.register('vineyard::Blob', bytes_resolver)
+        resolver_ctx.register('vineyard::RemoteBlob', bytes_resolver)
         resolver_ctx.register('vineyard::Scalar', scalar_resolver)
         resolver_ctx.register('vineyard::Array', array_resolver)
         resolver_ctx.register('vineyard::Sequence', sequence_resolver)

--- a/python/vineyard/data/tests/test_base.py
+++ b/python/vineyard/data/tests/test_base.py
@@ -25,9 +25,17 @@ from vineyard.data import register_builtin_types
 register_builtin_types(default_builder_context, default_resolver_context)
 
 
+def test_int_with_rpc_client(vineyard_rpc_client):
+    test_int(vineyard_rpc_client)
+
+
 def test_int(vineyard_client):
     object_id = vineyard_client.put(1)
     assert vineyard_client.get(object_id) == 1
+
+
+def test_double_with_rpc_client(vineyard_rpc_client):
+    test_double(vineyard_rpc_client)
 
 
 def test_double(vineyard_client):
@@ -35,9 +43,17 @@ def test_double(vineyard_client):
     assert vineyard_client.get(object_id) == pytest.approx(1.234)
 
 
+def test_string_with_rpc_client(vineyard_rpc_client):
+    test_string(vineyard_rpc_client)
+
+
 def test_string(vineyard_client):
     object_id = vineyard_client.put('abcde')
     assert vineyard_client.get(object_id) == 'abcde'
+
+
+def test_bytes_with_rpc_client(vineyard_rpc_client):
+    test_bytes(vineyard_rpc_client)
 
 
 def test_bytes(vineyard_client):
@@ -46,15 +62,27 @@ def test_bytes(vineyard_client):
     assert vineyard_client.get(object_id) == memoryview(bs)
 
 
+def test_memoryview_with_rpc_client(vineyard_rpc_client):
+    test_memoryview(vineyard_rpc_client)
+
+
 def test_memoryview(vineyard_client):
     bs = memoryview(b'abcde')
     object_id = vineyard_client.put(bs)
     assert vineyard_client.get(object_id) == bs
 
 
+def test_pair_with_rpc_client(vineyard_rpc_client):
+    test_pair(vineyard_rpc_client)
+
+
 def test_pair(vineyard_client):
     object_id = vineyard_client.put((1, "2"))
     assert vineyard_client.get(object_id) == (1, "2")
+
+
+def test_tuple_with_rpc_client(vineyard_rpc_client):
+    test_tuple(vineyard_rpc_client)
 
 
 def test_tuple(vineyard_client):
@@ -81,3 +109,13 @@ def test_tuple(vineyard_client):
         4444,
         "5.5.5.5.5.5.5",
     )
+
+
+@pytest.mark.parametrize(
+    "value", [1, 1.234, 'abcd', b'abcde', memoryview(b'abcde'), (1, "2")]
+)
+def test_with_ipc_and_rpc(value, vineyard_client, vineyard_rpc_client):
+    object_id = vineyard_client.put(value)
+    assert vineyard_client.get(object_id) == vineyard_rpc_client.get(object_id)
+    object_id = vineyard_rpc_client.put(value)
+    assert vineyard_client.get(object_id) == vineyard_rpc_client.get(object_id)

--- a/python/vineyard/data/tests/test_dataframe.py
+++ b/python/vineyard/data/tests/test_dataframe.py
@@ -19,6 +19,8 @@
 import numpy as np
 import pandas as pd
 
+import pytest
+
 from vineyard.core import default_builder_context
 from vineyard.core import default_resolver_context
 from vineyard.data import register_builtin_types
@@ -27,10 +29,18 @@ from vineyard.data.dataframe import NDArrayArray
 register_builtin_types(default_builder_context, default_resolver_context)
 
 
+def test_pandas_dataframe_with_rpc_client(vineyard_rpc_client):
+    test_pandas_dataframe(vineyard_rpc_client)
+
+
 def test_pandas_dataframe(vineyard_client):
     df = pd.DataFrame({'a': [1, 2, 3, 4], 'b': [5, 6, 7, 8]})
     object_id = vineyard_client.put(df)
     pd.testing.assert_frame_equal(df, vineyard_client.get(object_id))
+
+
+def test_pandas_dataframe_string_with_rpc_client(vineyard_rpc_client):
+    test_pandas_dataframe_string(vineyard_rpc_client)
 
 
 def test_pandas_dataframe_string(vineyard_client):
@@ -40,12 +50,8 @@ def test_pandas_dataframe_string(vineyard_client):
     pd.testing.assert_frame_equal(df, vineyard_client.get(object_id))
 
 
-def test_pandas_dataframe_empty(vineyard_client):
-    # see gh#533
-    df = pd.DataFrame({'a': [1, 2, 3, 4], 'b': ['5', '6', '7', '8']})
-    df = df.iloc[0:0]
-    object_id = vineyard_client.put(df)
-    pd.testing.assert_frame_equal(df, vineyard_client.get(object_id))
+def test_pandas_dataframe_complex_columns_with_rpc_client(vineyard_rpc_client):
+    test_pandas_dataframe_complex_columns(vineyard_rpc_client)
 
 
 def test_pandas_dataframe_complex_columns(vineyard_client):
@@ -55,10 +61,18 @@ def test_pandas_dataframe_complex_columns(vineyard_client):
     pd.testing.assert_frame_equal(df, vineyard_client.get(object_id))
 
 
+def test_pandas_dataframe_int_columns_with_rpc_client(vineyard_rpc_client):
+    test_pandas_dataframe_int_columns(vineyard_rpc_client)
+
+
 def test_pandas_dataframe_int_columns(vineyard_client):
     df = pd.DataFrame({1: [1, 2, 3, 4], 2: [5, 6, 7, 8]})
     object_id = vineyard_client.put(df)
     pd.testing.assert_frame_equal(df, vineyard_client.get(object_id))
+
+
+def test_pandas_dataframe_mixed_columns_with_rpc_client(vineyard_rpc_client):
+    test_pandas_dataframe_mixed_columns(vineyard_rpc_client)
 
 
 def test_pandas_dataframe_mixed_columns(vineyard_client):
@@ -69,11 +83,19 @@ def test_pandas_dataframe_mixed_columns(vineyard_client):
     pd.testing.assert_frame_equal(df, vineyard_client.get(object_id))
 
 
+def test_dataframe_reindex_with_rpc_client(vineyard_rpc_client):
+    test_dataframe_reindex(vineyard_rpc_client)
+
+
 def test_dataframe_reindex(vineyard_client):
     df = pd.DataFrame(np.random.rand(10, 5), columns=['c1', 'c2', 'c3', 'c4', 'c5'])
     expected = df.reindex(index=np.arange(10, 1, -1))
     object_id = vineyard_client.put(expected)
     pd.testing.assert_frame_equal(expected, vineyard_client.get(object_id))
+
+
+def test_dataframe_set_index_with_rpc_client(vineyard_rpc_client):
+    test_dataframe_set_index(vineyard_rpc_client)
 
 
 def test_dataframe_set_index(vineyard_client):
@@ -87,6 +109,10 @@ def test_dataframe_set_index(vineyard_client):
     pd.testing.assert_frame_equal(expected, vineyard_client.get(object_id))
 
 
+def test_sparse_array_with_rpc_client(vineyard_rpc_client):
+    test_sparse_array(vineyard_rpc_client)
+
+
 def test_sparse_array(vineyard_client):
     arr = np.random.randn(10)
     arr[2:5] = np.nan
@@ -94,6 +120,10 @@ def test_sparse_array(vineyard_client):
     sparr = pd.arrays.SparseArray(arr)
     object_id = vineyard_client.put(sparr)
     pd.testing.assert_extension_array_equal(sparr, vineyard_client.get(object_id))
+
+
+def test_dataframe_with_sparse_array_with_rpc_client(vineyard_rpc_client):
+    test_dataframe_with_sparse_array(vineyard_rpc_client)
 
 
 def test_dataframe_with_sparse_array(vineyard_client):
@@ -104,6 +134,10 @@ def test_dataframe_with_sparse_array(vineyard_client):
     pd.testing.assert_frame_equal(df, vineyard_client.get(object_id))
 
 
+def test_dataframe_with_sparse_array_int_columns_with_rpc_client(vineyard_rpc_client):
+    test_dataframe_with_sparse_array_int_columns(vineyard_rpc_client)
+
+
 def test_dataframe_with_sparse_array_int_columns(vineyard_client):
     df = pd.DataFrame(np.random.randn(100, 4), columns=[1, 2, 3, 4])
     df.iloc[:98] = np.nan
@@ -112,12 +146,20 @@ def test_dataframe_with_sparse_array_int_columns(vineyard_client):
     pd.testing.assert_frame_equal(df, vineyard_client.get(object_id))
 
 
+def test_dataframe_with_sparse_array_mixed_columns_with_rpc_client(vineyard_rpc_client):
+    test_dataframe_with_sparse_array_mixed_columns(vineyard_rpc_client)
+
+
 def test_dataframe_with_sparse_array_mixed_columns(vineyard_client):
     df = pd.DataFrame(np.random.randn(100, 4), columns=['x', 'y', 'z', 0])
     df.iloc[:98] = np.nan
     sdf = df.astype(pd.SparseDtype("float", np.nan))
     object_id = vineyard_client.put(sdf)
     pd.testing.assert_frame_equal(df, vineyard_client.get(object_id))
+
+
+def test_dataframe_with_datetime_with_rpc_client(vineyard_rpc_client):
+    test_dataframe_with_datetime(vineyard_rpc_client)
 
 
 def test_dataframe_with_datetime(vineyard_client):
@@ -131,6 +173,10 @@ def test_dataframe_with_datetime(vineyard_client):
     df = pd.DataFrame(pd.Series(dates))
     object_id = vineyard_client.put(df)
     pd.testing.assert_frame_equal(df, vineyard_client.get(object_id))
+
+
+def test_dataframe_with_multidimensional_with_rpc_client(vineyard_rpc_client):
+    test_dataframe_with_multidimensional(vineyard_rpc_client)
 
 
 def test_dataframe_with_multidimensional(vineyard_client):
@@ -165,3 +211,56 @@ def test_dataframe_reusing(vineyard_client):
         meta1['__values_-value-0']['buffer_'].id
         == meta2['__values_-value-0']['buffer_'].id
     )
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pd.DataFrame({'a': [1, 2, 3, 4], 'b': [5, 6, 7, 8]}),
+        pd.DataFrame({'a': ['1', '2', '3', '4'], 'b': ['5', '6', '7', '8']}),
+        pd.DataFrame([1, 2, 3, 4], columns=[['x']]),
+        pd.DataFrame({1: [1, 2, 3, 4], 2: [5, 6, 7, 8]}),
+        pd.DataFrame(
+            {
+                'a': [1, 2, 3, 4],
+                'b': [5, 6, 7, 8],
+                1: [9, 10, 11, 12],
+                2: [13, 14, 15, 16],
+            }
+        ),
+        pd.DataFrame(np.random.rand(10, 5), columns=['c1', 'c2', 'c3', 'c4', 'c5']),
+        pd.DataFrame(
+            [[1, 3, 3], [4, 2, 6], [7, 8, 9]],
+            index=['a1', 'a2', 'a3'],
+            columns=['x', 'y', 'z'],
+        ),
+        pd.arrays.SparseArray(np.random.randn(10)),
+        pd.DataFrame(np.random.randn(100, 4), columns=['x', 'y', 'z', 'a']).astype(
+            pd.SparseDtype("float", np.nan)
+        ),
+        pd.DataFrame(np.random.randn(100, 4), columns=[1, 2, 3, 4]).astype(
+            pd.SparseDtype("float", np.nan)
+        ),
+        pd.DataFrame(np.random.randn(100, 4), columns=['x', 'y', 'z', 0]).astype(
+            pd.SparseDtype("float", np.nan)
+        ),
+        pd.DataFrame(
+            pd.Series(
+                [
+                    pd.Timestamp("2012-05-01"),
+                    pd.Timestamp("2012-05-02"),
+                    pd.Timestamp("2012-05-03"),
+                ]
+            )
+        ),
+    ],
+)
+def test_with_ipc_and_rpc(value, vineyard_client, vineyard_rpc_client):
+    object_id = vineyard_client.put(value)
+    df1 = vineyard_client.get(object_id)
+    df2 = vineyard_rpc_client.get(object_id)
+    assert df1.equals(df2)
+    object_id = vineyard_rpc_client.put(value)
+    df1 = vineyard_client.get(object_id)
+    df2 = vineyard_rpc_client.get(object_id)
+    assert df1.equals(df2)

--- a/python/vineyard/data/tests/test_default.py
+++ b/python/vineyard/data/tests/test_default.py
@@ -18,11 +18,17 @@
 
 import numpy as np
 
+import pytest
+
 from vineyard.core import default_builder_context
 from vineyard.core import default_resolver_context
 from vineyard.data import register_builtin_types
 
 register_builtin_types(default_builder_context, default_resolver_context)
+
+
+def test_bool_with_rpc_client(vineyard_rpc_client):
+    test_bool(vineyard_rpc_client)
 
 
 def test_bool(vineyard_client):
@@ -35,6 +41,10 @@ def test_bool(vineyard_client):
     assert vineyard_client.get(object_id) == value
 
 
+def test_np_bool_with_rpc_client(vineyard_rpc_client):
+    test_np_bool(vineyard_rpc_client)
+
+
 def test_np_bool(vineyard_client):
     value = np.bool_(True)
     object_id = vineyard_client.put(value)
@@ -45,13 +55,40 @@ def test_np_bool(vineyard_client):
     assert vineyard_client.get(object_id) == value
 
 
+def test_list_with_rpc_client(vineyard_rpc_client):
+    test_list(vineyard_rpc_client)
+
+
 def test_list(vineyard_client):
     value = [1, 2, 3, 4, 5, 6, None, None, 9]
     object_id = vineyard_client.put(value)
     assert vineyard_client.get(object_id) == tuple(value)
 
 
+def test_dict_with_rpc_client(vineyard_rpc_client):
+    test_dict(vineyard_rpc_client)
+
+
 def test_dict(vineyard_client):
     value = {1: 2, 3: 4, 5: None, None: 6}
     object_id = vineyard_client.put(value)
     assert vineyard_client.get(object_id) == value
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        True,
+        False,
+        np.bool_(True),
+        np.bool_(False),
+        [1, 2, 3, 4, 5, 6, None, None, 9],
+        {1: 2, 3: 4, 5: None, None: 6},
+    ],
+)
+def test_ipc_and_rpc(value, vineyard_client, vineyard_rpc_client):
+    object_id = vineyard_client.put(value)
+    assert vineyard_client.get(object_id) == vineyard_rpc_client.get(object_id)
+
+    object_id = vineyard_rpc_client.put(value)
+    assert vineyard_client.get(object_id) == vineyard_rpc_client.get(object_id)

--- a/python/vineyard/data/tests/test_pickle.py
+++ b/python/vineyard/data/tests/test_pickle.py
@@ -131,11 +131,19 @@ def test_bytes_io_roundtrip(block_size, value):
         assert target == value
 
 
+def test_bytes_io_numpy_ndarray_with_rpc_client(vineyard_rpc_client):
+    test_bytes_io_numpy_ndarray(vineyard_rpc_client)
+
+
 def test_bytes_io_numpy_ndarray(vineyard_client):
     arr = np.random.rand(4, 5, 6)
     object_id = vineyard_client.put(arr)
     target = read_and_build(b1m, vineyard_client.get(object_id))
     np.testing.assert_allclose(arr, target)
+
+
+def test_bytes_io_empty_ndarray_with_rpc_client(vineyard_rpc_client):
+    test_bytes_io_empty_ndarray(vineyard_rpc_client)
 
 
 def test_bytes_io_empty_ndarray(vineyard_client):
@@ -180,11 +188,19 @@ def test_bytes_io_empty_ndarray(vineyard_client):
     np.testing.assert_allclose(arr, target)
 
 
+def test_bytes_io_str_ndarray_with_rpc_client(vineyard_rpc_client):
+    test_bytes_io_str_ndarray(vineyard_rpc_client)
+
+
 def test_bytes_io_str_ndarray(vineyard_client):
     arr = np.array(['', 'x', 'yz', 'uvw'])
     object_id = vineyard_client.put(arr)
     target = read_and_build(b1m, vineyard_client.get(object_id))
     np.testing.assert_equal(arr, target)
+
+
+def test_object_ndarray_with_rpc_client(vineyard_rpc_client):
+    test_object_ndarray(vineyard_rpc_client)
 
 
 def test_object_ndarray(vineyard_client):
@@ -199,12 +215,20 @@ def test_object_ndarray(vineyard_client):
     np.testing.assert_equal(arr, target)
 
 
+def test_bytes_io_tensor_order_with_rpc_client(vineyard_rpc_client):
+    test_bytes_io_tensor_order(vineyard_rpc_client)
+
+
 def test_bytes_io_tensor_order(vineyard_client):
     arr = np.asfortranarray(np.random.rand(10, 7))
     object_id = vineyard_client.put(arr)
     res = read_and_build(b1m, vineyard_client.get(object_id))
     assert res.flags['C_CONTIGUOUS'] == arr.flags['C_CONTIGUOUS']
     assert res.flags['F_CONTIGUOUS'] == arr.flags['F_CONTIGUOUS']
+
+
+def test_bytes_io_pandas_dataframe_with_rpc_client(vineyard_rpc_client):
+    test_bytes_io_pandas_dataframe(vineyard_rpc_client)
 
 
 def test_bytes_io_pandas_dataframe(vineyard_client):
@@ -214,11 +238,19 @@ def test_bytes_io_pandas_dataframe(vineyard_client):
     pd.testing.assert_frame_equal(df, target)
 
 
+def test_bytes_io_pandas_dataframe_int_columns_with_rpc_client(vineyard_rpc_client):
+    test_bytes_io_pandas_dataframe_int_columns(vineyard_rpc_client)
+
+
 def test_bytes_io_pandas_dataframe_int_columns(vineyard_client):
     df = pd.DataFrame({1: [1, 2, 3, 4], 2: [5, 6, 7, 8]})
     object_id = vineyard_client.put(df)
     target = read_and_build(b1m, vineyard_client.get(object_id))
     pd.testing.assert_frame_equal(df, target)
+
+
+def test_bytes_io_pandas_dataframe_mixed_columns_with_rpc_client(vineyard_rpc_client):
+    test_bytes_io_pandas_dataframe_mixed_columns(vineyard_rpc_client)
 
 
 def test_bytes_io_pandas_dataframe_mixed_columns(vineyard_client):
@@ -230,8 +262,35 @@ def test_bytes_io_pandas_dataframe_mixed_columns(vineyard_client):
     pd.testing.assert_frame_equal(df, target)
 
 
+def test_bytes_io_pandas_series_with_rpc_client(vineyard_rpc_client):
+    test_bytes_io_pandas_series(vineyard_rpc_client)
+
+
 def test_bytes_io_pandas_series(vineyard_client):
     s = pd.Series([1, 3, 5, np.nan, 6, 8], name='foo')
     object_id = vineyard_client.put(s)
     target = read_and_build(b1m, vineyard_client.get(object_id))
     pd.testing.assert_series_equal(s, target)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        np.ones((0, 1, 2, 3)),
+        np.zeros((0, 1, 2, 3), dtype='int'),
+        np.array(['', 'x', 'ht', 'yyds']),
+        np.array([1, 'x', 3.14, (1, 4)], dtype=object),
+        np.ones((), dtype='object'),
+        np.asfortranarray(np.random.rand(10, 7)),
+    ],
+)
+def test_ipc_and_rpc(value, vineyard_client, vineyard_rpc_client):
+    object_id = vineyard_client.put(value)
+    v1 = vineyard_client.get(object_id)
+    v2 = vineyard_rpc_client.get(object_id)
+    assert np.array_equal(v1, v2)
+
+    object_id = vineyard_rpc_client.put(value)
+    v1 = vineyard_client.get(object_id)
+    v2 = vineyard_rpc_client.get(object_id)
+    assert np.array_equal(v1, v2)

--- a/python/vineyard/data/tests/test_tensor.py
+++ b/python/vineyard/data/tests/test_tensor.py
@@ -33,10 +33,18 @@ from vineyard.data import register_builtin_types
 register_builtin_types(default_builder_context, default_resolver_context)
 
 
+def test_numpy_ndarray_with_rpc_client(vineyard_rpc_client):
+    test_numpy_ndarray(vineyard_rpc_client)
+
+
 def test_numpy_ndarray(vineyard_client):
     arr = np.random.rand(4, 5, 6)
     object_id = vineyard_client.put(arr)
     np.testing.assert_allclose(arr, vineyard_client.get(object_id))
+
+
+def test_empty_ndarray_with_rpc_client(vineyard_rpc_client):
+    test_empty_ndarray(vineyard_rpc_client)
 
 
 def test_empty_ndarray(vineyard_client):
@@ -73,10 +81,18 @@ def test_empty_ndarray(vineyard_client):
     np.testing.assert_allclose(arr, vineyard_client.get(object_id))
 
 
+def test_str_ndarray_with_rpc_client(vineyard_rpc_client):
+    test_str_ndarray(vineyard_rpc_client)
+
+
 def test_str_ndarray(vineyard_client):
     arr = np.array(['', 'x', 'yz', 'uvw'])
     object_id = vineyard_client.put(arr)
     np.testing.assert_equal(arr, vineyard_client.get(object_id))
+
+
+def test_object_ndarray_with_rpc_client(vineyard_rpc_client):
+    test_object_ndarray(vineyard_rpc_client)
 
 
 def test_object_ndarray(vineyard_client):
@@ -89,12 +105,21 @@ def test_object_ndarray(vineyard_client):
     np.testing.assert_equal(arr, vineyard_client.get(object_id))
 
 
+def test_tensor_order_with_rpc_client(vineyard_rpc_client):
+    test_tensor_order(vineyard_rpc_client)
+
+
 def test_tensor_order(vineyard_client):
     arr = np.asfortranarray(np.random.rand(10, 7))
     object_id = vineyard_client.put(arr)
     res = vineyard_client.get(object_id)
     assert res.flags['C_CONTIGUOUS'] == arr.flags['C_CONTIGUOUS']
     assert res.flags['F_CONTIGUOUS'] == arr.flags['F_CONTIGUOUS']
+
+
+@pytest.mark.skipif(sp is None, reason="scipy.sparse is not available")
+def test_bsr_matrix_with_rpc_client(vineyard_rpc_client):
+    test_bsr_matrix(vineyard_rpc_client)
 
 
 @pytest.mark.skipif(sp is None, reason="scipy.sparse is not available")
@@ -105,10 +130,20 @@ def test_bsr_matrix(vineyard_client):
 
 
 @pytest.mark.skipif(sp is None, reason="scipy.sparse is not available")
+def test_coo_matrix_with_rpc_client(vineyard_rpc_client):
+    test_coo_matrix(vineyard_rpc_client)
+
+
+@pytest.mark.skipif(sp is None, reason="scipy.sparse is not available")
 def test_coo_matrix(vineyard_client):
     arr = sp.sparse.coo_matrix((3, 4), dtype=np.int8)
     object_id = vineyard_client.put(arr)
     np.testing.assert_allclose(arr.A, vineyard_client.get(object_id).A)
+
+
+@pytest.mark.skipif(sp is None, reason="scipy.sparse is not available")
+def test_csc_matrix_with_rpc_client(vineyard_rpc_client):
+    test_csc_matrix(vineyard_rpc_client)
 
 
 @pytest.mark.skipif(sp is None, reason="scipy.sparse is not available")
@@ -119,6 +154,11 @@ def test_csc_matrix(vineyard_client):
 
 
 @pytest.mark.skipif(sp is None, reason="scipy.sparse is not available")
+def test_csr_matrix_with_rpc_client(vineyard_rpc_client):
+    test_csr_matrix(vineyard_rpc_client)
+
+
+@pytest.mark.skipif(sp is None, reason="scipy.sparse is not available")
 def test_csr_matrix(vineyard_client):
     arr = sp.sparse.csr_matrix((3, 4), dtype=np.int8)
     object_id = vineyard_client.put(arr)
@@ -126,7 +166,26 @@ def test_csr_matrix(vineyard_client):
 
 
 @pytest.mark.skipif(sp is None, reason="scipy.sparse is not available")
+def test_dia_matrix_with_rpc_client(vineyard_rpc_client):
+    test_dia_matrix(vineyard_rpc_client)
+
+
+@pytest.mark.skipif(sp is None, reason="scipy.sparse is not available")
 def test_dia_matrix(vineyard_client):
     arr = sp.sparse.dia_matrix((3, 4), dtype=np.int8)
     object_id = vineyard_client.put(arr)
     np.testing.assert_allclose(arr.A, vineyard_client.get(object_id).A)
+
+
+@pytest.mark.skipif(sp is None, reason="scipy.sparse is not available")
+def test_ipc_and_rpc(vineyard_client, vineyard_rpc_client):
+    value = sp.sparse.bsr_matrix((3, 4), dtype=np.int8)
+    object_id = vineyard_client.put(value)
+    v1 = vineyard_client.get(object_id)
+    v2 = vineyard_rpc_client.get(object_id)
+    assert np.array_equal(v1.todense(), v2.todense())
+
+    object_id = vineyard_rpc_client.put(value)
+    v1 = vineyard_client.get(object_id)
+    v2 = vineyard_rpc_client.get(object_id)
+    assert np.array_equal(v1.todense(), v2.todense())

--- a/python/vineyard/data/utils.py
+++ b/python/vineyard/data/utils.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 #
 
+import ctypes
 import json
 import pickle
 from typing import Union
@@ -26,6 +27,8 @@ import pyarrow as pa
 from vineyard._C import Object
 from vineyard._C import ObjectID
 from vineyard._C import ObjectMeta
+from vineyard._C import RemoteBlobBuilder
+from vineyard._C import RPCClient
 
 if pickle.HIGHEST_PROTOCOL < 5:
     import pickle5 as pickle  # pylint: disable=import-error
@@ -144,15 +147,30 @@ def ensure_ipc_client(client, error_message=None):
 def build_buffer(
     client, address, size, *args, **kwargs
 ) -> Union["Object", "ObjectMeta", "ObjectID"]:
-    '''Build a blob in vineyard server for the given bytes or memoryview.
+    '''Build a blob or a remote blob in vineyard server
+        for the given bytes or memoryview.
 
     If address is None or size is 0, an empty blob will be returned.
     '''
-    ensure_ipc_client(
-        client,
-        "Vineyard RPC client cannot be used to create local blobs, "
-        "try using an IPC client or `rpc_client.create_remote_blob()`",
-    )
+    if isinstance(client, RPCClient):
+        # copy the address with size to a local payloads
+        if size == 0 or address is None:
+            meta = ObjectMeta()
+            meta.id = ObjectID("o8000000000000000")
+            meta.nbytes = 0
+            meta.typename = "vineyard::RemoteBlob"
+            return client.create_metadata(meta)
+        if isinstance(address, bytes):
+            payload = address
+        else:
+            payload = bytearray(size)
+            address_bytes = (ctypes.c_byte * size).from_address(address)
+            payload[:size] = memoryview(address_bytes)[:size]
+        buffer = RemoteBlobBuilder(size)
+        buffer.copy(0, payload)
+        id = client.create_remote_blob(buffer)
+        meta = client.get_meta(id)
+        return meta
 
     if size == 0:
         return client.create_empty_blob()

--- a/src/client/client_base.cc
+++ b/src/client/client_base.cc
@@ -72,6 +72,11 @@ Status ClientBase::CreateData(const json& tree, ObjectID& id,
 }
 
 Status ClientBase::CreateMetaData(ObjectMeta& meta_data, ObjectID& id) {
+  if (this->instance_id_ == UnspecifiedInstanceID() - 1) {
+    std::shared_ptr<struct InstanceStatus> instance_status = nullptr;
+    VINEYARD_CHECK_OK(this->InstanceStatus(instance_status));
+    this->instance_id_ = instance_status->instance_id;
+  }
   return this->CreateMetaData(meta_data, this->instance_id_, std::ref(id));
 }
 

--- a/src/client/ds/blob.cc
+++ b/src/client/ds/blob.cc
@@ -132,7 +132,7 @@ void Blob::Construct(ObjectMeta const& meta) {
   if (meta.GetBuffer(meta.GetId(), this->buffer_).ok()) {
     if (this->buffer_ == nullptr) {
       throw std::runtime_error(
-          "Blob::Construct(): Invalid internal state: local blob found bit it "
+          "Blob::Construct(): Invalid internal state: local blob found but it "
           "is nullptr: " +
           ObjectIDToString(meta.GetId()));
     }

--- a/src/client/ds/object_meta.h
+++ b/src/client/ds/object_meta.h
@@ -132,6 +132,11 @@ class ObjectMeta {
   bool const IsLocal() const;
 
   /**
+   * @brief Whether the object meta and rpc client is located on the same node.
+   */
+  bool const IsLocated() const;
+
+  /**
    * @brief Mark the metadata as a "local" metadata to make sure the construct
    * process proceed.
    */
@@ -796,6 +801,7 @@ class ObjectMeta {
   friend class RPCClient;
 
   friend class Blob;
+  friend class RemoteBlob;
   friend class BlobWriter;
 };
 

--- a/test/runner.py
+++ b/test/runner.py
@@ -625,6 +625,7 @@ def run_python_contrib_distributed_tests(
             ['%s.%d' % (VINEYARD_CI_IPC_SOCKET, i) for i in range(instance_size)]
         )
         start_time = time.time()
+        rpc_socket_port = instances[0][1]
         subprocess.check_call(
             [
                 'pytest',
@@ -637,6 +638,7 @@ def run_python_contrib_distributed_tests(
                 'python/vineyard/contrib/%s' % contrib,
                 *test_args,
                 '--vineyard-ipc-sockets=%s' % vineyard_ipc_sockets,
+                '--vineyard-endpoint=localhost:%s' % rpc_socket_port,
             ],
             cwd=os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'),
         )


### PR DESCRIPTION
What do these changes do?
-------------------------

With it, rpc_client and ipc_client can get/put the value as the same way. 
