### PR TITLE
Add a const method for GetVertexMap

### DIFF
--- a/modules/graph/fragment/arrow_fragment.vineyard-mod
+++ b/modules/graph/fragment/arrow_fragment.vineyard-mod
@@ -580,7 +580,7 @@ class [[vineyard]] ArrowFragment
                            iodoffset_[v_label][e_label][offset + 1]);
   }
 
-const std::shared_ptr<vertex_map_t> GetVertexMap() const { return vm_ptr_; }
+  const std::shared_ptr<vertex_map_t> GetVertexMap() const { return vm_ptr_; }
 
   std::shared_ptr<vertex_map_t> GetVertexMap() { return vm_ptr_; }
 

--- a/modules/graph/fragment/arrow_fragment.vineyard-mod
+++ b/modules/graph/fragment/arrow_fragment.vineyard-mod
@@ -580,9 +580,7 @@ class [[vineyard]] ArrowFragment
                            iodoffset_[v_label][e_label][offset + 1]);
   }
 
-  const std::shared_ptr<vertex_map_t> GetVertexMap() const {
-    return vm_ptr_;
-  }
+const std::shared_ptr<vertex_map_t> GetVertexMap() const { return vm_ptr_; }
 
   std::shared_ptr<vertex_map_t> GetVertexMap() { return vm_ptr_; }
 

--- a/modules/graph/fragment/arrow_fragment.vineyard-mod
+++ b/modules/graph/fragment/arrow_fragment.vineyard-mod
@@ -580,6 +580,10 @@ class [[vineyard]] ArrowFragment
                            iodoffset_[v_label][e_label][offset + 1]);
   }
 
+  const std::shared_ptr<vertex_map_t> GetVertexMap() const {
+    return vm_ptr_;
+  }
+
   std::shared_ptr<vertex_map_t> GetVertexMap() { return vm_ptr_; }
 
   void PrepareToRunApp(const grape::CommSpec& comm_spec,


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------
We I want to use Arrow fragment's method GetVertexMap() in GAE apps, there will be a compile error, as the fragment is const, but the method is not const, so, add a new const method for GAE apps.
`void PEval(const fragment_t& frag, context_t& ctx,
             message_manager_t& messages) `


<!-- Please give a short brief about these changes. -->




