### PR TITLE
Fixes roundtrip put/get pyspark.dataframe into/from vineyard.

### DIFF
--- a/python/vineyard/contrib/pyspark/pyspark.py
+++ b/python/vineyard/contrib/pyspark/pyspark.py
@@ -73,9 +73,7 @@ def pyspark_table_resolver(obj, resolver, **kw):  # pylint: disable=unused-argum
         _jvineyardRDD = jvm.io.v6d.spark.rdd.VineyardRDD(
             sc._jsc.sc(), _jmeta, "partitions_", socket, _jclient.getClusterStatus()
         )
-        _jTableRDD = jvm.io.v6d.spark.rdd.TableRDD.fromVineyard(
-            _jvineyardRDD
-        )
+        _jTableRDD = jvm.io.v6d.spark.rdd.TableRDD.fromVineyard(_jvineyardRDD)
         _jdf = _jTableRDD.makeDataFrame(_jclient, sparkSession._jsparkSession, _jmeta)
         df = _java2py(sc, _jdf)
         return df


### PR DESCRIPTION
Previously(#1529), putting a pyspark.dataframe into vineyard defaulted to the `vineyard::Table` type, getting it back to pyspark.dataframe required very ad-hoc operations. These changes add wrappers to make the `put/get` pyspark.dataframe to vineyard more intuitive. An example:

```python3
# Assume you already have a dataframe.
id = vineyard_client.put(dataframe, spark_conf=conf, socket=vineyard_socket)
your_df = vineyard_client.get(id, spark_conf=conf, socket=vineyard_socket)
```