### PR TITLE
Delete the wait-for-it.sh as the vineyardd already support the retry logic  of connecting the etcd.

### DIFF
--- a/docker/Dockerfile.vineyardd
+++ b/docker/Dockerfile.vineyardd
@@ -26,9 +26,6 @@ RUN export arch="$PLATFORM" && \
     curl -LO https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_$arch && \
     chmod +x dumb-init_1.2.2_$arch && \
     mv /tmp/dumb-init_1.2.2_$arch /usr/bin/dumb-init && \
-    curl -LO https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh && \
-    chmod +x wait-for-it.sh && \
-    mv /tmp/wait-for-it.sh /usr/bin/wait-for-it.sh && \
     curl -LO https://github.com/etcd-io/etcd/releases/download/v3.5.9/etcd-v3.5.9-linux-$arch.tar.gz && \
     tar zxf etcd-v3.5.9-linux-$arch.tar.gz && \
     mv /tmp/etcd-v3.5.9-linux-$arch/etcd /usr/bin/etcd && \
@@ -82,7 +79,6 @@ SHELL ["/bin/bash", "-c"]
 
 COPY --from=builder /usr/bin/bash-linux /bin/bash
 COPY --from=builder /usr/bin/dumb-init /usr/bin/dumb-init
-COPY --from=builder /usr/bin/wait-for-it.sh /usr/bin/wait-for-it.sh
 COPY --from=builder /usr/bin/etcd /usr/bin/etcd
 COPY --from=builder /usr/bin/kubectl /usr/bin/kubectl
 COPY --from=builder /work/v6d/build/bin/vineyardd /usr/local/bin/vineyardd

--- a/docs/notes/cloud-native/vineyard-operator.rst
+++ b/docs/notes/cloud-native/vineyard-operator.rst
@@ -149,19 +149,19 @@ Next, use the following YAML to inject the default sidecar into the pod.
     apiVersion: apps/v1
     kind: Deployment
     metadata:
-      name: job-deployment-with-default-sidecar
+      name: job-deployment
       namespace: vineyard-job
     spec:
       selector:
         matchLabels:
-          app: job-deployment-with-default-sidecar
+          app: job-deployment
       replicas: 2
       template:
         metadata:
           annotations:
             sidecar.v6d.io/name: "default"
           labels:
-            app: job-deployment-with-default-sidecar
+            app: job-deployment
             sidecar.v6d.io/enabled: "true"
         spec:
           containers:
@@ -179,12 +179,12 @@ Next, you could see the sidecar container injected into the pod.
 .. code:: yaml
 
     # get the default sidecar cr
-    $ kubectl get sidecar app-job-deployment-with-default-sidecar-default-sidecar -n vineyard-job -o yaml
+    $ kubectl get sidecar app-job-deployment-default-sidecar -n vineyard-job -o yaml
     apiVersion: k8s.v6d.io/v1alpha1
     kind: Sidecar
     metadata:
       # the default sidecar's name is your label selector + "-default-sidecar"
-      name: app-job-deployment-with-default-sidecar-default-sidecar
+      name: app-job-deployment-default-sidecar
       namespace: vineyard-job
     spec:
       metric:
@@ -192,7 +192,7 @@ Next, you could see the sidecar container injected into the pod.
         image: vineyardcloudnative/vineyard-grok-exporter:latest
         imagePullPolicy: IfNotPresent
       replicas: 2
-      selector: app=job-deployment-with-default-sidecar
+      selector: app=job-deployment
       service:
         port: 9600
         selector: rpc.vineyardd.v6d.io/rpc=vineyard-rpc
@@ -213,11 +213,11 @@ Next, you could see the sidecar container injected into the pod.
         streamThreshold: 80
         syncCRDs: true
     # get the injected Pod, here we only show the important part of the Pod
-    $ kubectl get pod -l app=job-deployment-with-default-sidecar -n vineyard-job -o yaml
+    $ kubectl get pod -l app=job-deployment -n vineyard-job -o yaml
     apiVersion: v1
     kind: Pod
     metadata:
-      name: job-deployment-with-default-sidecar-55664458f8-h4jzk
+      name: job-deployment-55664458f8-h4jzk
       namespace: vineyard-job
     spec:
       containers:
@@ -238,8 +238,7 @@ Next, you could see the sidecar container injected into the pod.
         - /bin/bash
         - -c
         - |
-          /usr/bin/wait-for-it.sh -t 60 etcd-for-vineyard.vineyard-job.svc.cluster.local:2379;
-          sleep 1; /usr/local/bin/vineyardd --sync_crds true --socket /var/run/vineyard.sock
+          /usr/local/bin/vineyardd --sync_crds true --socket /var/run/vineyard.sock
           --stream_threshold 80 --etcd_cmd etcd --etcd_prefix /vineyard
           --etcd_endpoint http://etcd-for-vineyard:2379
         env:

--- a/k8s/cmd/README.md
+++ b/k8s/cmd/README.md
@@ -1512,8 +1512,7 @@ spec:
     - /bin/bash
     - -c
     - |
-      /usr/bin/wait-for-it.sh -t 60 vineyard-sidecar-etcd-service..svc.cluster.local:2379; \
-      sleep 1; /usr/local/bin/vineyardd --sync_crds true --socket /var/run/vineyard.sock --size \
+      /usr/local/bin/vineyardd --sync_crds true --socket /var/run/vineyard.sock --size \
       --stream_threshold 80 --etcd_cmd etcd --etcd_prefix /vineyard --etcd_endpoint http://vineyard-sidecar-etcd-service:2379
     env:
     - name: VINEYARDD_UID
@@ -1609,8 +1608,7 @@ template:
       - /bin/bash
       - -c
       - |
-        /usr/bin/wait-for-it.sh -t 60 vineyard-sidecar-etcd-service.vineyard-job.svc.cluster.local:2379; \
-        sleep 1; /usr/local/bin/vineyardd --sync_crds true --socket /var/run/vineyard.sock \
+        /usr/local/bin/vineyardd --sync_crds true --socket /var/run/vineyard.sock \
         --stream_threshold 80 --etcd_cmd etcd --etcd_prefix /vineyard \
         --etcd_endpoint http://vineyard-sidecar-etcd-service:2379
       env:

--- a/k8s/cmd/commands/deploy/deploy_vineyard_deployment_test.go
+++ b/k8s/cmd/commands/deploy/deploy_vineyard_deployment_test.go
@@ -406,8 +406,7 @@ func TestGetVineyardDeploymentObjectsFromTemplate_third(t *testing.T) {
 											"command": []interface{}{
 												"/bin/bash",
 												"-c",
-												"/usr/bin/wait-for-it.sh -t 60 test-vineyardd-sample-etcd-service.test-vineyard-system." +
-													"svc.cluster.local:2379; sleep 1; /usr/local/bin/vineyardd --sync_crds true --socket " +
+												"/usr/local/bin/vineyardd --sync_crds true --socket " +
 													"/var/run/vineyard.sock --size  --stream_threshold 80 --etcd_cmd etcd --etcd_prefix " +
 													"/vineyard --etcd_endpoint http://test-vineyardd-sample-etcd-service:2379\n",
 											},

--- a/k8s/cmd/commands/inject/inject.go
+++ b/k8s/cmd/commands/inject/inject.go
@@ -220,8 +220,7 @@ var (
 	    - /bin/bash
 	    - -c
 	    - |
-	      /usr/bin/wait-for-it.sh -t 60 vineyard-sidecar-etcd-service..svc.cluster.local:2379; \
-	      sleep 1; /usr/local/bin/vineyardd --sync_crds true --socket /var/run/vineyard.sock --size \
+	      /usr/local/bin/vineyardd --sync_crds true --socket /var/run/vineyard.sock --size \
 	      --stream_threshold 80 --etcd_cmd etcd --etcd_prefix /vineyard --etcd_endpoint http://vineyard-sidecar-etcd-service:2379
 	    env:
 	    - name: VINEYARDD_UID
@@ -315,8 +314,7 @@ var (
 	      - /bin/bash
 	      - -c
 	      - |
-	        /usr/bin/wait-for-it.sh -t 60 vineyard-sidecar-etcd-service.vineyard-job.svc.cluster.local:2379; \
-	        sleep 1; /usr/local/bin/vineyardd --sync_crds true --socket /var/run/vineyard.sock \
+	        /usr/local/bin/vineyardd --sync_crds true --socket /var/run/vineyard.sock \
 	        --stream_threshold 80 --etcd_cmd etcd --etcd_prefix /vineyard \
 	        --etcd_endpoint http://vineyard-sidecar-etcd-service:2379
 	      env:

--- a/k8s/cmd/commands/inject/inject_test.go
+++ b/k8s/cmd/commands/inject/inject_test.go
@@ -228,7 +228,7 @@ spec:
         - /bin/bash
         - -c
         - |
-          /usr/bin/wait-for-it.sh -t 60 vineyard-sidecar-etcd-service.vineyard-system.svc.cluster.local:2379; sleep 1; /usr/local/bin/vineyardd --sync_crds true --socket /var/run/vineyard.sock --size  --stream_threshold 80 --etcd_cmd etcd --etcd_prefix /vineyard --etcd_endpoint http://vineyard-sidecar-etcd-service:2379
+          /usr/local/bin/vineyardd --sync_crds true --socket /var/run/vineyard.sock --size  --stream_threshold 80 --etcd_cmd etcd --etcd_prefix /vineyard --etcd_endpoint http://vineyard-sidecar-etcd-service:2379
         env:
         - name: VINEYARDD_UID
           value: null
@@ -285,7 +285,7 @@ spec:
     - /bin/bash
     - -c
     - |
-      /usr/bin/wait-for-it.sh -t 60 vineyard-sidecar-etcd-service.vineyard-system.svc.cluster.local:2379; sleep 1; /usr/local/bin/vineyardd --sync_crds true --socket /var/run/vineyard.sock --size  --stream_threshold 80 --etcd_cmd etcd --etcd_prefix /vineyard --etcd_endpoint http://vineyard-sidecar-etcd-service:2379
+      /usr/local/bin/vineyardd --sync_crds true --socket /var/run/vineyard.sock --size  --stream_threshold 80 --etcd_cmd etcd --etcd_prefix /vineyard --etcd_endpoint http://vineyard-sidecar-etcd-service:2379
     env:
     - name: VINEYARDD_UID
       value: null

--- a/k8s/pkg/templates/sidecar/injection-template.yaml
+++ b/k8s/pkg/templates/sidecar/injection-template.yaml
@@ -19,8 +19,6 @@ spec:
       - /bin/bash
       - -c
       - >
-        /usr/bin/wait-for-it.sh -t 60 {{ .Name }}-etcd-service.{{ .Namespace }}.svc.cluster.local:2379;
-        sleep 1;
         /usr/local/bin/vineyardd
         --sync_crds {{ .Spec.Vineyard.SyncCRDs }}
         {{- if .Spec.Volume.MountPath }}

--- a/k8s/pkg/templates/vineyardd/deployment.yaml
+++ b/k8s/pkg/templates/vineyardd/deployment.yaml
@@ -49,8 +49,6 @@ spec:
           - /bin/bash
           - -c
           - >
-            /usr/bin/wait-for-it.sh -t 60 {{ .Name }}-etcd-service.{{ .Namespace }}.svc.cluster.local:2379;
-            sleep 1;
             /usr/local/bin/vineyardd
             --sync_crds {{ .Spec.Vineyard.SyncCRDs }}
             {{- if .Spec.Volume.MountPath }}

--- a/k8s/test/e2e/sidecar-demo/sidecar-with-custom-sidecar.yaml
+++ b/k8s/test/e2e/sidecar-demo/sidecar-with-custom-sidecar.yaml
@@ -20,7 +20,7 @@ metadata:
   namespace: vineyard-job
 spec:
   replicas: 2
-  selector: app=job-deployment-with-custom-sidecar
+  selector: app=job-deployment
   vineyard:
     image: localhost:5001/vineyardd:latest
     socket: /var/run/vineyard.sock
@@ -28,19 +28,19 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: job-deployment-with-custom-sidecar
+  name: job-deployment
   namespace: vineyard-job
 spec:
   selector:
     matchLabels:
-      app: job-deployment-with-custom-sidecar
+      app: job-deployment
   replicas: 2
   template:
     metadata:
       annotations:
         sidecar.v6d.io/name: "sidecar-sample"
       labels:
-        app: job-deployment-with-custom-sidecar
+        app: job-deployment
         sidecar.v6d.io/enabled: "true"
     spec:
       containers:

--- a/k8s/test/e2e/sidecar-demo/sidecar-with-default-sidecar.yaml
+++ b/k8s/test/e2e/sidecar-demo/sidecar-with-default-sidecar.yaml
@@ -16,20 +16,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: job-deployment-with-default-sidecar
+  name: job-deployment
   namespace: vineyard-job
 spec:
   selector:
     matchLabels:
-      app: job-deployment-with-default-sidecar
+      app: job-deployment
   replicas: 2
   template:
     metadata:
       annotations:
         sidecar.v6d.io/name: "default"
       labels:
-        app.kubernetes.io/instance: job-deployment-with-default-sidecar
-        app: job-deployment-with-default-sidecar
+        app.kubernetes.io/instance: job-deployment
+        app: job-deployment
         sidecar.v6d.io/enabled: "true"
     spec:
       containers:

--- a/k8s/test/e2e/sidecar/e2e.yaml
+++ b/k8s/test/e2e/sidecar/e2e.yaml
@@ -28,17 +28,19 @@ setup:
             --sidecar.image="localhost:5001/vineyardd:latest"| kubectl apply -f -
       wait:
         - namespace: vineyard-job
-          resource: deployment/job-deployment-with-default-sidecar
+          resource: deployment/job-deployment
           for: condition=Available
     - name: install app with default sidecar via kubectl
       command: |
         kubectl create namespace vineyard-job1
         kubectl label namespace vineyard-job1 sidecar-injection=enabled
+        docker tag localhost:5001/vineyardd:latest vineyardcloudnative/vineyardd:latest
+        kind load docker-image vineyardcloudnative/vineyardd:latest
         sed -e 's/vineyard-job/vineyard-job1/g' k8s/test/e2e/sidecar-demo/sidecar-with-default-sidecar.yaml | \
           kubectl apply -f -
       wait:
         - namespace: vineyard-job1
-          resource: deployment/job-deployment-with-default-sidecar
+          resource: deployment/job-deployment
           for: condition=Available
     - name: install app with custom sidecar
       command: |
@@ -46,7 +48,7 @@ setup:
         kubectl apply -f k8s/test/e2e/sidecar-demo/sidecar-with-custom-sidecar.yaml
       wait:
         - namespace: vineyard-job
-          resource: deployment/job-deployment-with-custom-sidecar
+          resource: deployment/job-deployment
           for: condition=Available
   timeout: 20m
 


### PR DESCRIPTION
What do these changes do?
-------------------------

Delete the wait-for-it.sh as the vineyardd already supports the retry logic of connecting the etcd.


