### PR TITLE
Add the JOB_NAME Env to the argo-vineyard-benchmark.yaml

### DIFF
--- a/python/vineyard/contrib/kedro/benchmark/mlops/argo-vineyard-benchmark.yml
+++ b/python/vineyard/contrib/kedro/benchmark/mlops/argo-vineyard-benchmark.yml
@@ -32,6 +32,8 @@ spec:
       command: [kedro]
       args: ["run", "-e", "vineyard", "-n",  "{{inputs.parameters.kedro_node}}"]
       env:
+        - name: JOB_NAME
+          value: "{{inputs.parameters.job}}"
         - name: VINEYARD_IPC_SOCKET
           value: /var/run/vineyard.sock
         - name: DATA_AUGMENT_MULTIPLIER


### PR DESCRIPTION
What do these changes do?
-------------------------

As titled. It can fix something wrong like `index out of range[0] with length 0`.





