### PR TITLE
Add a command line flag `--etcd_data_dir` for etcd's data dir

### DIFF
--- a/src/server/util/etcd_launcher.cc
+++ b/src/server/util/etcd_launcher.cc
@@ -180,13 +180,28 @@ Status EtcdLauncher::LaunchEtcdServer(
   args.emplace_back(peer_endpoint);
 
   // use a random etcd data dir
-  std::string file_template = "/tmp/vineyard-etcd-XXXXXX";
-  char* data_dir = mkdtemp(const_cast<char*>(file_template.c_str()));
-  if (data_dir == nullptr) {
-    return Status::EtcdError(
-        "Failed to create a temporary directory for etcd data");
+  etcd_data_dir_ = etcd_spec_.value("etcd_data_dir", "");
+  if (etcd_data_dir_.empty()) {
+    std::string file_template = "/tmp/vineyard-etcd-XXXXXX";
+    char* data_dir = mkdtemp(const_cast<char*>(file_template.c_str()));
+    if (data_dir == nullptr) {
+      return Status::EtcdError(
+          "Failed to create a temporary directory for etcd data");
+    }
+    etcd_data_dir_ = data_dir;
   }
-  etcd_data_dir_ = data_dir;
+  // prepare the data dir
+  if (!ghc::filesystem::exists(ghc::filesystem::path(etcd_data_dir_))) {
+    std::error_code err;
+    ghc::filesystem::create_directories(ghc::filesystem::path(etcd_data_dir_),
+                                        err);
+    if (err) {
+      return Status::EtcdError("Failed to create etcd data directory: " +
+                               err.message());
+    }
+  }
+  LOG(INFO) << "Vineyard will use '" << etcd_data_dir_
+            << "' as the data directory of etcd";
   args.emplace_back("--data-dir");
   args.emplace_back(etcd_data_dir_);
 

--- a/src/server/util/spec_resolvers.cc
+++ b/src/server/util/spec_resolvers.cc
@@ -50,6 +50,7 @@ DEFINE_int64(meta_timeout, 60 /* 1 minutes */,
 DEFINE_string(etcd_endpoint, "http://127.0.0.1:2379", "endpoint of etcd");
 DEFINE_string(etcd_prefix, "vineyard", "metadata path prefix in etcd");
 DEFINE_string(etcd_cmd, "", "path of etcd executable");
+DEFINE_string(etcd_data_dir, "default.etcd", "path of etcd's data directory");
 #endif
 
 #if defined(BUILD_VINEYARDD_REDIS)
@@ -144,6 +145,7 @@ json MetaStoreSpecResolver::resolve() const {
   spec["etcd_prefix"] = FLAGS_etcd_prefix;
   spec["etcd_endpoint"] = FLAGS_etcd_endpoint;
   spec["etcd_cmd"] = FLAGS_etcd_cmd;
+  spec["etcd_data_dir"] = FLAGS_etcd_data_dir;
 #endif
 
   // resolve for redis


### PR DESCRIPTION
What do these changes do?
-------------------------

Add the command line flag `--etcd_data_dir`.

Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1722

