### PR TITLE
Fixes a missing assignment in edge id generation

### DIFF
--- a/modules/graph/loader/basic_ev_fragment_loader_impl.h
+++ b/modules/graph/loader/basic_ev_fragment_loader_impl.h
@@ -739,10 +739,11 @@ BasicEVFragmentLoader<OID_T, VID_T, PARTITIONER_T>::generateEdgeId(
     auto& edge_table_list = edge_tables[e_label];
     uint64_t cur_id;
     if (existed_elabel_id != -1) {
-      eid_parser.GenerateId(comm_spec.fid(), existed_elabel_id, eid_offset);
+      cur_id =
+          eid_parser.GenerateId(comm_spec.fid(), existed_elabel_id, eid_offset);
     } else {
-      eid_parser.GenerateId(comm_spec.fid(), e_label + label_offset,
-                            eid_offset);
+      cur_id = eid_parser.GenerateId(comm_spec.fid(), e_label + label_offset,
+                                     eid_offset);
     }
     for (size_t edge_table_index = 0;
          edge_table_index != edge_table_list.size(); ++edge_table_index) {


### PR DESCRIPTION
The bug was first introduced in https://github.com/v6d-io/v6d/commit/1de8226e17b564230e5d535925c0c318ea69458c#diff-f5dfc05a30caf83fbf2edde2db77177a8bf8bb8bb296b0d8259a89f566a833ff and causes https://github.com/alibaba/GraphScope/actions/runs/7044062862/job/19176259486?pr=3392

There's also a workaround i graphscope (https://github.com/alibaba/GraphScope/pull/3421) to fixes the CI failure.