### PR TITLE
Create a hard link of vineyard socket rather than mount its parent directory.

### DIFF
--- a/docker/vineyard-fluid-fuse/entrypoint.sh
+++ b/docker/vineyard-fluid-fuse/entrypoint.sh
@@ -3,7 +3,7 @@ set -ex
 
 SOCKET_FILE="$FUSE_DIR/vineyard.sock"
 RPC_CONFIG_FILE="$RPC_CONF_DIR/VINEYARD_RPC_ENDPOINT"
-VINEYARD_YAML_FILE="$FUSE_DIR/vineyard.yaml"
+VINEYARD_YAML_FILE="$FUSE_DIR/vineyard-config.yaml"
 
 # Write the IPCSocket and RPCEndpoints to the vineyard configurations YAML file
 write_yaml_config() {
@@ -14,31 +14,27 @@ write_yaml_config() {
 
 mkdir -p $FUSE_DIR
 while true; do
-    # check if prestop marker exists, if so, skip mounting
+    # check if prestop marker exists, if so, skip creating the hard link
     if [ -f $PRESTOP_MARKER ]; then
-        echo "PreStop hook is in progress, skip mounting."
+        echo "PreStop hook is in progress, skip creating the hard link of vineyard socket."
         break
     fi
-    # before mounting, store the rpc endpoint to a variable
+    # before creating the hard link of vineyard socket, store the rpc endpoint to a variable
     if [ -f $RPC_CONFIG_FILE ]; then
         VINEYARD_RPC_ENDPOINT=$(cat $RPC_CONFIG_FILE)
     else
         echo "rpc config file $RPC_CONFIG_FILE does not exist."
     fi
 
-    if [ ! -S $SOCKET_FILE ]; then
-        echo "Checking if vineyard-fuse is already a mount point..."
-        if ! mountpoint -q $FUSE_DIR; then
-            echo "mount vineyard socket..."
-            mount --bind $MOUNT_DIR $FUSE_DIR
-            echo "write vineyard ipc socket and rpc endpoint to vineyard configuration YAML..."
-            write_yaml_config "$VINEYARD_RPC_ENDPOINT"
-        else
-            echo "$FUSE_DIR is already a mount point."
-        fi
+    echo "write vineyard ipc socket and rpc endpoint to vineyard configuration YAML..."
+    write_yaml_config "$VINEYARD_RPC_ENDPOINT"
+    echo "check whether vineyard socket symlink is created..."
+    if [ ! -S $SOCKET_FILE ] && [ -S $MOUNT_DIR/vineyard.sock ]; then
+        echo "create a hard link of vineyard socket..."
+        ln $MOUNT_DIR/vineyard.sock $SOCKET_FILE
     else
         echo "$SOCKET_FILE exists."
     fi
-    # wait for a minute so that the fuse mount point can be checked again
+    # wait for a minute so that the hard link of vineyard socket can be checked again
     sleep 60
 done

--- a/python/vineyard/__init__.py
+++ b/python/vineyard/__init__.py
@@ -295,9 +295,10 @@ def connect(*args, **kwargs):
     Connect to vineyard by specified UNIX-domain socket or TCP endpoint.
 
     If no arguments are provided and failed to resolve both the environment
-    variables :code:`VINEYARD_IPC_SOCKET`, :code:`VINEYARD_RPC_ENDPOINT`, and
-    :code:`VINEYARD_CONFIG`, it will launch a standalone vineyardd
-    server in the background and then connect to it.
+    variables :code:`VINEYARD_IPC_SOCKET`, :code:`VINEYARD_RPC_ENDPOINT`,
+    :code:`VINEYARD_CONFIG`, and the default configuration file 
+    :code:`/var/run/vineyard-config.yaml`, it will launch a standalone
+    vineyardd server in the background and then connect to it.
 
     The `connect()` method has various overloading:
 
@@ -400,6 +401,7 @@ def connect(*args, **kwargs):
         and 'VINEYARD_IPC_SOCKET' not in os.environ
         and 'VINEYARD_RPC_ENDPOINT' not in os.environ
         and 'VINEYARD_CONFIG' not in os.environ
+        and not os.path.exists("/var/run/vineyard-config.yaml")
     ):
         logger.info(
             'No vineyard socket or endpoint is specified, '

--- a/python/vineyard/__init__.py
+++ b/python/vineyard/__init__.py
@@ -427,7 +427,7 @@ def put(
         E.g. 127.0.0.1:9600
     VINEYARD_CONFIG:
         Either be a path to a YAML configuration file or a path to a
-        directory containing the default config file `vineyard.yaml`.
+        directory containing the default config file `vineyard-config.yaml`.
 
         The configuration file should be like:
 
@@ -492,7 +492,7 @@ def get(
         E.g. 127.0.0.1:9600
     VINEYARD_CONFIG:
         Either be a path to a YAML configuration file or a path to a
-        directory containing the default config file `vineyard.yaml`.
+        directory containing the default config file `vineyard-config.yaml`.
 
         The configuration file should be like:
 

--- a/python/vineyard/__init__.py
+++ b/python/vineyard/__init__.py
@@ -296,7 +296,7 @@ def connect(*args, **kwargs):
 
     If no arguments are provided and failed to resolve both the environment
     variables :code:`VINEYARD_IPC_SOCKET`, :code:`VINEYARD_RPC_ENDPOINT`,
-    :code:`VINEYARD_CONFIG`, and the default configuration file 
+    :code:`VINEYARD_CONFIG`, and the default configuration file
     :code:`/var/run/vineyard-config.yaml`, it will launch a standalone
     vineyardd server in the background and then connect to it.
 

--- a/python/vineyard/core/client.py
+++ b/python/vineyard/core/client.py
@@ -56,7 +56,7 @@ def _parse_configuration(config) -> Tuple[Optional[str], Optional[str]]:
 
     Parameters:
         config: Path to a YAML configuration file or a directory containing
-                the default config file `vineyard.yaml`.
+                the default config file `vineyard-config.yaml`.
 
     Returns:
         (socket, endpoints): IPC socket path and RPC endpoints.
@@ -70,7 +70,7 @@ def _parse_configuration(config) -> Tuple[Optional[str], Optional[str]]:
         return None, None
 
     if os.path.isdir(config):
-        config = os.path.join(config, 'vineyard.yaml')
+        config = os.path.join(config, 'vineyard-config.yaml')
     if not os.path.isfile(config):
         return None, None
 
@@ -131,8 +131,8 @@ class Client:
         - `connect('hostname', port)`, which will try to establish an RPC connection.
         - `connect(endpoint=('hostname', port))`, which will try to establish an RPC
           connection.
-        - `connect(config='/path/to/vineyard.yaml')`, which will try to resolve the IPC
-          socket and RPC endpoints from the configuration file.
+        - `connect(config='/path/to/vineyard-config.yaml')`, which will try to
+          resolve the IPC socket and RPC endpoints from the configuration file.
 
         Parameters:
             socket: Optional, the path to the IPC socket, or RPC endpoints of format
@@ -147,10 +147,10 @@ class Client:
                       is enabled.
             config: Optional, can either be a path to a YAML configuration file or
                     a path to a directory containing the default config file
-                    `vineyard.yaml`. Also, the environment variable
+                    `vineyard-config.yaml`. Also, the environment variable
                     `VINEYARD_CONFIG` can be used to specify the
                     path to the configuration file. If not defined, the default
-                    config file `/var/run/vineyard/config.yaml` will be used.
+                    config file `/var/run/vineyard-config.yaml` will be used.
 
         The content of the configuration file should has the following content:
 
@@ -179,7 +179,7 @@ class Client:
         if not endpoint and not (host and port):
             endpoint = os.getenv('VINEYARD_RPC_ENDPOINT', None)
         if not config:
-            config = os.getenv('VINEYARD_CONFIG', '/var/run/vineyard/config.yaml')
+            config = os.getenv('VINEYARD_CONFIG', '/var/run/vineyard-config.yaml')
         if endpoint:
             if not isinstance(endpoint, (tuple, list)):
                 endpoint = endpoint.split(':')


### PR DESCRIPTION
What do these changes do?
-------------------------

- Create a hard link of vineyard socket rather than mount its parent directory in `vineyard-fluid-fuse`.
- Change the vineyard configuration from `vineyard.yaml` to `config.yaml`.

Related issue number
--------------------

Related to https://github.com/fluid-cloudnative/fluid/pull/3713

