### PR TITLE
Fix the unit test error and adjust the condition for fetching objects

### DIFF
--- a/k8s/cmd/commands/deploy/deploy_vineyard_deployment.go
+++ b/k8s/cmd/commands/deploy/deploy_vineyard_deployment.go
@@ -105,9 +105,9 @@ func GetVineyardDeploymentObjectsFromTemplate() ([]*unstructured.Unstructured, e
 			return etcdConfig
 		},
 		"toYaml": func(v interface{}) string {
-			bs, error := yaml.Marshal(v)
-			if error != nil {
-				log.Error(error, "failed to marshal object %v to yaml", v)
+			bs, err := yaml.Marshal(v)
+			if err != nil {
+				log.Error(err, "failed to marshal object %v to yaml", v)
 				return ""
 			}
 			return string(bs)

--- a/k8s/cmd/commands/deploy/deploy_vineyard_deployment_test.go
+++ b/k8s/cmd/commands/deploy/deploy_vineyard_deployment_test.go
@@ -403,6 +403,7 @@ func TestGetVineyardDeploymentObjectsFromTemplate_third(t *testing.T) {
 												"limits":   nil,
 												"requests": nil,
 											},
+											"securityContext": map[string]interface{}{},
 											"command": []interface{}{
 												"/bin/bash",
 												"-c",

--- a/k8s/cmd/commands/inject/inject.go
+++ b/k8s/cmd/commands/inject/inject.go
@@ -240,6 +240,7 @@ var (
 	    resources:
 	      limits: null
 	      requests: null
+	    securityContext: {}
 	    volumeMounts:
 	    - mountPath: /var/run
 	      name: vineyard-socket
@@ -487,9 +488,9 @@ func GetManifestFromTemplate(workload string) (OutputManifests, error) {
 			return etcdConfig
 		},
 		"toYaml": func(v interface{}) string {
-			bs, error := yaml.Marshal(v)
-			if error != nil {
-				log.Error(error, "failed to marshal object %v to yaml", v)
+			bs, err := yaml.Marshal(v)
+			if err != nil {
+				log.Error(err, "failed to marshal object %v to yaml", v)
 				return ""
 			}
 			return string(bs)

--- a/k8s/cmd/commands/inject/inject_test.go
+++ b/k8s/cmd/commands/inject/inject_test.go
@@ -246,6 +246,7 @@ spec:
         resources:
           limits: null
           requests: null
+        securityContext: {}
         volumeMounts:
         - mountPath: /var/run
           name: vineyard-socket
@@ -303,6 +304,7 @@ spec:
     resources:
       limits: null
       requests: null
+    securityContext: {}
     volumeMounts:
     - mountPath: /var/run
       name: vineyard-socket

--- a/k8s/cmd/commands/util/template_test.go
+++ b/k8s/cmd/commands/util/template_test.go
@@ -18,6 +18,7 @@ package util
 import (
 	_ "embed"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -25,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
 
 	"github.com/v6d-io/v6d/k8s/apis/k8s/v1alpha1"
 	"github.com/v6d-io/v6d/k8s/cmd/commands/flags"
@@ -56,6 +58,18 @@ func Test_RenderManifestAsObj(t *testing.T) {
 					},
 					"getEtcdConfig": func() k8s.EtcdConfig {
 						return etcdConfig
+					},
+					"toYaml": func(v interface{}) string {
+						bs, err := yaml.Marshal(v)
+						if err != nil {
+							t.Error(err, "failed to marshal object %v to yaml", v)
+							return ""
+						}
+						return string(bs)
+					},
+					"indent": func(spaces int, s string) string {
+						prefix := strings.Repeat(" ", spaces)
+						return prefix + strings.Replace(s, "\n", "\n"+prefix, -1)
 					},
 				},
 			},
@@ -152,6 +166,18 @@ func TestBuildObjsFromEtcdManifests(t *testing.T) {
 		"getEtcdConfig": func() k8s.EtcdConfig {
 			return etcdConfig
 		},
+		"toYaml": func(v interface{}) string {
+			bs, err := yaml.Marshal(v)
+			if err != nil {
+				t.Error(err, "failed to marshal object %v to yaml", v)
+				return ""
+			}
+			return string(bs)
+		},
+		"indent": func(spaces int, s string) string {
+			prefix := strings.Repeat(" ", spaces)
+			return prefix + strings.Replace(s, "\n", "\n"+prefix, -1)
+		},
 	}
 	vineyardd := value
 	name := vineyardd.Name
@@ -215,6 +241,18 @@ func TestBuildObjsFromVineyarddManifests(t *testing.T) {
 		"getEtcdConfig": func() k8s.EtcdConfig {
 			return etcdConfig
 		},
+		"toYaml": func(v interface{}) string {
+			bs, err := yaml.Marshal(v)
+			if err != nil {
+				t.Error(err, "failed to marshal object %v to yaml", v)
+				return ""
+			}
+			return string(bs)
+		},
+		"indent": func(spaces int, s string) string {
+			prefix := strings.Repeat(" ", spaces)
+			return prefix + strings.Replace(s, "\n", "\n"+prefix, -1)
+		},
 	}
 
 	objs, err := BuildObjsFromVineyarddManifests(files, value, tmplFunc)
@@ -270,6 +308,18 @@ func TestBuildObjsFromManifests(t *testing.T) {
 		},
 		"getBackupConfig": func() k8s.BackupConfig {
 			return backupCfg
+		},
+		"toYaml": func(v interface{}) string {
+			bs, err := yaml.Marshal(v)
+			if err != nil {
+				t.Error(err, "failed to marshal object %v to yaml", v)
+				return ""
+			}
+			return string(bs)
+		},
+		"indent": func(spaces int, s string) string {
+			prefix := strings.Repeat(" ", spaces)
+			return prefix + strings.Replace(s, "\n", "\n"+prefix, -1)
 		},
 	}
 

--- a/k8s/controllers/k8s/sidecar_controller.go
+++ b/k8s/controllers/k8s/sidecar_controller.go
@@ -70,9 +70,9 @@ func (r *SidecarReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		TmplFunc: map[string]interface{}{
 			"getEtcdConfig": nil,
 			"toYaml": func(v interface{}) string {
-				bs, error := yaml.Marshal(v)
-				if error != nil {
-					logger.Error(error, "failed to marshal object %v to yaml", v)
+				bs, err := yaml.Marshal(v)
+				if err != nil {
+					logger.Error(err, "failed to marshal object %v to yaml", v)
 					return ""
 				}
 				return string(bs)

--- a/k8s/controllers/k8s/vineyardd_controller.go
+++ b/k8s/controllers/k8s/vineyardd_controller.go
@@ -91,9 +91,9 @@ func (r *VineyarddReconciler) Reconcile(
 				return q.String()
 			},
 			"toYaml": func(v interface{}) string {
-				bs, error := yaml.Marshal(v)
-				if error != nil {
-					logger.Error(error, "failed to marshal object %v to yaml", v)
+				bs, err := yaml.Marshal(v)
+				if err != nil {
+					logger.Error(err, "failed to marshal object %v to yaml", v)
 					return ""
 				}
 				return string(bs)

--- a/python/vineyard/core/client.py
+++ b/python/vineyard/core/client.py
@@ -530,7 +530,7 @@ class Client:
         meta = self.get_meta(object_id)
 
         if self.has_ipc_client():
-            if meta.instance_id == self._ipc_client.instance_id:
+            if meta.instance_id == self._ipc_client.instance_id or meta.isglobal:
                 return self._ipc_client.get_object(object_id, fetch=False)
             else:
                 warnings.warn(


### PR DESCRIPTION
What do these changes do?
-------------------------

The e2e repartition is caused by the error as follows.
```
 start to get ddf                                                                                                                                                                                       │
│ /usr/local/lib/python3.10/site-packages/vineyard/core/client.py:536: UserWarning: Migrating object ObjectID <"o0024772b04722d27"> from another vineyard instance 18446744073709551615                  │
│   warnings.warn(                                                                                                                                                                                       │
│ Traceback (most recent call last):                                                                                                                                                                     │
│   File "/job.py", line 55, in <module>                                                                                                                                                                 │
│     data = client.get(vineyard.ObjectID(gid),                                                                                                                                                          │
│   File "/usr/local/lib/python3.10/site-packages/vineyard/core/client.py", line 582, in get                                                                                                             │
│     return get(self, object_id, name, resolver, fetch, **kwargs)                                                                                                                                       │
│   File "/usr/local/lib/python3.10/site-packages/vineyard/core/resolver.py", line 235, in get                                                                                                           │
│     obj = client.get_object(object_id)                                                                                                                                                                 │
│   File "/usr/local/lib/python3.10/site-packages/vineyard/core/client.py", line 451, in get_object                                                                                                      │
│     return self._fetch_object(object_id)                                                                                                                                                               │
│   File "/usr/local/lib/python3.10/site-packages/vineyard/core/client.py", line 540, in _fetch_object                                                                                                   │
│     return self._ipc_client.get_object(object_id, fetch=True)                                                                                                                                          │
│ vineyard._C.InvalidException: Invalid: IPC error at /work/v6d/src/common/util/protocols.cc:2072: global objects cannot be directly migrated 
```

Add a juadgement before fetching object to fix that.


Related issue number
--------------------

Fixes #1679 

