### PR TITLE
Check whether the ipc socket exist When parsing the config YAML.

### DIFF
--- a/python/vineyard/core/client.py
+++ b/python/vineyard/core/client.py
@@ -83,9 +83,14 @@ def _parse_configuration(config) -> Tuple[Optional[str], Optional[str]]:
     ipc_socket = vineyard_config.get('IPCSocket', None)
     rpc_endpoint = vineyard_config.get('RPCEndpoint', None)
 
-    if ipc_socket and not os.path.isabs(ipc_socket):
-        base_dir = os.path.dirname(config) if os.path.isfile(config) else config
-        ipc_socket = os.path.join(base_dir, ipc_socket)
+    if ipc_socket:
+        if not os.path.isabs(ipc_socket):
+            base_dir = os.path.dirname(config) if os.path.isfile(config) else config
+            ipc_socket = os.path.join(base_dir, ipc_socket)
+
+        if not os.path.exists(ipc_socket):
+            ipc_socket = None
+
     return ipc_socket, rpc_endpoint
 
 

--- a/python/vineyard/deploy/kubernetes.py
+++ b/python/vineyard/deploy/kubernetes.py
@@ -108,9 +108,9 @@ def start_vineyardd(
             'Port': rpc_socket_port,
             'Image': vineyard_image,
             'ImagePullPolicy': vineyard_image_pull_policy,
-            'ImagePullSecrets': vineyard_image_pull_secrets
-            if vineyard_image_pull_secrets
-            else 'none',
+            'ImagePullSecrets': (
+                vineyard_image_pull_secrets if vineyard_image_pull_secrets else 'none',
+            ),
         }
         definitions = fp.read().format(**formatter)
 

--- a/python/vineyard/shared_memory/shared_memory.py
+++ b/python/vineyard/shared_memory/shared_memory.py
@@ -195,10 +195,14 @@ class ShareableList(shm.ShareableList):
 
             sequence = sequence or ()
             _formats = [
-                self._types_mapping[type(item)]
-                if not isinstance(item, (str, bytes))  # noqa: E131
-                else self._types_mapping[type(item)]
-                % (self._alignment * (len(item) // self._alignment + 1),)  # noqa: E131
+                (
+                    self._types_mapping[type(item)]
+                    if not isinstance(item, (str, bytes))  # noqa: E131
+                    else self._types_mapping[type(item)]
+                    % (
+                        self._alignment * (len(item) // self._alignment + 1),
+                    )  # noqa: E131
+                )
                 for item in sequence
             ]
             self._list_len = len(_formats)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ linkify-it-py
 myst-parser>=0.13.0
 nbsphinx
 pygments>=2.4.1
-pytest
+pytest<8.0.0
 pytest-benchmark
 pytest-cases
 pytest-datafiles


### PR DESCRIPTION
What do these changes do?
-------------------------

When using something like `client = vineyard.connect(config=./vineyard.yaml)`, we need to check whether the IPC socket file exists.
