### PR TITLE
Install the rax headers under the thirdparty directory.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -612,17 +612,6 @@ macro(install_vineyard_headers header_path)
             PATTERN "*.vineyard-mod"                            # select vineyard template files
             PATTERN "*/thirdparty/*" EXCLUDE                    # exclude thirdparty
     )
-
-    # install the rax headers separately
-    # as cmake does not support the negative lookaheads currently
-    # refer to https://cmake.org/cmake/help/latest/command/string.html#regex-specification
-    if (${header_path} MATCHES ".*rax.*")
-        install(DIRECTORY ${header_path}
-                DESTINATION ${install_headers_destination}          # target directory
-                FILES_MATCHING                                      # install only matched files
-                PATTERN "*/thirdparty/rax/*.h"                      # only install the rax headers 
-        )
-    endif()
 endmacro()
 
 install_vineyard_headers("${PROJECT_SOURCE_DIR}/src/common")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -950,7 +950,6 @@ endif()
 
 if(BUILD_VINEYARD_LLM_CACHE)
     add_subdirectory(modules/llm-cache)
-    install_vineyard_headers("${PROJECT_SOURCE_DIR}/thirdparty/rax")
     list(APPEND VINEYARD_INSTALL_LIBS vineyard_llm_cache)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -612,6 +612,17 @@ macro(install_vineyard_headers header_path)
             PATTERN "*.vineyard-mod"                            # select vineyard template files
             PATTERN "*/thirdparty/*" EXCLUDE                    # exclude thirdparty
     )
+
+    # install the rax headers separately
+    # as cmake does not support the negative lookaheads currently
+    # refer to https://cmake.org/cmake/help/latest/command/string.html#regex-specification
+    if (${header_path} MATCHES ".*rax.*")
+        install(DIRECTORY ${header_path}
+                DESTINATION ${install_headers_destination}          # target directory
+                FILES_MATCHING                                      # install only matched files
+                PATTERN "*/thirdparty/rax/*.h"                      # only install the rax headers 
+        )
+    endif()
 endmacro()
 
 install_vineyard_headers("${PROJECT_SOURCE_DIR}/src/common")
@@ -939,6 +950,7 @@ endif()
 
 if(BUILD_VINEYARD_LLM_CACHE)
     add_subdirectory(modules/llm-cache)
+    install_vineyard_headers("${PROJECT_SOURCE_DIR}/thirdparty/rax")
     list(APPEND VINEYARD_INSTALL_LIBS vineyard_llm_cache)
 endif()
 

--- a/LICENSE
+++ b/LICENSE
@@ -1184,7 +1184,7 @@ SOFTWARE.
 
 -------------------------------------------------------------------------------
 
-The files thirdparty/rax/{radix.cc, radix.h, rax_malloc} is referred from project antirez/rax,
+The files thirdparty/rax/{radix.cc, radix.h, rax_malloc.h} is referred from project antirez/rax,
 which has the following license:
 
 Copyright (c) 2017, Salvatore Sanfilippo <antirez@gmail.com>

--- a/modules/llm-cache/CMakeLists.txt
+++ b/modules/llm-cache/CMakeLists.txt
@@ -10,6 +10,14 @@ file(GLOB VINEYARD_LLM_CACHE_SRCS "${CMAKE_CURRENT_SOURCE_DIR}"
 add_library(vineyard_llm_cache ${VINEYARD_LLM_CACHE_SRCS})
 target_link_libraries(vineyard_llm_cache PUBLIC vineyard_client vineyard_basic)
 
+# install bundled thirdparty: rax
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/thirdparty/rax
+        DESTINATION include/vineyard/contrib    # target directory
+        FILES_MATCHING                          # install only matched files
+        PATTERN "*.h"                           # select header files
+        PATTERN "*.hpp"                         # select C++ template header files
+)
+
 install_export_vineyard_target(vineyard_llm_cache)
 install_vineyard_headers("${CMAKE_CURRENT_SOURCE_DIR}")
 

--- a/modules/llm-cache/ds/kv_state_cache.cc
+++ b/modules/llm-cache/ds/kv_state_cache.cc
@@ -19,14 +19,14 @@ limitations under the License.
 #include <string>
 #include <utility>
 
+#include "rax/radix.h"
+
 #include "client/client.h"
 #include "common/util/base64.h"
 #include "common/util/logging.h"
 #include "common/util/status.h"
 #include "llm-cache/ds/kv_state_cache.h"
 #include "llm-cache/radix-tree/radix-tree.h"
-
-#include "rax/radix.h"
 
 namespace vineyard {
 

--- a/modules/llm-cache/radix-tree/radix-tree.h
+++ b/modules/llm-cache/radix-tree/radix-tree.h
@@ -16,14 +16,14 @@ limitations under the License.
 #ifndef MODULES_LLM_CACHE_RADIX_TREE_RADIX_TREE_H_
 #define MODULES_LLM_CACHE_RADIX_TREE_RADIX_TREE_H_
 
-#include "rax/radix.h"
-
 #include <iomanip>
 #include <map>
 #include <memory>
 #include <set>
 #include <string>
 #include <vector>
+
+#include "rax/radix.h"
 
 #include "common/util/base64.h"
 #include "common/util/logging.h"

--- a/modules/llm-cache/tests/kv_state_cache_radix_tree_test.cc
+++ b/modules/llm-cache/tests/kv_state_cache_radix_tree_test.cc
@@ -17,6 +17,7 @@ limitations under the License.
 #include <iostream>
 #include <random>
 #include <vector>
+
 #include "rax/radix.h"
 
 #include "common/util/logging.h"

--- a/modules/llm-cache/tests/kv_state_cache_test.cc
+++ b/modules/llm-cache/tests/kv_state_cache_test.cc
@@ -17,6 +17,7 @@ limitations under the License.
 #include <iostream>
 #include <random>
 #include <vector>
+
 #include "rax/radix.h"
 
 #include "common/util/logging.h"


### PR DESCRIPTION
What do these changes do?
-------------------------

Currently, the rax headers will not be installed as it's under the [exclude pattern](https://github.com/v6d-io/v6d/blob/main/CMakeLists.txt#L613), and the pr is to add the script for installing rax headers.


Related issue number
--------------------

A follow up of https://github.com/v6d-io/v6d/pull/1787 and fix https://github.com/v6d-io/v6d/issues/1785

