### PR TITLE
Implement concurrent memcpy for building Python objects into vineyard

### DIFF
--- a/python/pybind11_docs.cc
+++ b/python/pybind11_docs.cc
@@ -339,11 +339,6 @@ const char* Blob_address = R"doc(
 The memory address value of this blob.
 )doc";
 
-const char* Blob_buffer = R"doc(
-The readonly buffer behind this blob. The result buffer has type
-:code:`memoryview`.
-)doc";
-
 const char* BlobBuilder = R"doc(
 :class:`BlobBuilder` is the builder for creating a finally immutable blob in
 vineyard server.
@@ -373,7 +368,7 @@ Shrink the blob builder to the given size if it is not sealed yet.
 )doc";
 
 const char* BlobBuilder_copy = R"doc(
-.. method:: copy(self, offset: int, ptr: int, size: int)
+.. method:: copy(self, offset: int, ptr: int, size: int, concurrency: int = 6)
     :noindex:
 
 Copy the given address to the given offset.
@@ -381,11 +376,6 @@ Copy the given address to the given offset.
 
 const char* BlobBuilder_address = R"doc(
 The memory address value of this blob builder.
-)doc";
-
-const char* BlobBuilder_buffer = R"doc(
-The writeable buffer behind this blob builder. The result buffer has type
-:code:`memoryview`, and it is a mutable one.
 )doc";
 
 const char* RemoteBlob = R"doc(
@@ -412,11 +402,6 @@ The size of this blob.
 
 const char* RemoteBlob_address = R"doc(
 The memory address value of this blob.
-)doc";
-
-const char* RemoteBlob_buffer = R"doc(
-The readonly buffer behind this blob. The result buffer has type
-:code:`memoryview`.
 )doc";
 
 const char* RemoteBlobBuilder = R"doc(
@@ -476,7 +461,7 @@ Abort the blob builder if it is not sealed yet.
 )doc";
 
 const char* RemoteBlobBuilder_copy = R"doc(
-.. method:: copy(self, offset: int, ptr: int, size: int)
+.. method:: copy(self, offset: int, ptr: int, size: int, concurrency: int = 6)
     :noindex:
 
 Copy the given address to the given offset.
@@ -484,11 +469,6 @@ Copy the given address to the given offset.
 
 const char* RemoteBlobBuilder_address = R"doc(
 The memory address value of this blob builder.
-)doc";
-
-const char* RemoteBlobBuilder_buffer = R"doc(
-The writeable buffer behind this blob builder. The result buffer has type
-:code:`memoryview`, and it is a mutable one.
 )doc";
 
 const char* InstanceStatus = R"doc(

--- a/python/pybind11_docs.h
+++ b/python/pybind11_docs.h
@@ -58,7 +58,6 @@ extern const char* Blob_is_empty;
 extern const char* Blob_empty;
 extern const char* Blob__len__;
 extern const char* Blob_address;
-extern const char* Blob_buffer;
 
 extern const char* BlobBuilder;
 extern const char* BlobBuilder_id;
@@ -67,7 +66,6 @@ extern const char* BlobBuilder_abort;
 extern const char* BlobBuilder_shrink;
 extern const char* BlobBuilder_copy;
 extern const char* BlobBuilder_address;
-extern const char* BlobBuilder_buffer;
 
 extern const char* RemoteBlob;
 extern const char* RemoteBlob_id;
@@ -75,14 +73,12 @@ extern const char* RemoteBlob_instance_id;
 extern const char* RemoteBlob_is_empty;
 extern const char* RemoteBlob__len__;
 extern const char* RemoteBlob_address;
-extern const char* RemoteBlob_buffer;
 
 extern const char* RemoteBlobBuilder;
 extern const char* RemoteBlobBuilder_size;
 extern const char* RemoteBlobBuilder_abort;
 extern const char* RemoteBlobBuilder_copy;
 extern const char* RemoteBlobBuilder_address;
-extern const char* RemoteBlobBuilder_buffer;
 
 extern const char* InstanceStatus;
 extern const char* InstanceStatus_instance_id;

--- a/python/pybind11_utils.h
+++ b/python/pybind11_utils.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include <string>
 #include <utility>
 
+#include "common/memory/memcpy.h"
 #include "common/util/json.h"
 #include "common/util/status.h"
 #include "common/util/uuid.h"
@@ -107,17 +108,18 @@ void throw_on_error(Status const& status);
  *
  * @size: capacity of the dst memory block.
  */
-Status copy_memoryview(PyObject* src, void* dst, size_t const size,
-                       size_t const offset = 0);
+Status copy_memoryview(
+    PyObject* src, void* dst, size_t const size, size_t const offset = 0,
+    size_t const concurrency = memory::default_memcpy_concurrency);
 
 /**
  * Copy a memoryview/buffer to a dst pointer.
  *
  * @size: capacity of the dst memoryview.
  */
-Status copy_memoryview_to_memoryview(PyObject* src, PyObject* dst,
-                                     size_t const size,
-                                     size_t const offset = 0);
+Status copy_memoryview_to_memoryview(
+    PyObject* src, PyObject* dst, size_t const size, size_t const offset = 0,
+    size_t const concurrency = memory::default_memcpy_concurrency);
 
 namespace detail {
 py::object from_json(const json& value);

--- a/python/vineyard/data/arrow.py
+++ b/python/vineyard/data/arrow.py
@@ -32,6 +32,7 @@ from vineyard._C import Blob
 from vineyard._C import IPCClient
 from vineyard._C import Object
 from vineyard._C import ObjectMeta
+from vineyard._C import RemoteBlob
 from vineyard.core.builder import BuilderContext
 from vineyard.core.resolver import ResolverContext
 from vineyard.data.utils import build_buffer
@@ -48,16 +49,11 @@ def buffer_builder(client, buffer: Union[bytes, memoryview], builder: BuilderCon
     return build_buffer(client, address, size, builder)
 
 
-def as_arrow_buffer(blob: Blob):
-    if isinstance(blob, Blob):
-        buffer = blob.buffer
+def as_arrow_buffer(blob: Union[Blob, RemoteBlob]):
+    if isinstance(blob, (Blob, RemoteBlob)) and not blob.is_empty:
+        buffer = memoryview(blob)
     else:
-        if not blob.is_empty:
-            buffer = memoryview(blob)
-        else:
-            buffer = memoryview(b'')
-    if buffer is None:
-        return pa.py_buffer(bytearray())
+        buffer = memoryview(b'')
     return pa.py_buffer(buffer)
 
 

--- a/python/vineyard/data/benchmarks/__init__.py
+++ b/python/vineyard/data/benchmarks/__init__.py
@@ -1,0 +1,17 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020-2023 Alibaba Group Holding Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/python/vineyard/data/benchmarks/test_tensor.py
+++ b/python/vineyard/data/benchmarks/test_tensor.py
@@ -1,0 +1,86 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020-2023 Alibaba Group Holding Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import numpy as np
+import pyarrow as pa
+
+try:
+    import pyarrow.plasma as plasma
+except ImportError:
+    plasma = None
+
+import pytest
+import pytest_cases
+
+from vineyard.conftest import vineyard_client
+from vineyard.conftest import vineyard_rpc_client
+from vineyard.core import default_builder_context
+from vineyard.core import default_resolver_context
+from vineyard.data import register_builtin_types
+
+register_builtin_types(default_builder_context, default_resolver_context)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def plasma_client():
+    if plasma is None:
+        pytest.skip("plasma is not installed, pyarrow<=11 is required")
+
+    with plasma.start_plasma_store(plasma_store_memory=1024 * 1024 * 1024 * 8) as (
+        plasma_socket,
+        plasma_proc,
+    ):
+        plasma_client = plasma.connect(plasma_socket)
+        yield plasma_client
+        plasma_client.disconnect()
+        plasma_proc.kill()
+
+
+@pytest.mark.skipif(
+    plasma is None, reason="plasma is not installed, pyarrow<=11 is required"
+)
+@pytest_cases.parametrize(
+    "client,nbytes",
+    [
+        (vineyard_client, '256'),
+        (vineyard_client, '256KB'),
+        (vineyard_client, '256MB'),
+        (vineyard_client, '1GB'),
+        (vineyard_client, '4GB'),
+        (plasma_client, '256'),
+        (plasma_client, '256KB'),
+        (plasma_client, '256MB'),
+        (plasma_client, '1GB'),
+        (plasma_client, '4GB'),
+    ],
+)
+def test_bench_numpy_ndarray(benchmark, client, nbytes):
+    shape = {
+        '256': (64,),
+        '256KB': (64, 1024),
+        '256MB': (64, 1024, 1024),
+        '1GB': (256, 1024, 1024),
+        '4GB': (1024, 1024, 1024),
+    }[nbytes]
+    data = np.random.rand(*shape).astype(np.float32)
+
+    def bench_numpy_ndarray(client, data):
+        object_id = client.put(data)
+        client.delete([object_id])
+
+    benchmark(bench_numpy_ndarray, client, data)

--- a/python/vineyard/drivers/io/adaptors/deserializer.py
+++ b/python/vineyard/drivers/io/adaptors/deserializer.py
@@ -69,7 +69,7 @@ def copy_bytestream_to_blob(client, bs: ByteStream, blob: BlobBuilder):
         serialization_options = json.loads(serialization_options)
     offset = 0
     reader = bs.open_reader(client)
-    buffer = blob.buffer
+    buffer = memoryview(blob)
     raw_buffer = io.BytesIO()
     while True:
         try:

--- a/src/common/memory/memcpy.h
+++ b/src/common/memory/memcpy.h
@@ -19,7 +19,10 @@
 #define SRC_COMMON_MEMORY_MEMCPY_H_
 
 #include <stddef.h>
+#include <stdint.h>
 #include <stdlib.h>
+#include <thread>
+#include <vector>
 
 namespace vineyard {
 
@@ -249,6 +252,41 @@ static inline void * inline_memcpy(void * __restrict dst_, const void * __restri
 #endif
 
 // clang-format on
+
+// use the same default concurrency as apache-arrow.
+static constexpr size_t default_memcpy_concurrency = 6;
+
+static inline void* concurrent_memcpy(void* __restrict dst_,
+                                      const void* __restrict src_, size_t size,
+                                      const size_t concurrency = default_memcpy_concurrency) {
+  static constexpr size_t concurrent_memcpy_threshold = 1024 * 1024 * 4;
+  if (size < concurrent_memcpy_threshold) {
+    inline_memcpy(dst_, src_, size);
+  } else if ((dst_ >= src_ &&
+              dst_ <= static_cast<const uint8_t*>(src_) + size) ||
+             (src_ >= dst_ && src_ <= static_cast<uint8_t*>(dst_) + size)) {
+    inline_memcpy(dst_, src_, size);
+  } else {
+    static constexpr size_t alignment = 1024 * 1024 * 4;
+    size_t chunk_size = (size / concurrency + alignment - 1) & ~(alignment - 1);
+    std::vector<std::thread> threads;
+    for (size_t i = 0; i < concurrency; ++i) {
+      if (size <= i * chunk_size) {
+        break;
+      }
+      size_t chunk = std::min(chunk_size, size - i * chunk_size);
+      threads.emplace_back([=]() {
+        inline_memcpy(static_cast<uint8_t*>(dst_) + i * chunk_size,
+                      static_cast<const uint8_t*>(src_) + i * chunk_size,
+                      chunk);
+      });
+    }
+    for (auto &thread: threads) {
+      thread.join();
+    }
+  }
+  return dst_;
+}
 
 }  // namespace memory
 

--- a/test/concurrent_memcpy_test.cc
+++ b/test/concurrent_memcpy_test.cc
@@ -1,0 +1,65 @@
+/** Copyright 2020-2023 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "common/memory/memcpy.h"
+#include "common/util/logging.h"
+
+using namespace vineyard;  // NOLINT(build/namespaces)
+
+void testing_memcpy(const size_t size) {
+  LOG(INFO) << "Testing memcpy with size: " << size;
+  std::unique_ptr<char[]> src(new char[size]);
+  std::unique_ptr<char[]> dst(new char[size]);
+  for (size_t i = 0; i < size; ++i) {
+    src[i] = i % 256;
+  }
+
+  std::vector<size_t> sizes_to_test = {
+      size, size - 1, size - 3, size - 10, size - 1024, size - 1024 * 1024,
+  };
+
+  for (size_t size_to_test : sizes_to_test) {
+    if (size_to_test > size) {
+      continue;
+    }
+    for (size_t concurrency = 1; concurrency <= 8; ++concurrency) {
+      memset(dst.get(), 0, size_to_test);
+      memory::concurrent_memcpy(dst.get(), src.get(), size_to_test,
+                                concurrency);
+      CHECK_EQ(0, memcmp(dst.get(), src.get(), size_to_test));
+    }
+  }
+  LOG(INFO) << "Passed memcpy test with size: " << size;
+}
+
+int main(int argc, char** argv) {
+  if (argc < 1) {
+    printf("usage ./concurrent_memcpy_test");
+    return 1;
+  }
+
+  for (size_t sz = 1024 * 1024 * 8; sz < 1024 * 1024 * 1024;
+       sz += 1024 * 1024 * 256) {
+    testing_memcpy(sz);
+  }
+
+  LOG(INFO) << "Passed concurrent memcpy tests...";
+
+  return 0;
+}

--- a/test/runner.py
+++ b/test/runner.py
@@ -206,7 +206,7 @@ def make_metadata_settings(meta, endpoint, prefix):
 def start_vineyardd(
     metadata_settings,
     allocator_settings,
-    size=3 * 1024 * 1024 * 1024,
+    size=8 * 1024 * 1024 * 1024,
     default_ipc_socket=VINEYARD_CI_IPC_SOCKET,
     idx=None,
     spill_path="",
@@ -433,6 +433,7 @@ def run_vineyard_cpp_tests(meta, allocator, endpoints, tests):
         # run_test('allocator_test')
         run_test(tests, 'arrow_data_structure_test')
         run_test(tests, 'clear_test')
+        run_test(tests, 'concurrent_memcpy_test')
         run_test(tests, 'custom_vector_test')
         run_test(tests, 'dataframe_test')
         run_test(tests, 'delete_test')


### PR DESCRIPTION
Remove the problematic `.buffer` property (as it cannot bind the lifetime of the underlying blob to the memoryview object) and add concurrent support for memcpy for faster object building.

Fixes #1631