### PR TITLE
Improve the query API of llm cache and use vector<uint8_t> as payload object.

### DIFF
--- a/modules/basic/ds/dataframe.cc
+++ b/modules/basic/ds/dataframe.cc
@@ -85,6 +85,12 @@ const std::shared_ptr<arrow::RecordBatch> DataFrame::AsBatch(bool copy) const {
     } else if (auto tensor =
                    std::dynamic_pointer_cast<Tensor<std::string>>(df_col)) {
       num_rows = tensor->shape()[0];
+    } else if (auto tensor =
+                   std::dynamic_pointer_cast<Tensor<uint8_t>>(df_col)) {
+      num_rows = tensor->shape()[0];
+    } else if (auto tensor =
+                   std::dynamic_pointer_cast<Tensor<int8_t>>(df_col)) {
+      num_rows = tensor->shape()[0];
     }
 
     std::vector<std::shared_ptr<arrow::Buffer>> buffer{

--- a/modules/llm-cache/ds/kv_state_cache.cc
+++ b/modules/llm-cache/ds/kv_state_cache.cc
@@ -45,7 +45,9 @@ void KVStateCache::Resolve() {
   // 1. construct the radix tree
   this->rootTree = RadixTree::Deserialize(
       base64_decode(this->meta_.GetKeyValue<std::string>("radix_tree")));
-  // raxShow(this->rootTree->GetRootTree());
+  if (VLOG_IS_ON(100)) {
+    VLOG(100) << raxShow(this->rootTree->GetRootTree());
+  }
 
   // 2. construct the kvStateCacheBlockBuilder list
   size_t numBlocks = this->meta_.GetKeyValue<size_t>("numBlocks");
@@ -57,24 +59,24 @@ void KVStateCache::Resolve() {
   }
 
   // 3. construct the member field
-  this->dimension = this->meta_.GetKeyValue<int>("dimension");
+  this->tensorBytes = this->meta_.GetKeyValue<int>("tensorBytes");
   this->version = this->meta_.GetKeyValue<uint64_t>("version");
   this->layer = this->meta_.GetKeyValue<int>("layer");
-  VLOG(100) << "construct the member field success, with dimension:"
-            << this->dimension << " version:" << this->version
+  VLOG(100) << "construct the member field success, with tensorBytes:"
+            << this->tensorBytes << " version:" << this->version
             << " layer:" << this->layer;
 }
 
 KVStateCache::~KVStateCache() {}
 
-KVStateCacheBuilder::KVStateCacheBuilder(Client& client, int dimension,
+KVStateCacheBuilder::KVStateCacheBuilder(Client& client, int tensorBytes,
                                          int cacheCapacity, int layer,
                                          int blockSize) {
-  this->dimension = dimension;
+  this->tensorBytes = tensorBytes;
   this->version = 0;
   this->layer = layer;
   KVStateCacheBlockBuilder* builder =
-      new KVStateCacheBlockBuilder(client, this->dimension, layer, blockSize);
+      new KVStateCacheBlockBuilder(client, this->tensorBytes, layer, blockSize);
 
   this->rootTree = std::make_shared<RadixTree>(cacheCapacity);
 
@@ -90,7 +92,7 @@ KVStateCacheBuilder::KVStateCacheBuilder(Client& client, int dimension,
 
 KVStateCacheBuilder::KVStateCacheBuilder(Client& client,
                                          std::shared_ptr<KVStateCache> cache) {
-  this->dimension = cache->GetDimension();
+  this->tensorBytes = cache->GetTensorBytes();
   this->version = cache->GetVersion();
   this->layer = cache->GetLayer();
   // 1. create block builder from block
@@ -114,11 +116,11 @@ KVStateCacheBuilder::KVStateCacheBuilder(Client& client,
 
 KVStateCacheBlockBuilder* KVStateCacheBuilder::Split(
     Client& client, KVStateCacheBlockBuilder* kvStateCacheBlockBuilder,
-    std::vector<std::shared_ptr<NodeData>> nodeDataList) {
+    std::vector<std::shared_ptr<NodeData>>& nodeDataList) {
   // Split the tree if the list of kvState is full.
   VINEYARD_ASSERT(nodeDataList.size() > 0);
   KVStateCacheBlockBuilder* childKVStateCacheBlockBuilder =
-      new KVStateCacheBlockBuilder(client, this->dimension, this->layer,
+      new KVStateCacheBlockBuilder(client, this->tensorBytes, this->layer,
                                    kvStateCacheBlockBuilder->GetBlockSize());
   for (size_t i = 0; i < nodeDataList.size(); i++) {
     OffsetData* data =
@@ -138,10 +140,9 @@ KVStateCacheBlockBuilder* KVStateCacheBuilder::Split(
   return childKVStateCacheBlockBuilder;
 }
 
-void KVStateCacheBuilder::Update(Client& client,
-                                 const std::vector<int>& tokenList,
-                                 int nextToken,
-                                 const KV_STATE_WITH_LAYER& kvState) {
+void KVStateCacheBuilder::Update(
+    Client& client, const std::vector<int>& tokenList, int nextToken,
+    const std::map<int, std::pair<LLMKV, LLMKV>>& kvState) {
   std::vector<int> tokenListCopy = tokenList;
   tokenListCopy.push_back(nextToken);
 
@@ -199,9 +200,9 @@ void KVStateCacheBuilder::Update(Client& client,
             << " bitmap:" << kvStateCacheBlockBuilder->GetBitmapStr();
 }
 
-int KVStateCacheBuilder::Query(Client& client,
-                               const std::vector<int>& tokenList, int token,
-                               KV_STATE_WITH_LAYER& kvState) {
+int KVStateCacheBuilder::Query(
+    Client& client, const std::vector<int>& tokenList, int token,
+    std::map<int, std::pair<LLMKV, LLMKV>>& kvState) {
   std::vector<int> tokenListCopy = tokenList;
   tokenListCopy.push_back(token);
 
@@ -275,14 +276,14 @@ void KVStateCacheBuilder::Merge(Client& client,
   for (auto it = insertTokenList.begin(); it != insertTokenList.end(); ++it) {
     std::vector<int> tokenList =
         std::vector<int>((*it).begin(), (*it).end() - 1);
-    KV_STATE_WITH_LAYER kvState;
+    std::map<int, std::pair<LLMKV, LLMKV>> kvState;
     for (int currentLayer = 0; currentLayer < this->layer; currentLayer++) {
-      K_STATE key_state;
-      V_STATE value_state;
-      key_state.data = malloc(this->dimension * sizeof(double));
-      key_state.length = this->dimension * sizeof(double);
-      value_state.data = malloc(this->dimension * sizeof(double));
-      value_state.length = this->dimension * sizeof(double);
+      LLMKV key_state;
+      LLMKV value_state;
+      key_state.data = malloc(this->tensorBytes);
+      key_state.length = this->tensorBytes;
+      value_state.data = malloc(this->tensorBytes);
+      value_state.length = this->tensorBytes;
 
       kvState.insert(
           std::make_pair(currentLayer, std::make_pair(key_state, value_state)));
@@ -290,8 +291,8 @@ void KVStateCacheBuilder::Merge(Client& client,
     globalCacheBuilder->Query(client, tokenList, (*it).back(), kvState);
     this->Update(client, tokenList, (*it).back(), kvState);
     for (int currentLayer = 0; currentLayer < this->layer; currentLayer++) {
-      K_STATE key_state = kvState[currentLayer].first;
-      V_STATE value_state = kvState[currentLayer].second;
+      LLMKV key_state = kvState[currentLayer].first;
+      LLMKV value_state = kvState[currentLayer].second;
       free(key_state.data);
       free(value_state.data);
     }
@@ -309,7 +310,7 @@ std::shared_ptr<Object> KVStateCacheBuilder::_Seal(Client& client) {
   std::shared_ptr<KVStateCache> kvStateCache = std::make_shared<KVStateCache>();
 
   // 1. store the member variables to cache object meta
-  kvStateCache->meta_.AddKeyValue("dimension", this->dimension);
+  kvStateCache->meta_.AddKeyValue("tensorBytes", this->tensorBytes);
   kvStateCache->meta_.AddKeyValue("version", this->version);
   kvStateCache->meta_.AddKeyValue("layer", this->layer);
 

--- a/modules/llm-cache/ds/kv_state_cache_manager.h
+++ b/modules/llm-cache/ds/kv_state_cache_manager.h
@@ -14,9 +14,11 @@ limitations under the License.
 */
 
 #include <condition_variable>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "llm-cache/ds/kv_state_cache.h"
@@ -41,32 +43,33 @@ class KVStateCacheManager {
 
  public:
   KVStateCacheManager(
-      int dimension = 10, int cacheCapacity = 10, int layer = 1,
+      int tensorBytes = 80, int cacheCapacity = 10, int layer = 1,
       int blockSize = 5, int syncInterval = 3,
       std::string socket = std::string(getenv("VINEYARD_IPC_SOCKET")));
 
   void Update(const std::vector<int>& tokenList, int nextToken,
-              const KV_STATE_WITH_LAYER& kvState);
+              const std::map<int, std::pair<LLMKV, LLMKV>>& kvState);
 
-  void Update(const std::vector<int>& tokenList,
-              const LIST_KV_STATE_WITH_LAYER& kvState);
+  void Update(
+      const std::vector<int>& tokenList,
+      const std::vector<std::map<int, std::pair<LLMKV, LLMKV>>>& kvState);
 
   int Query(const std::vector<int>& tokenList, int token,
-            KV_STATE_WITH_LAYER& kvState);
+            std::map<int, std::pair<LLMKV, LLMKV>>& kvState);
 
   int Query(const std::vector<int>& tokenList,
-            LIST_KV_STATE_WITH_LAYER& listKVState);
+            std::vector<std::map<int, std::pair<LLMKV, LLMKV>>>& listKVState);
 
   ~KVStateCacheManager();
 
  private:
   void UpdateInternal(const std::vector<int>& tokenList, int nextToken,
-                      const KV_STATE_WITH_LAYER& kvState);
+                      const std::map<int, std::pair<LLMKV, LLMKV>>& kvState);
 
   int QueryInternal(const std::vector<int>& tokenList, int token,
-                    KV_STATE_WITH_LAYER& kvState);
+                    std::map<int, std::pair<LLMKV, LLMKV>>& kvState);
 
-  void Delete(std::vector<int> token);
+  void Delete(std::vector<int>& token);
 
   static void SyncThreadFunc(KVStateCacheManager* manager);
 

--- a/modules/llm-cache/radix-tree/radix-tree.h
+++ b/modules/llm-cache/radix-tree/radix-tree.h
@@ -65,30 +65,30 @@ class RadixTree : public std::enable_shared_from_this<RadixTree> {
 
  private:
   std::shared_ptr<NodeData> InsertInternal(
-      std::vector<int> tokens, std::shared_ptr<NodeData>& evictedNode);
+      const std::vector<int>& tokens, std::shared_ptr<NodeData>& evictedNode);
 
-  void DeleteInternal(std::vector<int> tokens,
+  void DeleteInternal(const std::vector<int>& tokens,
                       std::shared_ptr<NodeData>& evictedNode);
 
-  std::shared_ptr<NodeData> QueryInternal(std::vector<int> key);
+  std::shared_ptr<NodeData> QueryInternal(const std::vector<int>& key);
 
   std::vector<std::shared_ptr<NodeData>> SplitInternal(
-      std::vector<int> tokens, std::shared_ptr<NodeData>& header);
+      const std::vector<int>& tokens, std::shared_ptr<NodeData>& header);
 
  public:
   RadixTree(int cacheCapacity);  //  NOLINT(runtime/explicit)
 
   ~RadixTree();
 
-  std::shared_ptr<NodeData> Insert(std::vector<int> tokens,
+  std::shared_ptr<NodeData> Insert(std::vector<int>& tokens,
                                    std::shared_ptr<NodeData>& evictedNode);
 
-  void Delete(std::vector<int> tokens, std::shared_ptr<NodeData>& evictedNode);
+  void Delete(std::vector<int>& tokens, std::shared_ptr<NodeData>& evictedNode);
 
-  std::shared_ptr<NodeData> Query(std::vector<int> key);
+  std::shared_ptr<NodeData> Query(std::vector<int>& key);
 
   std::vector<std::shared_ptr<NodeData>> Split(
-      std::vector<int> tokens, std::shared_ptr<NodeData>& header);
+      std::vector<int>& tokens, std::shared_ptr<NodeData>& header);
 
   std::string Serialize();
 

--- a/modules/llm-cache/tests/kv_state_cache_benchmark_test.cc
+++ b/modules/llm-cache/tests/kv_state_cache_benchmark_test.cc
@@ -27,16 +27,15 @@ limitations under the License.
 
 using namespace vineyard;  //  NOLINT(build/namespaces)
 
-#define DIMENSION 100
-#define CAPACITY 1000
-#define LAYER 64
-#define BLOCK_SIZE 100
+constexpr int TENSORBYTES = 800;
+constexpr int CAPACITY = 1000;
+constexpr int LAYER = 64;
+constexpr int BLOCK_SIZE = 100;
 
 KVStateCacheManager* manager;
 
 void init() {
-  manager =
-      new KVStateCacheManager(DIMENSION, CAPACITY, LAYER, DEFAULT_BLOCK_SIZE);
+  manager = new KVStateCacheManager(TENSORBYTES, CAPACITY, LAYER, BLOCK_SIZE);
 }
 
 std::vector<int> generate_random_tokens(size_t max_length) {
@@ -52,15 +51,15 @@ std::vector<int> generate_random_tokens(size_t max_length) {
   return tokens;
 }
 
-std::map<int, std::pair<K_STATE, V_STATE>> generate_kv_state(int token) {
-  std::map<int, std::pair<K_STATE, V_STATE>> kv_state;
+std::map<int, std::pair<LLMKV, LLMKV>> generate_kv_state(int token) {
+  std::map<int, std::pair<LLMKV, LLMKV>> kv_state;
   for (int currentLayer = 0; currentLayer < LAYER; currentLayer++) {
-    K_STATE key_state;
-    V_STATE value_state;
-    key_state.data = malloc(DIMENSION * sizeof(double));
-    key_state.length = DIMENSION * sizeof(double);
-    value_state.data = malloc(DIMENSION * sizeof(double));
-    value_state.length = DIMENSION * sizeof(double);
+    LLMKV key_state;
+    LLMKV value_state;
+    key_state.data = malloc(TENSORBYTES);
+    key_state.length = TENSORBYTES;
+    value_state.data = malloc(TENSORBYTES);
+    value_state.length = TENSORBYTES;
 
     kv_state.insert(
         std::make_pair(currentLayer, std::make_pair(key_state, value_state)));
@@ -71,7 +70,7 @@ std::map<int, std::pair<K_STATE, V_STATE>> generate_kv_state(int token) {
 // test the performance of Query and Update function
 void benchmark_inference(std::vector<std::vector<int>>& tokens) {
   LOG(INFO) << "inference for benchmark";
-  std::map<int, std::pair<K_STATE, V_STATE>> kv_state;
+  std::map<int, std::pair<LLMKV, LLMKV>> kv_state;
 
   std::chrono::steady_clock::time_point start, end;
   double token_list_size = 0;

--- a/modules/llm-cache/tests/kv_state_cache_multi_test.cc
+++ b/modules/llm-cache/tests/kv_state_cache_multi_test.cc
@@ -22,14 +22,7 @@ limitations under the License.
 
 #include "common/util/logging.h"
 
-char process_name[] = "kv_state_cache_test";
-char arg_0[] = "-s";
-char token_sequence_1[] = "1";
-char token_sequence_2[] = "2";
-char token_sequence_3[] = "3";
-char token_sequence_4[] = "4";
-
-const char* program = "./build/bin/kv_state_cache_test";
+constexpr char* program = "./build/bin/kv_state_cache_test";
 
 pid_t create_subprocess(char* argv[]) {
   pid_t pid = fork();
@@ -46,6 +39,13 @@ pid_t create_subprocess(char* argv[]) {
 }
 
 int main(int argc, char** argv) {
+  char process_name[] = "kv_state_cache_test";
+  char arg_0[] = "-s";
+  char token_sequence_1[] = "1";
+  char token_sequence_2[] = "2";
+  char token_sequence_3[] = "3";
+  char token_sequence_4[] = "4";
+
   std::string sockets[2];
   std::string rpc_endpoint;
   for (int i = 1; i < argc; i++) {

--- a/modules/llm-cache/tests/kv_state_cache_radix_tree_test.cc
+++ b/modules/llm-cache/tests/kv_state_cache_radix_tree_test.cc
@@ -40,15 +40,19 @@ void radix_tree_insert_test() {
   std::shared_ptr<NodeData> node_data;
   for (int i = 0; i < 10; i++) {
     tokens.push_back(i);
-    VINEYARD_ASSERT(radix_tree->Insert(tokens, node_data) != NULL);
+    std::vector<int> tokens_copy = tokens;
+    VINEYARD_ASSERT(radix_tree->Insert(tokens_copy, node_data) != NULL);
     VINEYARD_ASSERT(node_data == NULL);
   }
-
+  if (VLOG_IS_ON(100)) {
+    VLOG(100) << raxShow(radix_tree->tree);
+  }
   /* insert new token and check whether the old token is evicted */
   tokens.clear();
   for (int i = 1; i < 10; i++) {
     tokens.push_back(i);
-    VINEYARD_ASSERT(radix_tree->Insert(tokens, node_data) != NULL);
+    std::vector<int> tokens_copy = tokens;
+    VINEYARD_ASSERT(radix_tree->Insert(tokens_copy, node_data) != NULL);
     VINEYARD_ASSERT(node_data != NULL);
   }
 
@@ -68,7 +72,8 @@ void radix_tree_delete_test() {
   std::shared_ptr<NodeData> node_data;
   for (int i = 0; i < 10; i++) {
     tokens.push_back(i);
-    VINEYARD_ASSERT(radix_tree->Insert(tokens, node_data) != NULL);
+    std::vector<int> tokens_copy = tokens;
+    VINEYARD_ASSERT(radix_tree->Insert(tokens_copy, node_data) != NULL);
     VINEYARD_ASSERT(node_data == NULL);
   }
 
@@ -100,7 +105,8 @@ void radix_tree_query_test() {
   std::shared_ptr<NodeData> node_data;
   for (int i = 0; i < 10; i++) {
     tokens.push_back(i);
-    VINEYARD_ASSERT(radix_tree->Insert(tokens, node_data) != NULL);
+    std::vector<int> tokens_copy = tokens;
+    VINEYARD_ASSERT(radix_tree->Insert(tokens_copy, node_data) != NULL);
     VINEYARD_ASSERT(node_data == NULL);
   }
 
@@ -127,7 +133,8 @@ void radix_tree_serialize_and_deserialize() {
   std::shared_ptr<NodeData> node_data;
   for (int i = 0; i < 10; i++) {
     tokens.push_back(i);
-    VINEYARD_ASSERT(radix_tree->Insert(tokens, node_data) != NULL);
+    std::vector<int> tokens_copy = tokens;
+    VINEYARD_ASSERT(radix_tree->Insert(tokens_copy, node_data) != NULL);
     VINEYARD_ASSERT(node_data == NULL);
   }
 
@@ -142,21 +149,22 @@ void radix_tree_serialize_and_deserialize() {
   tokens.clear();
   for (int i = 0; i < 10; i++) {
     tokens.push_back(i);
+    std::vector<int> tokens_copy = tokens;
     print_tokens(tokens);
-    VINEYARD_ASSERT(deserialized_radix_tree->Query(tokens) != NULL);
+    VINEYARD_ASSERT(deserialized_radix_tree->Query(tokens_copy) != NULL);
   }
 }
 
 void radix_tree_split() {
   std::shared_ptr<RadixTree> radix_tree = std::make_shared<RadixTree>(20);
 
-  raxShow(radix_tree->tree);
   /* insert a token list*/
   std::vector<int> tokens;
   std::shared_ptr<NodeData> node_data;
   for (int i = 0; i < 10; i++) {
     tokens.push_back(i);
-    VINEYARD_ASSERT(radix_tree->Insert(tokens, node_data) != NULL);
+    std::vector<int> tokens_copy = tokens;
+    VINEYARD_ASSERT(radix_tree->Insert(tokens_copy, node_data) != NULL);
     VINEYARD_ASSERT(node_data == NULL);
   }
 

--- a/modules/llm-cache/tests/kv_state_cache_test.cc
+++ b/modules/llm-cache/tests/kv_state_cache_test.cc
@@ -24,27 +24,18 @@ limitations under the License.
 
 using namespace vineyard;  // NOLINT(build/namespaces)
 
-int dimension = 10;
+int tensorBytes = 80;
 int capacity = 20;
 int layer = 3;
 int block_size = 5;
-
-std::vector<int> round_1_tokens = {
-    1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18,
-    19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36,
-    37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
-    55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69};
-std::vector<int> round_2_tokens = {1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14};
-std::vector<int> round_3_tokens = {1, 2, 3, 9, 10, 11, 12, 13, 14};
-std::vector<int> round_4_tokens = {1, 2, 3, 4, 5, 6};
 
 std::vector<std::vector<int>> tokens_list;
 
 KVStateCacheManager* kv_state_cache_manager;
 
-void init(int dimension, int capacity, int layer, int block_size,
+void init(int tensorBytes, int capacity, int layer, int block_size,
           std::string socket) {
-  kv_state_cache_manager = new KVStateCacheManager(dimension, capacity, layer,
+  kv_state_cache_manager = new KVStateCacheManager(tensorBytes, capacity, layer,
                                                    block_size, 3, socket);
 }
 
@@ -57,21 +48,19 @@ void print_current_tokens(const std::vector<int>& prefix, int next_token) {
   LOG(INFO) << "Current tokens: " + tokens_str;
 }
 
-void print_kv_state(
-    const std::map<int, std::pair<K_STATE, V_STATE>>& kv_state) {
+void print_kv_state(const std::map<int, std::pair<LLMKV, LLMKV>>& kv_state) {
   LOG(INFO) << "kv_state: ";
   for (auto iter = kv_state.begin(); iter != kv_state.end(); ++iter) {
+    uint8_t* key_state_data =
+        reinterpret_cast<uint8_t*>(iter->second.first.data);
+    uint8_t* value_state_data =
+        reinterpret_cast<uint8_t*>(iter->second.second.data);
+    // print the first tensorBytes bytes
     std::string key_state_str = "";
     std::string value_state_str = "";
-    for (int i = 0; i < dimension; ++i) {
-      key_state_str +=
-          std::to_string(
-              (reinterpret_cast<double*>(iter->second.first.data))[i]) +
-          " ";
-      value_state_str +=
-          std::to_string(
-              (reinterpret_cast<double*>(iter->second.second.data))[i]) +
-          " ";
+    for (int j = 0; j < tensorBytes; j++) {
+      key_state_str += std::to_string(key_state_data[j]) + " ";
+      value_state_str += std::to_string(value_state_data[j]) + " ";
     }
     LOG(INFO) << "layer " << iter->first << ":";
     LOG(INFO) << "key_state: " << key_state_str;
@@ -81,69 +70,59 @@ void print_kv_state(
 }
 
 // we do not consider the layer.
-std::map<int, std::pair<K_STATE, V_STATE>> generate_kv_state() {
-  std::map<int, std::pair<K_STATE, V_STATE>> kv_state;
+std::map<int, std::pair<LLMKV, LLMKV>> generate_kv_state(int token) {
+  std::map<int, std::pair<LLMKV, LLMKV>> kv_state;
   for (int currentLayer = 0; currentLayer < layer; currentLayer++) {
-    K_STATE key_state;
-    V_STATE value_state;
-    key_state.data = malloc(dimension * sizeof(double));
-    value_state.data = malloc(dimension * sizeof(double));
+    LLMKV key_state;
+    LLMKV value_state;
+    key_state.data = malloc(tensorBytes);
+    value_state.data = malloc(tensorBytes);
 
-    key_state.length = dimension * sizeof(double);
-    value_state.length = dimension * sizeof(double);
+    key_state.length = tensorBytes;
+    value_state.length = tensorBytes;
 
+    for (int i = 0; i < tensorBytes; ++i) {
+      (reinterpret_cast<uint8_t*>(key_state.data))[i] =
+          (static_cast<uint8_t>(token)) / tensorBytes * (i + 1) +
+          currentLayer * 10;
+      (reinterpret_cast<uint8_t*>(value_state.data))[i] =
+          (static_cast<uint8_t>(token)) / tensorBytes * (i + 1) * 2 +
+          currentLayer * 10;
+    }
     kv_state.insert(
         std::make_pair(currentLayer, std::make_pair(key_state, value_state)));
   }
   return kv_state;
 }
 
-void update_kv_state(std::map<int, std::pair<K_STATE, V_STATE>>& kvState,
-                     int token) {
-  for (int currentLayer = 0; currentLayer < layer; currentLayer++) {
-    K_STATE key_state = kvState[currentLayer].first;
-    V_STATE value_state = kvState[currentLayer].second;
-    for (int i = 0; i < dimension; ++i) {
-      (reinterpret_cast<double*>(key_state.data))[i] =
-          (static_cast<double>(token)) / dimension * (i + 1) +
-          currentLayer * 10;
-      (reinterpret_cast<double*>(value_state.data))[i] =
-          (static_cast<double>(token)) / dimension * (i + 1) * 2 +
-          currentLayer * 10;
-    }
-  }
-}
-
-void check_kv_state(const std::map<int, std::pair<K_STATE, V_STATE>>& kv_state,
+void check_kv_state(const std::map<int, std::pair<LLMKV, LLMKV>>& kv_state,
                     int& token) {
   VINEYARD_ASSERT(kv_state.size() == (size_t) layer);
   for (auto iter = kv_state.begin(); iter != kv_state.end(); ++iter) {
-    VINEYARD_ASSERT(iter->second.first.length ==
-                    (size_t) dimension * sizeof(double));
-    VINEYARD_ASSERT(iter->second.second.length ==
-                    (size_t) dimension * sizeof(double));
-    for (int i = 0; i < dimension; ++i) {
-      if ((reinterpret_cast<double*>(iter->second.first.data))[i] !=
-          (static_cast<double>(token)) / dimension * (i + 1) +
+    VINEYARD_ASSERT(iter->second.first.length == (size_t) tensorBytes);
+    VINEYARD_ASSERT(iter->second.second.length == (size_t) tensorBytes);
+    for (int i = 0; i < tensorBytes; ++i) {
+      if ((reinterpret_cast<uint8_t*>(iter->second.first.data))[i] !=
+          (static_cast<uint8_t>(token)) / tensorBytes * (i + 1) +
               iter->first * 10) {
-        LOG(INFO) << "token:" << token << " dimension" << dimension
+        LOG(INFO) << "token:" << token << " tensorBytes" << tensorBytes
                   << " layer:" << iter->first;
         LOG(INFO) << "key_state[" << i << "]: "
-                  << (reinterpret_cast<double*>(iter->second.first.data))[i]
+                  << (reinterpret_cast<uint8_t*>(iter->second.first.data))[i]
                   << ". But is should be "
-                  << (static_cast<double>(token)) / dimension * (i + 1) +
+                  << (static_cast<uint8_t>(token)) / tensorBytes * (i + 1) +
                          iter->first * 10;
         throw std::runtime_error("key_state error!");
       }
-      if ((reinterpret_cast<double*>(iter->second.second.data))[i] !=
-          (static_cast<double>(token)) / dimension * (i + 1) * 2 +
+      if (reinterpret_cast<uint8_t*>(iter->second.second.data)[i] !=
+          (static_cast<uint8_t>(token)) / tensorBytes * (i + 1) * 2 +
               iter->first * 10) {
-        LOG(INFO) << "token:" << token << " dimension" << dimension
+        LOG(INFO) << "token:" << token << " tensorBytes" << tensorBytes
                   << " layer:" << iter->first;
         LOG(INFO) << "value_state[" << i << "]: "
-                  << (reinterpret_cast<double*>(iter->second.second.data))[i]
+                  << (reinterpret_cast<uint8_t*>(iter->second.second.data))[i]
                   << ". But is should be "
-                  << (static_cast<double>(token)) / dimension * (i + 1) * 2 +
+                  << (static_cast<uint8_t>(token)) / tensorBytes * (i + 1) * 2 +
                          iter->first * 10;
         throw std::runtime_error("value_state error!");
       }
@@ -153,16 +132,16 @@ void check_kv_state(const std::map<int, std::pair<K_STATE, V_STATE>>& kv_state,
 
 void inference(std::vector<int> tokens, bool block = false) {
   std::vector<int> inference_tokens;
-  std::map<int, std::pair<K_STATE, V_STATE>> kv_state;
-  kv_state = generate_kv_state();
+  std::map<int, std::pair<LLMKV, LLMKV>> kv_state;
   for (size_t i = 0; i < tokens.size(); ++i) {
+    kv_state.clear();
     int result =
         kv_state_cache_manager->Query(inference_tokens, tokens[i], kv_state);
     if (result != 0) {
       LOG(INFO) << "Can not find the kv_state from cache:";
       print_current_tokens(inference_tokens, tokens[i]);
       LOG(INFO) << "Generate the kv_state and update the cache.";
-      update_kv_state(kv_state, tokens[i]);
+      kv_state = generate_kv_state(tokens[i]);
       print_kv_state(kv_state);
       kv_state_cache_manager->Update(inference_tokens, tokens[i], kv_state);
     } else {
@@ -176,6 +155,15 @@ void inference(std::vector<int> tokens, bool block = false) {
 }
 
 int main(int argc, char** argv) {
+  std::vector<int> round_1_tokens = {
+      1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18,
+      19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36,
+      37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
+      55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69};
+  std::vector<int> round_2_tokens = {1, 2,  3,  4,  5,  7, 8,
+                                     9, 10, 11, 12, 13, 14};
+  std::vector<int> round_3_tokens = {1, 2, 3, 9, 10, 11, 12, 13, 14};
+  std::vector<int> round_4_tokens = {1, 2, 3, 4, 5, 6};
   if (argc < 2) {
     printf("usage ./kv_state_cache_test <ipc_socket_name>");
     return 1;
@@ -184,7 +172,7 @@ int main(int argc, char** argv) {
 
   for (int i = 2; i < argc; i++) {
     if (strcmp(argv[i], "-d") == 0) {
-      dimension = atoi(argv[i + 1]);
+      tensorBytes = atoi(argv[i + 1]);
     } else if (strcmp(argv[i], "-c") == 0) {
       capacity = atoi(argv[i + 1]);
     } else if (strcmp(argv[i], "-l") == 0) {
@@ -209,11 +197,11 @@ int main(int argc, char** argv) {
     }
   }
 
-  LOG(INFO) << "Test KVStateCache with dimension: " << dimension
+  LOG(INFO) << "Test KVStateCache with tensorBytes: " << tensorBytes
             << ", capacity: " << capacity << ", layer: " << layer
             << ", block_size: " << block_size << ".";
 
-  init(dimension, capacity, layer, block_size, ipc_socket);
+  init(tensorBytes, capacity, layer, block_size, ipc_socket);
 
   for (size_t i = 0; i < tokens_list.size(); i++) {
     inference(tokens_list[i]);

--- a/thirdparty/rax/radix.h
+++ b/thirdparty/rax/radix.h
@@ -210,15 +210,15 @@ extern void* raxNotFound;
 
 /* Exported API. */
 rax* raxNew(void);
-int raxInsert(rax* rax, int* s, size_t len, void* data, void** old,
+int raxInsert(rax* rax, const int* s, size_t len, void* data, void** old,
               bool set_timestamp = true);
 int raxTryInsert(rax* rax, int* s, size_t len, void* data, void** old);
-int raxInsertAndReturnDataNode(rax* rax, int* s, size_t len, void* data,
+int raxInsertAndReturnDataNode(rax* rax, const int* s, size_t len, void* data,
                                void** node, void** old);
-int raxRemove(rax* rax, int* s, size_t len, void** old,
+int raxRemove(rax* rax, const int* s, size_t len, void** old,
               bool set_timestamp = true);
 void* raxFind(rax* rax, int* s, size_t len);
-raxNode* raxFindAndReturnDataNode(rax* rax, int* s, size_t len,
+raxNode* raxFindAndReturnDataNode(rax* rax, const int* s, size_t len,
                                   raxNode** sub_tree_node = NULL,
                                   bool set_timestamp = true);
 void raxSetSubtree(raxNode* n);
@@ -236,7 +236,7 @@ int raxRandomWalk(raxIterator* it, size_t steps);
 int raxCompare(raxIterator* iter, const char* op, int* key, size_t key_len);
 void raxStop(raxIterator* it);
 int raxEOF(raxIterator* it);
-void raxShow(rax* rax);
+std::string raxShow(rax* rax);
 uint64_t raxSize(rax* rax);
 void raxSetCustomData(raxNode* n, void* data);
 void* raxGetCustomData(raxNode* n);
@@ -245,7 +245,7 @@ void raxSetDebugMsg(int onoff);
 void raxTraverse(raxNode* rax,
                  std::vector<std::shared_ptr<raxNode>>& dataNodeList);
 void raxTraverseSubTree(raxNode* n, std::vector<raxNode*>& dataNodeList);
-raxNode* raxSplit(rax* rax, int* s, size_t len, std::vector<int>& key);
+raxNode* raxSplit(rax* rax, const int* s, size_t len, std::vector<int>& key);
 void raxSerialize(rax* root, std::vector<std::vector<int>>& tokenList,
                   std::vector<void*>& dataList,
                   std::vector<uint64_t>& timestampsList,
@@ -261,7 +261,5 @@ void raxFindLastRecentNode(raxNode* node, std::vector<int>& key);
 void mergeTree(rax* first_tree, rax* second_tree,
                std::vector<std::vector<int>>& evicted_tokens,
                std::set<std::vector<int>>& insert_tokens, int max_node);
-void testIteRax(rax* tree);
 raxNode* raxGetFirstChildPtr(raxNode* node);
-// raxNode *raxSetSubTreeAndReturnDataNode(rax *rax, int *s, size_t len);
 #endif


### PR DESCRIPTION
What do these changes do?
-------------------------

- Improve the `query` API, users only input a token list and will get the kv_cache with the longest prefix.
- Use vector<uint8_t> as payload object.
- Replace the alias of KV_STATE_WITH_LAYER with std::map<int, std::pair<K_STATE, V_STATE>>.
- Rename the `Dimension` with `TensorBytes`.
- Use the references of `std::vector<T>` to avoid copying.
- Print the rax tree to a string for debugging.

Related issue number
--------------------

- Fixes #1786
- Fixes #1792
- Fixes #1795