### PR TITLE
Packed nbr_unit_t to decrease the memory footprint when using int32_t as vid_t

### DIFF
--- a/k8s/cmd/main.go
+++ b/k8s/cmd/main.go
@@ -48,7 +48,7 @@ var cmdLong = util.LongDesc(`
 
 var cmd = &cobra.Command{
 	Use:     "vineyardctl [command]",
-	Version: "v0.19.3",
+	Version: "v0.20.0",
 	Short:   "vineyardctl is the command-line tool for interact with the Vineyard Operator.",
 	Long:    cmdLong,
 }

--- a/modules/graph/CMakeLists.txt
+++ b/modules/graph/CMakeLists.txt
@@ -1,5 +1,18 @@
 include(GNUInstallDirs)
 
+# options to control several default behaviors of vineyard graph
+option(VINEYARD_GRAPH_MAX_LABEL_ID "Maximum label id value of vineyard graphs, defaults to 128" OFF)
+
+option(MY_OPTION "Description of My Option" OFF)
+set(VINEYARD_GRAPH_MAX_LABEL_ID_DEFAULT_VALUE 128 CACHE STRING "Default value for maximum label if for vineyard graphs")
+set_property(CACHE VINEYARD_GRAPH_MAX_LABEL_ID PROPERTY STRINGS "1;2;4;8;16;32;64;128")
+
+if (VINEYARD_GRAPH_MAX_LABEL_ID)
+    message(STATUS "Setting VINEYARD_GRAPH_MAX_LABEL_ID to '${VINEYARD_GRAPH_MAX_LABEL_ID}'")
+else()
+    message(STATUS "Setting VINEYARD_GRAPH_MAX_LABEL_ID to default value: '${VINEYARD_GRAPH_MAX_LABEL_ID_DEFAULT_VALUE}'")
+endif()
+
 # build vineyard-graph
 file(GLOB_RECURSE VINEYARD_MOD_SRCS "${CMAKE_CURRENT_SOURCE_DIR}"
                                     "*.vineyard-mod")
@@ -135,6 +148,10 @@ if(BUILD_VINEYARD_GRAPH_WITH_GAR)
         # depends on gar
         target_link_libraries(vineyard_graph PRIVATE gar)
     endif()
+endif()
+
+if (VINEYARD_GRAPH_MAX_LABEL_ID)
+    target_compile_options(vineyard_graph PUBLIC -DVINEYARD_GRAPH_MAX_LABEL_ID=${VINEYARD_GRAPH_MAX_LABEL_ID})
 endif()
 
 target_link_libraries(vineyard_graph PUBLIC vineyard_client

--- a/modules/graph/README.rst
+++ b/modules/graph/README.rst
@@ -19,6 +19,18 @@ among graph computing engines.
     * `Read Options <#read-options>`_
     * `Global Options <#global-options>`_
 
+CMake configure options
+-----------------------
+
+- :code:`VINEYARD_GRAPH_MAX_LABEL_ID`
+
+  The internal vertex id (aka. :code:`VID`) in vineyard is encoded as fragment id, vertex label id
+  and vertex offset. The option :code:`VINEYARD_GRAPH_MAX_LABEL_ID` decides the bit field width of
+  label id in :code:`VID`. Decreasing this value can be helpful to support larger number of vertices
+  when using :code:`int32_t` as :code:`VID_T`.
+
+  Defaults to `128`, can be `1`, `2`, `4`, `8`, `16`, `32`, `64`, or `128`.
+
 vineyard-graph-loader
 ---------------------
 


### PR DESCRIPTION
Fixes #1714 

