### PR TITLE
Add the vineyard directory for searching vineyard config file and support multiple rpc endpoints.

### DIFF
--- a/python/vineyard/__init__.py
+++ b/python/vineyard/__init__.py
@@ -297,7 +297,8 @@ def connect(*args, **kwargs):
     If no arguments are provided and failed to resolve both the environment
     variables :code:`VINEYARD_IPC_SOCKET`, :code:`VINEYARD_RPC_ENDPOINT`,
     :code:`VINEYARD_CONFIG`, and the default configuration file
-    :code:`/var/run/vineyard-config.yaml`, it will launch a standalone
+    :code:`/var/run/vineyard-config.yaml` and
+    :code:`/var/run/vineyard/vineyard-config.yaml`, it will launch a standalone
     vineyardd server in the background and then connect to it.
 
     The `connect()` method has various overloading:
@@ -401,7 +402,13 @@ def connect(*args, **kwargs):
         and 'VINEYARD_IPC_SOCKET' not in os.environ
         and 'VINEYARD_RPC_ENDPOINT' not in os.environ
         and 'VINEYARD_CONFIG' not in os.environ
-        and not os.path.exists("/var/run/vineyard-config.yaml")
+        and not any(
+            os.path.exists(path)
+            for path in [
+                "/var/run/vineyard-config.yaml",
+                "/var/run/vineyard/vineyard-config.yaml",
+            ]
+        )
     ):
         logger.info(
             'No vineyard socket or endpoint is specified, '

--- a/python/vineyard/core/client.py
+++ b/python/vineyard/core/client.py
@@ -57,7 +57,9 @@ def _parse_configuration(config) -> Tuple[Optional[str], Optional[str]]:
     Parameters:
         config: Path to a YAML configuration file or a directory containing
                 the default config file `vineyard-config.yaml`. If you define
-                the directory of config and
+                the directory of vineyard config, the
+                `/directory/vineyard-config.yaml` and
+                `/directory/vineyard/vineyard-config.yaml` will be parsed.
 
     Returns:
         (socket, endpoints): IPC socket path and RPC endpoints.

--- a/python/vineyard/core/client.py
+++ b/python/vineyard/core/client.py
@@ -197,9 +197,13 @@ class Client:
                     hosts.append(h)
                     ports.append(p)
             else:
-                host, port = endpoint
-                hosts = [host]
-                ports = [port]
+                h, p = endpoint
+                hosts = [h]
+                ports = [p]
+
+        if host and port:
+            hosts.append(host)
+            ports.append(port)
 
         if config and ((not socket) or (not (hosts and ports))):
             ipc_socket, rpc_endpoint = _parse_configuration(config)


### PR DESCRIPTION
What do these changes do?
-------------------------

- Add the vineyard directory for searching vineyard config file. E,g, `client = vineyard.connect(config='/var/run')`, the client will search the config file `/var/run/vineyard-config.yaml` and `/var/run/vineyard/vineyard-config.yaml`.
- Support to parse endpoints like `127.0.0.1:9600,127.0.0.2:9600`.

