### PR TITLE
GraphAr: Support load and write subgraph to graphar with selected vertices/edges and properties

### DIFF
--- a/modules/graph/CMakeLists.txt
+++ b/modules/graph/CMakeLists.txt
@@ -134,7 +134,7 @@ install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/powturbo/include"
 
 if(BUILD_VINEYARD_GRAPH_WITH_GAR)
     target_compile_definitions(vineyard_graph PUBLIC -DENABLE_GAR)
-    find_package(gar 0.11.2 QUIET)
+    find_package(gar 0.11.3 QUIET)
     if (gar_FOUND)
         message(STATUS "-- Found GraphAr: ${GAR_LIBRARIES}")
         target_include_directories(vineyard_graph PRIVATE ${GAR_INCLUDE_DIRS})

--- a/modules/graph/loader/gar_fragment_loader.h
+++ b/modules/graph/loader/gar_fragment_loader.h
@@ -40,7 +40,6 @@ limitations under the License.
 #include "graph/fragment/graph_schema.h"
 #include "graph/fragment/property_graph_types.h"
 #include "graph/vertex_map/arrow_vertex_map.h"
-#include "graph/writer/util.h"
 
 namespace GraphArchive {
 class GraphInfo;

--- a/modules/graph/loader/gar_fragment_loader.h
+++ b/modules/graph/loader/gar_fragment_loader.h
@@ -40,6 +40,7 @@ limitations under the License.
 #include "graph/fragment/graph_schema.h"
 #include "graph/fragment/property_graph_types.h"
 #include "graph/vertex_map/arrow_vertex_map.h"
+#include "graph/writer/util.h"
 
 namespace GraphArchive {
 class GraphInfo;
@@ -80,6 +81,9 @@ class GARFragmentLoader {
   static constexpr const char* MARKER = "PROGRESS--GRAPH-LOADING-";
 
  public:
+
+  explicit GARFragmentLoader(Client& client, const grape::CommSpec& comm_spec);
+
   /**
    * @brief Initialize the GARFragmentLoader.
    *    Notes that if vertex_labels or edge_labels are empty, the loader will
@@ -94,11 +98,10 @@ class GARFragmentLoader {
    * @param generate_eid whether to generate edge id.
    * @param store_in_local whether the gar data files are stored in local.
    */
-  GARFragmentLoader(
-      Client& client, const grape::CommSpec& comm_spec,
+  boost::leaf::result<void> Init(
       const std::string& graph_info_yaml,
-      const std::vector<std::string>& vertex_labels = {},
-      const std::vector<std::vector<std::string>>& edge_labels = {},
+      const std::vector<std::string>& selected_vertices = {},
+      const std::vector<std::string>& selected_edges = {},
       bool directed = true, bool generate_eid = false,
       bool store_in_local = false);
 
@@ -146,6 +149,8 @@ class GARFragmentLoader {
   boost::leaf::result<void> initializeVertexChunkBeginAndNum(
       int vertex_label_index,
       const std::shared_ptr<GraphArchive::VertexInfo>& vertex_info);
+
+  boost::leaf::result<void> checkInitialization();
 
  private:
   Client& client_;

--- a/modules/graph/loader/gar_fragment_loader.h
+++ b/modules/graph/loader/gar_fragment_loader.h
@@ -81,7 +81,6 @@ class GARFragmentLoader {
   static constexpr const char* MARKER = "PROGRESS--GRAPH-LOADING-";
 
  public:
-
   explicit GARFragmentLoader(Client& client, const grape::CommSpec& comm_spec);
 
   /**

--- a/modules/graph/loader/gar_fragment_loader.h
+++ b/modules/graph/loader/gar_fragment_loader.h
@@ -99,9 +99,8 @@ class GARFragmentLoader {
   boost::leaf::result<void> Init(
       const std::string& graph_info_yaml,
       const std::vector<std::string>& selected_vertices = {},
-      const std::vector<std::string>& selected_edges = {},
-      bool directed = true, bool generate_eid = false,
-      bool store_in_local = false);
+      const std::vector<std::string>& selected_edges = {}, bool directed = true,
+      bool generate_eid = false, bool store_in_local = false);
 
   ~GARFragmentLoader() = default;
 

--- a/modules/graph/loader/gar_fragment_loader_impl.h
+++ b/modules/graph/loader/gar_fragment_loader_impl.h
@@ -77,7 +77,9 @@ boost::leaf::result<void> GARFragmentLoader<OID_T, VID_T, VERTEX_MAP_T>::Init(
     for (const auto& label : selected_vertices) {
       auto vertex_info = graph_info_->GetVertexInfo(label);
       if (vertex_info == nullptr) {
-        LOG(ERROR) << "Vertex label " << label << " is not found in graph info";
+        RETURN_GS_ERROR(ErrorCode::kGraphArError,
+                        "The selected vertex label " + label +
+                            " is not found in the graph info");
       }
       project_vertex_infos.push_back(vertex_info);
     }
@@ -486,8 +488,6 @@ GARFragmentLoader<OID_T, VID_T, VERTEX_MAP_T>::loadVertexTableOfLabel(
   metadata->Append("type", PropertyGraphSchema::VERTEX_TYPE_NAME);
   metadata->Append("retain_oid", std::to_string(false));
   vertex_tables_[label_id] = table_out->ReplaceSchemaMetadata(metadata);
-  LOG(INFO) << "vertex: " << vertex_label << " table schema: "
-            << vertex_tables_[label_id]->schema()->ToString();
   return {};
 }
 
@@ -664,8 +664,6 @@ GARFragmentLoader<OID_T, VID_T, VERTEX_MAP_T>::loadEdgeTableOfLabel(
         arrow::ConcatenateTables(edge_property_chunk_tables[i]);
     RETURN_GS_ERROR_IF_NOT_OK(property_chunk_table.status());
     property_table_of_groups[i] = std::move(property_chunk_table).ValueOrDie();
-    LOG(INFO) << "edge: " << edge_label << " property table schema: "
-              << property_table_of_groups[i]->schema()->ToString();
   }
 
   label_id_t label_id = edge_label_to_index_[edge_label];

--- a/modules/graph/loader/gar_fragment_loader_impl.h
+++ b/modules/graph/loader/gar_fragment_loader_impl.h
@@ -49,7 +49,12 @@ namespace vineyard {
 
 template <typename OID_T, typename VID_T,
           template <typename, typename> class VERTEX_MAP_T>
-GARFragmentLoader<OID_T, VID_T, VERTEX_MAP_T>::GARFragmentLoader(Client& client, const grape::CommSpec& comm_spec) : client_(client), comm_spec_(comm_spec), graph_info_(nullptr), store_in_local_(false) {}
+GARFragmentLoader<OID_T, VID_T, VERTEX_MAP_T>::GARFragmentLoader(
+    Client& client, const grape::CommSpec& comm_spec)
+    : client_(client),
+      comm_spec_(comm_spec),
+      graph_info_(nullptr),
+      store_in_local_(false) {}
 
 template <typename OID_T, typename VID_T,
           template <typename, typename> class VERTEX_MAP_T>
@@ -67,7 +72,7 @@ boost::leaf::result<void> GARFragmentLoader<OID_T, VID_T, VERTEX_MAP_T>::Init(
   if (!maybe_graph_info.status().ok()) {
     RETURN_GS_ERROR(ErrorCode::kGraphArError,
                     "Failed to load graph info from " + graph_info_yaml +
-                        ", error: " + maybe_graph_info.status().message()); 
+                        ", error: " + maybe_graph_info.status().message());
   }
   graph_info_ = maybe_graph_info.value();
   if (!selected_vertices.empty() && !selected_edges.empty()) {
@@ -383,8 +388,9 @@ GARFragmentLoader<OID_T, VID_T, VERTEX_MAP_T>::constructVertexMap() {
     // so we can remove it from the vertex table
     int index_col_index = vertex_tables_[label_id]->schema()->GetFieldIndex(
         GraphArchive::GeneralParams::kVertexIndexCol);
-    CHECK_ARROW_ERROR_AND_ASSIGN(vertex_tables_[label_id], vertex_tables_[label_id]->RemoveColumn(
-        index_col_index));
+    CHECK_ARROW_ERROR_AND_ASSIGN(
+        vertex_tables_[label_id],
+        vertex_tables_[label_id]->RemoveColumn(index_col_index));
     VY_OK_OR_RAISE(FragmentAllGatherArray(comm_spec_, local_oid_array,
                                           shuffled_oid_array));
     for (auto const& array : shuffled_oid_array) {

--- a/modules/graph/test/arrow_fragment_gar_test.cc
+++ b/modules/graph/test/arrow_fragment_gar_test.cc
@@ -73,10 +73,14 @@ void traverse_graph(std::shared_ptr<GraphType> graph, const std::string& path) {
 boost::leaf::result<int> write_out_to_gar(
     const grape::CommSpec& comm_spec, std::shared_ptr<StringGraphType> graph,
     const std::string& output_path, const std::string& file_type) {
-  auto writer = std::make_unique<ArrowFragmentWriter<StringGraphType>>(
-      graph, comm_spec, /* graph_name */ "graph", output_path,
-      /* vertex_chunk_size */ 512,
-      /* edge_chunk_size */ 1024, file_type);
+  auto writer = std::make_unique<ArrowFragmentWriter<StringGraphType>>();
+  BOOST_LEAF_CHECK(writer->Init(graph, comm_spec, /* graph_name */ "graph", output_path,
+               /* vertex_chunk_size */ 512,
+               /* edge_chunk_size */ 1024, file_type,
+               /* selected_vertex_labels */ std::vector<std::string>{},
+               /* selected_edge_relations */ std::vector<std::vector<std::string>>{},
+               /* selected_vertex_properties */ std::unordered_map<std::string, std::vector<std::string>>{},
+               /* selected_edge_properties */ std::unordered_map<std::string, std::vector<std::string>>{}));
   BOOST_LEAF_CHECK(writer->WriteGraphInfo(output_path));
   BOOST_LEAF_CHECK(writer->WriteFragment());
   LOG(INFO) << "[worker-" << comm_spec.worker_id() << "] generate GAR files...";

--- a/modules/graph/test/arrow_fragment_gar_test.cc
+++ b/modules/graph/test/arrow_fragment_gar_test.cc
@@ -78,7 +78,7 @@ boost::leaf::result<int> write_out_to_gar(
                /* vertex_chunk_size */ 512,
                /* edge_chunk_size */ 1024, file_type,
                /* selected_vertex_labels */ std::vector<std::string>{},
-               /* selected_edge_relations */ std::vector<std::vector<std::string>>{},
+               /* selected_edge_relations */ std::vector<std::string>{},
                /* selected_vertex_properties */ std::unordered_map<std::string, std::vector<std::string>>{},
                /* selected_edge_properties */ std::unordered_map<std::string, std::vector<std::string>>{}));
   BOOST_LEAF_CHECK(writer->WriteGraphInfo(output_path));
@@ -148,7 +148,10 @@ int main(int argc, char** argv) {
       auto loader =
           std::make_unique<GARFragmentLoader<property_graph_types::OID_TYPE,
                                              property_graph_types::VID_TYPE>>(
-              client, comm_spec, graph_yaml_path);
+              client, comm_spec);
+      loader->Init(graph_yaml_path, /*selected_vertices*/ {},
+                   /*selected_edges*/ {}, /*directed*/ true, /*generate_eid*/ false,
+                   /*store_in_local*/ false); 
       vineyard::ObjectID fragment_id = loader->LoadFragment().value();
 
       std::shared_ptr<GraphType> graph =

--- a/modules/graph/test/arrow_fragment_gar_test.cc
+++ b/modules/graph/test/arrow_fragment_gar_test.cc
@@ -74,13 +74,16 @@ boost::leaf::result<int> write_out_to_gar(
     const grape::CommSpec& comm_spec, std::shared_ptr<StringGraphType> graph,
     const std::string& output_path, const std::string& file_type) {
   auto writer = std::make_unique<ArrowFragmentWriter<StringGraphType>>();
-  BOOST_LEAF_CHECK(writer->Init(graph, comm_spec, /* graph_name */ "graph", output_path,
-               /* vertex_chunk_size */ 512,
-               /* edge_chunk_size */ 1024, file_type,
-               /* selected_vertex_labels */ std::vector<std::string>{},
-               /* selected_edge_relations */ std::vector<std::string>{},
-               /* selected_vertex_properties */ std::unordered_map<std::string, std::vector<std::string>>{},
-               /* selected_edge_properties */ std::unordered_map<std::string, std::vector<std::string>>{}));
+  BOOST_LEAF_CHECK(writer->Init(
+      graph, comm_spec, /* graph_name */ "graph", output_path,
+      /* vertex_chunk_size */ 512,
+      /* edge_chunk_size */ 1024, file_type,
+      /* selected_vertex_labels */ std::vector<std::string>{},
+      /* selected_edge_relations */ std::vector<std::string>{},
+      /* selected_vertex_properties */
+      std::unordered_map<std::string, std::vector<std::string>>{},
+      /* selected_edge_properties */
+      std::unordered_map<std::string, std::vector<std::string>>{}));
   BOOST_LEAF_CHECK(writer->WriteGraphInfo(output_path));
   BOOST_LEAF_CHECK(writer->WriteFragment());
   LOG(INFO) << "[worker-" << comm_spec.worker_id() << "] generate GAR files...";
@@ -150,8 +153,9 @@ int main(int argc, char** argv) {
                                              property_graph_types::VID_TYPE>>(
               client, comm_spec);
       loader->Init(graph_yaml_path, /*selected_vertices*/ {},
-                   /*selected_edges*/ {}, /*directed*/ true, /*generate_eid*/ false,
-                   /*store_in_local*/ false); 
+                   /*selected_edges*/ {}, /*directed*/ true,
+                   /*generate_eid*/ false,
+                   /*store_in_local*/ false);
       vineyard::ObjectID fragment_id = loader->LoadFragment().value();
 
       std::shared_ptr<GraphType> graph =

--- a/modules/graph/test/arrow_fragment_gar_test.cc
+++ b/modules/graph/test/arrow_fragment_gar_test.cc
@@ -78,8 +78,8 @@ boost::leaf::result<int> write_out_to_gar(
       graph, comm_spec, /* graph_name */ "graph", output_path,
       /* vertex_chunk_size */ 512,
       /* edge_chunk_size */ 1024, file_type,
-      /* selected_vertex_labels */ std::vector<std::string>{},
-      /* selected_edge_relations */ std::vector<std::string>{},
+      /* selected_vertices */ std::vector<std::string>{},
+      /* selected_edges */ std::vector<std::string>{},
       /* selected_vertex_properties */
       std::unordered_map<std::string, std::vector<std::string>>{},
       /* selected_edge_properties */

--- a/modules/graph/writer/arrow_fragment_writer.cc
+++ b/modules/graph/writer/arrow_fragment_writer.cc
@@ -51,7 +51,6 @@ void InitializeArrayArrayBuilders(
   int col_id = 2;
   for (auto& pid : property_ids) {
     auto prop_type = graph_schema.GetEdgePropertyType(edge_label, pid);
-    LOG(INFO) << "property type: " << prop_type->ToString();
     if (arrow::boolean()->Equals(prop_type)) {
       builders[col_id] = std::make_shared<arrow::BooleanBuilder>();
     } else if (arrow::int32()->Equals(prop_type)) {

--- a/modules/graph/writer/arrow_fragment_writer.cc
+++ b/modules/graph/writer/arrow_fragment_writer.cc
@@ -51,6 +51,7 @@ void InitializeArrayArrayBuilders(
   int col_id = 2;
   for (auto& pid : property_ids) {
     auto prop_type = graph_schema.GetEdgePropertyType(edge_label, pid);
+    LOG(INFO) << "property type: " << prop_type->ToString();
     if (arrow::boolean()->Equals(prop_type)) {
       builders[col_id] = std::make_shared<arrow::BooleanBuilder>();
     } else if (arrow::int32()->Equals(prop_type)) {

--- a/modules/graph/writer/arrow_fragment_writer.h
+++ b/modules/graph/writer/arrow_fragment_writer.h
@@ -117,16 +117,18 @@ class ArrowFragmentWriter {
    * @param file_type The file type to store the fragment
    * @param store_in_local Whether write the fragment to local
    */
-  boost::leaf::result<void> Init(const std::shared_ptr<fragment_t>& frag,
-                                 const grape::CommSpec& comm_spec,
-                                 const std::string& graph_name,
-                      const std::string& out_path, int64_t vertex_block_size,
-                      int64_t edge_block_size, const std::string& file_type,
-                      const std::vector<std::string>& selected_vertices,
-                      const std::vector<std::string>& selected_edges,
-                      const std::unordered_map<std::string, std::vector<std::string>>& selected_vertex_properties,
-                      const std::unordered_map<std::string, std::vector<std::string>>& selected_edge_properties,
-                      bool store_in_local = false);
+  boost::leaf::result<void> Init(
+      const std::shared_ptr<fragment_t>& frag, const grape::CommSpec& comm_spec,
+      const std::string& graph_name, const std::string& out_path,
+      int64_t vertex_block_size, int64_t edge_block_size,
+      const std::string& file_type,
+      const std::vector<std::string>& selected_vertices,
+      const std::vector<std::string>& selected_edges,
+      const std::unordered_map<std::string, std::vector<std::string>>&
+          selected_vertex_properties,
+      const std::unordered_map<std::string, std::vector<std::string>>&
+          selected_edge_properties,
+      bool store_in_local = false);
 
   ~ArrowFragmentWriter() = default;
 

--- a/modules/graph/writer/arrow_fragment_writer.h
+++ b/modules/graph/writer/arrow_fragment_writer.h
@@ -42,7 +42,6 @@ limitations under the License.
 
 #include "graph/loader/fragment_loader_utils.h"
 #include "graph/utils/partitioner.h"
-#include "graph/writer/util.h"
 
 namespace GraphArchive {
 class GraphInfo;

--- a/modules/graph/writer/arrow_fragment_writer.h
+++ b/modules/graph/writer/arrow_fragment_writer.h
@@ -42,6 +42,7 @@ limitations under the License.
 
 #include "graph/loader/fragment_loader_utils.h"
 #include "graph/utils/partitioner.h"
+#include "graph/writer/util.h"
 
 namespace GraphArchive {
 class GraphInfo;
@@ -90,6 +91,8 @@ class ArrowFragmentWriter {
   static constexpr const char* MARKER = "PROGRESS--GRAPH-LOADING-";
 
  public:
+  ArrowFragmentWriter();
+
   /**
    * @brief Initialize ArrowFragmentWriter with graph info
    *
@@ -97,8 +100,6 @@ class ArrowFragmentWriter {
    * @param comm_spec The communicator specification
    * @param graph_info_yaml The graph info yaml path
    */
-  ArrowFragmentWriter();
-
   boost::leaf::result<void> Init(const std::shared_ptr<fragment_t>& frag,
                                  const grape::CommSpec& comm_spec,
                                  const std::string& graph_info_yaml);
@@ -122,8 +123,8 @@ class ArrowFragmentWriter {
                                  const std::string& graph_name,
                       const std::string& out_path, int64_t vertex_block_size,
                       int64_t edge_block_size, const std::string& file_type,
-                      const std::vector<std::string>& selected_vertex_labels,
-                      const std::vector<std::vector<std::string>>& selected_edge_relations,
+                      const std::vector<std::string>& selected_vertices,
+                      const std::vector<std::string>& selected_edges,
                       const std::unordered_map<std::string, std::vector<std::string>>& selected_vertex_properties,
                       const std::unordered_map<std::string, std::vector<std::string>>& selected_edge_properties,
                       bool store_in_local = false);

--- a/modules/graph/writer/arrow_fragment_writer.h
+++ b/modules/graph/writer/arrow_fragment_writer.h
@@ -97,9 +97,11 @@ class ArrowFragmentWriter {
    * @param comm_spec The communicator specification
    * @param graph_info_yaml The graph info yaml path
    */
-  ArrowFragmentWriter(const std::shared_ptr<fragment_t>& frag,
-                      const grape::CommSpec& comm_spec,
-                      const std::string& graph_info_yaml);
+  ArrowFragmentWriter();
+
+  boost::leaf::result<void> Init(const std::shared_ptr<fragment_t>& frag,
+                                 const grape::CommSpec& comm_spec,
+                                 const std::string& graph_info_yaml);
 
   /**
    * @brief Initialize ArrowFragmentWriter with base graph info information
@@ -115,11 +117,15 @@ class ArrowFragmentWriter {
    * @param file_type The file type to store the fragment
    * @param store_in_local Whether write the fragment to local
    */
-  ArrowFragmentWriter(const std::shared_ptr<fragment_t>& frag,
-                      const grape::CommSpec& comm_spec,
-                      const std::string& graph_name,
+  boost::leaf::result<void> Init(const std::shared_ptr<fragment_t>& frag,
+                                 const grape::CommSpec& comm_spec,
+                                 const std::string& graph_name,
                       const std::string& out_path, int64_t vertex_block_size,
                       int64_t edge_block_size, const std::string& file_type,
+                      const std::vector<std::string>& selected_vertex_labels,
+                      const std::vector<std::vector<std::string>>& selected_edge_relations,
+                      const std::unordered_map<std::string, std::vector<std::string>>& selected_vertex_properties,
+                      const std::unordered_map<std::string, std::vector<std::string>>& selected_edge_properties,
                       bool store_in_local = false);
 
   ~ArrowFragmentWriter() = default;
@@ -139,6 +145,8 @@ class ArrowFragmentWriter {
                                       const std::string& dst_label);
 
  private:
+  boost::leaf::result<void> checkInitialization();
+
   boost::leaf::result<void> writeEdgeImpl(
       const std::shared_ptr<GraphArchive::EdgeInfo>& edge_info,
       label_id_t src_label_id, label_id_t edge_label_id,

--- a/modules/graph/writer/arrow_fragment_writer_impl.h
+++ b/modules/graph/writer/arrow_fragment_writer_impl.h
@@ -56,7 +56,8 @@ namespace GAR = GraphArchive;
 namespace vineyard {
 
 template <typename FRAG_T>
-ArrowFragmentWriter<FRAG_T>::ArrowFragmentWriter() : frag_(nullptr), graph_info_(nullptr), store_in_local_(false) {}
+ArrowFragmentWriter<FRAG_T>::ArrowFragmentWriter()
+    : frag_(nullptr), graph_info_(nullptr), store_in_local_(false) {}
 
 template <typename FRAG_T>
 boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::Init(
@@ -67,7 +68,8 @@ boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::Init(
   // Load graph info.
   auto maybe_graph_info = GAR::GraphInfo::Load(graph_info_yaml);
   if (!maybe_graph_info.status().ok()) {
-    RETURN_GS_ERROR(ErrorCode::kGraphArError, maybe_graph_info.status().message());
+    RETURN_GS_ERROR(ErrorCode::kGraphArError,
+                    maybe_graph_info.status().message());
   }
   graph_info_ = maybe_graph_info.value();
   return {};
@@ -81,21 +83,22 @@ boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::Init(
     const std::string& file_type,
     const std::vector<std::string>& selected_vertices,
     const std::vector<std::string>& selected_edges,
-    const std::unordered_map<std::string, std::vector<std::string>>& selected_vertex_properties,
-    const std::unordered_map<std::string, std::vector<std::string>>& selected_edge_properties,
+    const std::unordered_map<std::string, std::vector<std::string>>&
+        selected_vertex_properties,
+    const std::unordered_map<std::string, std::vector<std::string>>&
+        selected_edge_properties,
     bool store_in_local) {
   frag_ = std::move(frag);
   comm_spec_ = std::move(comm_spec);
   store_in_local_ = store_in_local;
   auto& schema = frag_->schema();
-  BOOST_LEAF_ASSIGN(graph_info_, generate_graph_info_with_schema(
-  schema, graph_name, out_path, vertex_block_size, edge_block_size,
-  GAR::StringToFileType(file_type),
-  selected_vertices,
-  selected_edges,
-  selected_vertex_properties,
-  selected_edge_properties,
-  store_in_local));
+  BOOST_LEAF_ASSIGN(
+      graph_info_,
+      generate_graph_info_with_schema(
+          schema, graph_name, out_path, vertex_block_size, edge_block_size,
+          GAR::StringToFileType(file_type), selected_vertices, selected_edges,
+          selected_vertex_properties, selected_edge_properties,
+          store_in_local));
   if (graph_info_ == nullptr || !graph_info_->IsValidated()) {
     RETURN_GS_ERROR(ErrorCode::kGraphArError, "Failed to generate graph info.");
   }

--- a/modules/graph/writer/arrow_fragment_writer_impl.h
+++ b/modules/graph/writer/arrow_fragment_writer_impl.h
@@ -113,10 +113,8 @@ boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::WriteGraphInfo(
     // otherwise, only the last fragment writes graph info
     for (const auto& vertex_info : graph_info_->GetVertexInfos()) {
       const auto& label = vertex_info->GetLabel();
-      LOG(INFO) << "Vertex info path: " << output_path + label + ".vertex.yaml";
       auto st = vertex_info->Save(output_path + label + ".vertex.yaml");
       if (!st.ok()) {
-        LOG(INFO) << "Failed to save vertex info: " << st.message();
         RETURN_GS_ERROR(ErrorCode::kGraphArError, st.message());
       }
     }
@@ -124,8 +122,6 @@ boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::WriteGraphInfo(
       const auto& src_label = edge_info->GetSrcLabel();
       const auto& edge_label = edge_info->GetEdgeLabel();
       const auto& dst_label = edge_info->GetDstLabel();
-      LOG(INFO) << "Edge info path: " << output_path + src_label + "_" + edge_label +
-                    "_" + dst_label + ".edge.yaml";  
       auto st = edge_info->Save(output_path + src_label + "_" + edge_label +
                                 "_" + dst_label + ".edge.yaml");
       if (!st.ok()) {
@@ -133,7 +129,6 @@ boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::WriteGraphInfo(
       }
     }
     const auto& graph_name = graph_info_->GetName();
-    LOG(INFO) << "Graph info path: " << output_path + graph_name + ".graph.yaml";
     auto st = graph_info_->Save(output_path + graph_name + ".graph.yaml");
     if (!st.ok()) {
       RETURN_GS_ERROR(ErrorCode::kGraphArError, st.message());
@@ -203,7 +198,6 @@ boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::WriteVertex(
         vertex_table,
         vertex_info->GetChunkSize() - num_rows % vertex_info->GetChunkSize());
   }
-  LOG(INFO) << "vertex: " << label << " table schema: " << vertex_table->schema()->ToString();
   auto st = writer->WriteTable(vertex_table, chunk_index_begin);
   if (!st.ok()) {
     RETURN_GS_ERROR(ErrorCode::kGraphArError, st.message());
@@ -473,8 +467,6 @@ boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::writeEdgeImpl(
     // write the adj list chunks
     FinishArrowArrayBuilders(builders, column_arrays);
     auto table = arrow::Table::Make(table_schema, column_arrays);
-    LOG(INFO) << "edge: " << edge_info->GetSrcLabel() << "_" << edge_info->GetEdgeLabel() << "_" << edge_info->GetDstLabel()
-              << " table schema: " << table->schema()->ToString();
     auto s = writer->WriteTable(table, vertex_chunk_index);
     if (!s.ok()) {
       return Status::IOError(

--- a/modules/graph/writer/arrow_fragment_writer_impl.h
+++ b/modules/graph/writer/arrow_fragment_writer_impl.h
@@ -56,34 +56,52 @@ namespace GAR = GraphArchive;
 namespace vineyard {
 
 template <typename FRAG_T>
-ArrowFragmentWriter<FRAG_T>::ArrowFragmentWriter(
+ArrowFragmentWriter<FRAG_T>::ArrowFragmentWriter() : frag_(nullptr), graph_info_(nullptr), store_in_local(false) {}
+
+template <typename FRAG_T>
+boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::Init(
     const std::shared_ptr<fragment_t>& frag, const grape::CommSpec& comm_spec,
-    const std::string& graph_info_yaml)
-    : frag_(frag), comm_spec_(comm_spec), store_in_local_(false) {
+    const std::string& graph_info_yaml) {
+  frag_ = std::move(frag);
+  comm_spec_ = std::move(comm_spec);
   // Load graph info.
   auto maybe_graph_info = GAR::GraphInfo::Load(graph_info_yaml);
   if (!maybe_graph_info.status().ok()) {
-    LOG(ERROR) << "Failed to load graph info from " << graph_info_yaml;
+    RETURN_GS_ERROR(ErrorCode::kGraphArError, maybe_graph_info.status().message());
   }
   graph_info_ = maybe_graph_info.value();
 }
 
 template <typename FRAG_T>
-ArrowFragmentWriter<FRAG_T>::ArrowFragmentWriter(
+boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::Init(
     const std::shared_ptr<fragment_t>& frag, const grape::CommSpec& comm_spec,
     const std::string& graph_name, const std::string& out_path,
     int64_t vertex_block_size, int64_t edge_block_size,
-    const std::string& file_type, bool store_in_local)
-    : frag_(frag), comm_spec_(comm_spec), store_in_local_(store_in_local) {
+    const std::string& file_type,
+    const std::vector<std::string>& selected_vertex_labels,
+    const std::vector<std::vector<std::string>>& selected_edge_relations,
+    const std::unordered_map<std::string, std::vector<std::string>>& selected_vertex_properties,
+    const std::unordered_map<std::string, std::vector<std::string>>& selected_edge_properties,
+    bool store_in_local) {
+  frag_ = std::move(frag);
+  comm_spec_ = std::move(comm_spec);
+  store_in_local_ = store_in_local;
   auto& schema = frag_->schema();
-  graph_info_ = generate_graph_info_with_schema(
-      schema, graph_name, out_path, vertex_block_size, edge_block_size,
-      GAR::StringToFileType(file_type), store_in_local);
+  BOOST_LEAF_ASSIGN(graph_info_, generate_graph_info_with_schema(
+  schema, graph_name, out_path, vertex_block_size, edge_block_size,
+  GAR::StringToFileType(file_type),
+  selected_vertex_labels,
+  selected_edge_relations,
+  selected_vertex_properties,
+  selected_edge_properties,
+  store_in_local));
 }
 
 template <typename FRAG_T>
 boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::WriteGraphInfo(
     const std::string& output_path) {
+  BOOST_LEAF_CHECK(checkInitialization());
+
   LOG_IF(INFO, !comm_spec_.worker_id()) << MARKER << "WRITING-GRAPH-INFO-0";
   if (store_in_local_ || frag_->fid() == frag_->fnum() - 1) {
     // store in local: all fragments write graph info
@@ -118,6 +136,7 @@ boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::WriteGraphInfo(
 
 template <typename FRAG_T>
 boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::WriteFragment() {
+  BOOST_LEAF_CHECK(checkInitialization());
   LOG_IF(INFO, !comm_spec_.worker_id()) << MARKER << "WRITING-VERTICES-0";
   BOOST_LEAF_CHECK(WriteVertices());
   LOG_IF(INFO, !comm_spec_.worker_id()) << MARKER << "WRITING-VERTICES-100";
@@ -130,6 +149,7 @@ boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::WriteFragment() {
 
 template <typename FRAG_T>
 boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::WriteVertices() {
+  BOOST_LEAF_CHECK(checkInitialization());
   for (const auto& vertex_info : graph_info_->GetVertexInfos()) {
     const auto& label = vertex_info->GetLabel();
     LOG_IF(INFO, !comm_spec_.worker_id())
@@ -142,6 +162,7 @@ boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::WriteVertices() {
 template <typename FRAG_T>
 boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::WriteVertex(
     const std::string& label) {
+  BOOST_LEAF_CHECK(checkInitialization());
   auto vertex_info = graph_info_->GetVertexInfo(label);
 
   auto& schema = frag_->schema();
@@ -207,6 +228,7 @@ boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::WriteVertex(
 
 template <typename FRAG_T>
 boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::WriteEdges() {
+  BOOST_LEAF_CHECK(checkInitialization());
   for (const auto& edge_info : graph_info_->GetEdgeInfos()) {
     const auto& src_label = edge_info->GetSrcLabel();
     const auto& edge_label = edge_info->GetEdgeLabel();
@@ -223,6 +245,7 @@ template <typename FRAG_T>
 boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::WriteEdge(
     const std::string& src_label, const std::string& edge_label,
     const std::string& dst_label) {
+  BOOST_LEAF_CHECK(checkInitialization());
   auto edge_info = graph_info_->GetEdgeInfo(src_label, edge_label, dst_label);
 
   // check if the edge information is valid in fragment
@@ -301,6 +324,15 @@ boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::WriteEdge(
                   GraphArchive::AdjListType::unordered_by_dest);
   }
 
+  return {};
+}
+
+template <typename FRAG_T>
+boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::checkInitialization() {
+  if (frag_ == nullptr || graph_info_ == nullptr) {
+    RETURN_GS_ERROR(ErrorCode::kInvalidOperationError,
+                    "The writer is not initialized yet.");
+  }
   return {};
 }
 

--- a/modules/graph/writer/arrow_fragment_writer_impl.h
+++ b/modules/graph/writer/arrow_fragment_writer_impl.h
@@ -56,7 +56,7 @@ namespace GAR = GraphArchive;
 namespace vineyard {
 
 template <typename FRAG_T>
-ArrowFragmentWriter<FRAG_T>::ArrowFragmentWriter() : frag_(nullptr), graph_info_(nullptr), store_in_local(false) {}
+ArrowFragmentWriter<FRAG_T>::ArrowFragmentWriter() : frag_(nullptr), graph_info_(nullptr), store_in_local_(false) {}
 
 template <typename FRAG_T>
 boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::Init(
@@ -70,6 +70,7 @@ boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::Init(
     RETURN_GS_ERROR(ErrorCode::kGraphArError, maybe_graph_info.status().message());
   }
   graph_info_ = maybe_graph_info.value();
+  return {};
 }
 
 template <typename FRAG_T>
@@ -78,8 +79,8 @@ boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::Init(
     const std::string& graph_name, const std::string& out_path,
     int64_t vertex_block_size, int64_t edge_block_size,
     const std::string& file_type,
-    const std::vector<std::string>& selected_vertex_labels,
-    const std::vector<std::vector<std::string>>& selected_edge_relations,
+    const std::vector<std::string>& selected_vertices,
+    const std::vector<std::string>& selected_edges,
     const std::unordered_map<std::string, std::vector<std::string>>& selected_vertex_properties,
     const std::unordered_map<std::string, std::vector<std::string>>& selected_edge_properties,
     bool store_in_local) {
@@ -90,11 +91,15 @@ boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::Init(
   BOOST_LEAF_ASSIGN(graph_info_, generate_graph_info_with_schema(
   schema, graph_name, out_path, vertex_block_size, edge_block_size,
   GAR::StringToFileType(file_type),
-  selected_vertex_labels,
-  selected_edge_relations,
+  selected_vertices,
+  selected_edges,
   selected_vertex_properties,
   selected_edge_properties,
   store_in_local));
+  if (graph_info_ == nullptr || !graph_info_->IsValidated()) {
+    RETURN_GS_ERROR(ErrorCode::kGraphArError, "Failed to generate graph info.");
+  }
+  return {};
 }
 
 template <typename FRAG_T>
@@ -108,8 +113,10 @@ boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::WriteGraphInfo(
     // otherwise, only the last fragment writes graph info
     for (const auto& vertex_info : graph_info_->GetVertexInfos()) {
       const auto& label = vertex_info->GetLabel();
+      LOG(INFO) << "Vertex info path: " << output_path + label + ".vertex.yaml";
       auto st = vertex_info->Save(output_path + label + ".vertex.yaml");
       if (!st.ok()) {
+        LOG(INFO) << "Failed to save vertex info: " << st.message();
         RETURN_GS_ERROR(ErrorCode::kGraphArError, st.message());
       }
     }
@@ -117,6 +124,8 @@ boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::WriteGraphInfo(
       const auto& src_label = edge_info->GetSrcLabel();
       const auto& edge_label = edge_info->GetEdgeLabel();
       const auto& dst_label = edge_info->GetDstLabel();
+      LOG(INFO) << "Edge info path: " << output_path + src_label + "_" + edge_label +
+                    "_" + dst_label + ".edge.yaml";  
       auto st = edge_info->Save(output_path + src_label + "_" + edge_label +
                                 "_" + dst_label + ".edge.yaml");
       if (!st.ok()) {
@@ -124,6 +133,7 @@ boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::WriteGraphInfo(
       }
     }
     const auto& graph_name = graph_info_->GetName();
+    LOG(INFO) << "Graph info path: " << output_path + graph_name + ".graph.yaml";
     auto st = graph_info_->Save(output_path + graph_name + ".graph.yaml");
     if (!st.ok()) {
       RETURN_GS_ERROR(ErrorCode::kGraphArError, st.message());
@@ -193,6 +203,7 @@ boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::WriteVertex(
         vertex_table,
         vertex_info->GetChunkSize() - num_rows % vertex_info->GetChunkSize());
   }
+  LOG(INFO) << "vertex: " << label << " table schema: " << vertex_table->schema()->ToString();
   auto st = writer->WriteTable(vertex_table, chunk_index_begin);
   if (!st.ok()) {
     RETURN_GS_ERROR(ErrorCode::kGraphArError, st.message());
@@ -462,6 +473,8 @@ boost::leaf::result<void> ArrowFragmentWriter<FRAG_T>::writeEdgeImpl(
     // write the adj list chunks
     FinishArrowArrayBuilders(builders, column_arrays);
     auto table = arrow::Table::Make(table_schema, column_arrays);
+    LOG(INFO) << "edge: " << edge_info->GetSrcLabel() << "_" << edge_info->GetEdgeLabel() << "_" << edge_info->GetDstLabel()
+              << " table schema: " << table->schema()->ToString();
     auto s = writer->WriteTable(table, vertex_chunk_index);
     if (!s.ok()) {
       return Status::IOError(
@@ -581,9 +594,9 @@ ArrowFragmentWriter<FRAG_T>::appendPropertiesToArrowArrayBuilders(
           edge.template get_data<arrow::Time32Type::c_type>(pid)));
     } else if (prop_type->id() == arrow::Type::TIME64) {
       auto builder =
-          std::dynamic_pointer_cast<arrow::Date64Builder>(builders[col_id]);
+          std::dynamic_pointer_cast<arrow::Time64Builder>(builders[col_id]);
       ARROW_OK_OR_RAISE(builder->Append(
-          edge.template get_data<arrow::Date64Type::c_type>(pid)));
+          edge.template get_data<arrow::Time64Type::c_type>(pid)));
     } else if (prop_type->id() == arrow::Type::TIMESTAMP) {
       auto builder =
           std::dynamic_pointer_cast<arrow::TimestampBuilder>(builders[col_id]);

--- a/modules/graph/writer/util.cc
+++ b/modules/graph/writer/util.cc
@@ -33,8 +33,8 @@ boost::leaf::result<std::shared_ptr<GraphArchive::GraphInfo>> generate_graph_inf
     const PropertyGraphSchema& schema, const std::string& graph_name,
     const std::string& path, int64_t vertex_block_size, int64_t edge_block_size,
     GAR::FileType file_type,
-    const std::vector<std::string>& selected_vertex_labels,
-    const std::vector<std::vector<std::string>>& selected_edge_relations,
+    const std::vector<std::string>& selected_vertices,
+    const std::vector<std::string>& selected_edges,
     const std::unordered_map<std::string, std::vector<std::string>>& selected_vertex_properties,
     const std::unordered_map<std::string, std::vector<std::string>>& selected_edge_properties,
     bool store_in_local) {
@@ -42,9 +42,9 @@ boost::leaf::result<std::shared_ptr<GraphArchive::GraphInfo>> generate_graph_inf
   GraphArchive::EdgeInfoVector edge_infos;
 
   for (const auto& entry : schema.vertex_entries()) {
-    if (!selected_vertex_labels.empty() &&
-        std::find(selected_vertex_labels.begin(), selected_vertex_labels.end(),
-                  entry.label) == selected_vertex_labels.end()) {
+    if (!selected_vertices.empty() &&
+        std::find(selected_vertices.begin(), selected_vertices.end(),
+                  entry.label) == selected_vertices.end()) {
       // Skip the vertex type that is not selected.
       continue;
     }
@@ -53,7 +53,8 @@ boost::leaf::result<std::shared_ptr<GraphArchive::GraphInfo>> generate_graph_inf
         selected_vertex_properties.end()) {
       selected_property = true;
     }
-    std::vector<GraphArchive::Property> properties;
+    LOG(INFO) << "vertex " << entry.label << " selected_property " << selected_property;
+    std::vector<GAR::Property> properties;
     for (const auto& prop : entry.props_) {
       if (selected_property &&
           std::find(selected_vertex_properties.at(entry.label).begin(),
@@ -63,51 +64,77 @@ boost::leaf::result<std::shared_ptr<GraphArchive::GraphInfo>> generate_graph_inf
         // Skip the property that is not selected.
         continue;
       }
+      LOG(INFO) << "vertex " << entry.label << " prop " << prop.name;
       properties.emplace_back(GAR::Property(
           prop.name, GAR::DataType::ArrowDataTypeToDataType(prop.type), false));
     }
-    auto pg = GAR::CreatePropertyGroup(properties, file_type);
-    auto vertex_info =
-        GAR::CreateVertexInfo(entry.label, vertex_block_size, {pg});
+    GAR::PropertyGroupVector property_groups;
+    if (!properties.empty()) {
+      auto pg = GAR::CreatePropertyGroup(properties, file_type);
+      if (pg == nullptr) {
+        RETURN_GS_ERROR(ErrorCode::kGraphArError, "Failed to create property group for vertex " + entry.label);
+      }
+      property_groups.push_back(pg);
+    }
+    auto vertex_info = 
+        GAR::CreateVertexInfo(entry.label, vertex_block_size, property_groups);
+    if (vertex_info == nullptr) {
+      RETURN_GS_ERROR(ErrorCode::kGraphArError, "Failed to create vertex info for " + entry.label);
+    }
     vertex_infos.emplace_back(vertex_info);
   }
   GAR::AdjacentListVector default_adjacent_lists{
       GAR::CreateAdjacentList(GAR::AdjListType::ordered_by_source, file_type),
       GAR::CreateAdjacentList(GAR::AdjListType::ordered_by_dest, file_type)};
   for (const auto& entry : schema.edge_entries()) {
+    if (!selected_edges.empty() && 
+        std::find(selected_edges.begin(), selected_edges.end(), entry.label) == selected_edges.end()) {
+      // Skip the edge type that is not selected.
+      continue;
+    }
     bool selected_property = false;
     if (selected_edge_properties.find(entry.label) !=
         selected_edge_properties.end()) {
       selected_property = true;
     }
-    std::vector<GraphArchive::Property> properties;
+    std::vector<GAR::Property> properties;
     for (const auto& prop : entry.props_) {
       if (selected_property &&
           std::find(selected_edge_properties.at(entry.label).begin(),
                     selected_edge_properties.at(entry.label).end(),
                     prop.name) == selected_edge_properties.at(entry.label)
-                                        .end()) {
+                                      .end()) {
         // Skip the property that is not selected.
         continue;
       }
       properties.emplace_back(GAR::Property(
           prop.name, GAR::DataType::ArrowDataTypeToDataType(prop.type), false));
     }
-    auto pg = GAR::CreatePropertyGroup(properties, file_type);
+    GAR::PropertyGroupVector property_groups;
+    if (!properties.empty()) {
+      auto pg = GAR::CreatePropertyGroup(properties, file_type);
+      if (pg == nullptr) {
+        RETURN_GS_ERROR(ErrorCode::kGraphArError, "Failed to create property group for edge " + entry.label);
+      }
+      property_groups.push_back(pg);
+    }
+
     for (const auto& relation : entry.relations) {
-      if (!selected_edge_relations.empty() &&
-          std::find(selected_edge_relations.begin(),
-                    selected_edge_relations.end(),
-                    std::vector<std::string>{relation.first, entry.label,
-                                             relation.second}) ==
-              selected_edge_relations.end()) {
-        // Skip the edge type that is not selected.
+      if (!selected_vertices.empty() &&
+          (std::find(selected_vertices.begin(), selected_vertices.end(),
+                     relation.first) == selected_vertices.end() ||
+           std::find(selected_vertices.begin(), selected_vertices.end(),
+                     relation.second) == selected_vertices.end())) {
+        // Skip the relation that source or destination vertex type is not selected.
         continue;
       }
       auto edge_info = GAR::CreateEdgeInfo(
           relation.first, entry.label, relation.second, edge_block_size,
           vertex_block_size, vertex_block_size, true /* directed */,
-          default_adjacent_lists, {pg});
+          default_adjacent_lists, property_groups);
+      if (edge_info == nullptr) {
+        RETURN_GS_ERROR(ErrorCode::kGraphArError, "Failed to create edge info for relation " + relation.first + " " + entry.label + " " + relation.second);
+      }
       edge_infos.emplace_back(edge_info);
     }
   }

--- a/modules/graph/writer/util.cc
+++ b/modules/graph/writer/util.cc
@@ -29,14 +29,16 @@ namespace GAR = GraphArchive;
 
 namespace vineyard {
 
-boost::leaf::result<std::shared_ptr<GraphArchive::GraphInfo>> generate_graph_info_with_schema(
+boost::leaf::result<std::shared_ptr<GraphArchive::GraphInfo>>
+generate_graph_info_with_schema(
     const PropertyGraphSchema& schema, const std::string& graph_name,
     const std::string& path, int64_t vertex_block_size, int64_t edge_block_size,
-    GAR::FileType file_type,
-    const std::vector<std::string>& selected_vertices,
+    GAR::FileType file_type, const std::vector<std::string>& selected_vertices,
     const std::vector<std::string>& selected_edges,
-    const std::unordered_map<std::string, std::vector<std::string>>& selected_vertex_properties,
-    const std::unordered_map<std::string, std::vector<std::string>>& selected_edge_properties,
+    const std::unordered_map<std::string, std::vector<std::string>>&
+        selected_vertex_properties,
+    const std::unordered_map<std::string, std::vector<std::string>>&
+        selected_edge_properties,
     bool store_in_local) {
   GAR::VertexInfoVector vertex_infos;
   GAR::EdgeInfoVector edge_infos;
@@ -58,8 +60,8 @@ boost::leaf::result<std::shared_ptr<GraphArchive::GraphInfo>> generate_graph_inf
       if (selected_property &&
           std::find(selected_vertex_properties.at(entry.label).begin(),
                     selected_vertex_properties.at(entry.label).end(),
-                    prop.name) == selected_vertex_properties.at(entry.label)
-                                        .end()) {
+                    prop.name) ==
+              selected_vertex_properties.at(entry.label).end()) {
         // Skip the property that is not selected.
         continue;
       }
@@ -70,14 +72,17 @@ boost::leaf::result<std::shared_ptr<GraphArchive::GraphInfo>> generate_graph_inf
     if (!properties.empty()) {
       auto pg = GAR::CreatePropertyGroup(properties, file_type);
       if (pg == nullptr) {
-        RETURN_GS_ERROR(ErrorCode::kGraphArError, "Failed to create property group for vertex " + entry.label);
+        RETURN_GS_ERROR(
+            ErrorCode::kGraphArError,
+            "Failed to create property group for vertex " + entry.label);
       }
       property_groups.push_back(pg);
     }
-    auto vertex_info = 
+    auto vertex_info =
         GAR::CreateVertexInfo(entry.label, vertex_block_size, property_groups);
     if (vertex_info == nullptr) {
-      RETURN_GS_ERROR(ErrorCode::kGraphArError, "Failed to create vertex info for " + entry.label);
+      RETURN_GS_ERROR(ErrorCode::kGraphArError,
+                      "Failed to create vertex info for " + entry.label);
     }
     vertex_infos.emplace_back(vertex_info);
   }
@@ -85,8 +90,9 @@ boost::leaf::result<std::shared_ptr<GraphArchive::GraphInfo>> generate_graph_inf
       GAR::CreateAdjacentList(GAR::AdjListType::ordered_by_source, file_type),
       GAR::CreateAdjacentList(GAR::AdjListType::ordered_by_dest, file_type)};
   for (const auto& entry : schema.edge_entries()) {
-    if (!selected_edges.empty() && 
-        std::find(selected_edges.begin(), selected_edges.end(), entry.label) == selected_edges.end()) {
+    if (!selected_edges.empty() &&
+        std::find(selected_edges.begin(), selected_edges.end(), entry.label) ==
+            selected_edges.end()) {
       // Skip the edge type that is not selected.
       continue;
     }
@@ -100,8 +106,8 @@ boost::leaf::result<std::shared_ptr<GraphArchive::GraphInfo>> generate_graph_inf
       if (selected_property &&
           std::find(selected_edge_properties.at(entry.label).begin(),
                     selected_edge_properties.at(entry.label).end(),
-                    prop.name) == selected_edge_properties.at(entry.label)
-                                      .end()) {
+                    prop.name) ==
+              selected_edge_properties.at(entry.label).end()) {
         // Skip the property that is not selected.
         continue;
       }
@@ -112,7 +118,9 @@ boost::leaf::result<std::shared_ptr<GraphArchive::GraphInfo>> generate_graph_inf
     if (!properties.empty()) {
       auto pg = GAR::CreatePropertyGroup(properties, file_type);
       if (pg == nullptr) {
-        RETURN_GS_ERROR(ErrorCode::kGraphArError, "Failed to create property group for edge " + entry.label);
+        RETURN_GS_ERROR(
+            ErrorCode::kGraphArError,
+            "Failed to create property group for edge " + entry.label);
       }
       property_groups.push_back(pg);
     }
@@ -123,7 +131,8 @@ boost::leaf::result<std::shared_ptr<GraphArchive::GraphInfo>> generate_graph_inf
                      relation.first) == selected_vertices.end() ||
            std::find(selected_vertices.begin(), selected_vertices.end(),
                      relation.second) == selected_vertices.end())) {
-        // Skip the relation that source or destination vertex type is not selected.
+        // Skip the relation that source or destination vertex type is not
+        // selected.
         continue;
       }
       auto edge_info = GAR::CreateEdgeInfo(
@@ -131,7 +140,10 @@ boost::leaf::result<std::shared_ptr<GraphArchive::GraphInfo>> generate_graph_inf
           vertex_block_size, vertex_block_size, true /* directed */,
           default_adjacent_lists, property_groups);
       if (edge_info == nullptr) {
-        RETURN_GS_ERROR(ErrorCode::kGraphArError, "Failed to create edge info for relation " + relation.first + " " + entry.label + " " + relation.second);
+        RETURN_GS_ERROR(ErrorCode::kGraphArError,
+                        "Failed to create edge info for relation " +
+                            relation.first + " " + entry.label + " " +
+                            relation.second);
       }
       edge_infos.emplace_back(edge_info);
     }

--- a/modules/graph/writer/util.cc
+++ b/modules/graph/writer/util.cc
@@ -38,8 +38,8 @@ boost::leaf::result<std::shared_ptr<GraphArchive::GraphInfo>> generate_graph_inf
     const std::unordered_map<std::string, std::vector<std::string>>& selected_vertex_properties,
     const std::unordered_map<std::string, std::vector<std::string>>& selected_edge_properties,
     bool store_in_local) {
-  GraphArchive::VertexInfoVector vertex_infos;
-  GraphArchive::EdgeInfoVector edge_infos;
+  GAR::VertexInfoVector vertex_infos;
+  GAR::EdgeInfoVector edge_infos;
 
   for (const auto& entry : schema.vertex_entries()) {
     if (!selected_vertices.empty() &&
@@ -53,7 +53,6 @@ boost::leaf::result<std::shared_ptr<GraphArchive::GraphInfo>> generate_graph_inf
         selected_vertex_properties.end()) {
       selected_property = true;
     }
-    LOG(INFO) << "vertex " << entry.label << " selected_property " << selected_property;
     std::vector<GAR::Property> properties;
     for (const auto& prop : entry.props_) {
       if (selected_property &&
@@ -64,7 +63,6 @@ boost::leaf::result<std::shared_ptr<GraphArchive::GraphInfo>> generate_graph_inf
         // Skip the property that is not selected.
         continue;
       }
-      LOG(INFO) << "vertex " << entry.label << " prop " << prop.name;
       properties.emplace_back(GAR::Property(
           prop.name, GAR::DataType::ArrowDataTypeToDataType(prop.type), false));
     }

--- a/modules/graph/writer/util.cc
+++ b/modules/graph/writer/util.cc
@@ -29,7 +29,105 @@ namespace GAR = GraphArchive;
 
 namespace vineyard {
 
-boost::leaf::result<std::shared_ptr<GraphArchive::GraphInfo>>
+boost::leaf::result<std::shared_ptr<GAR::VertexInfo>>
+generate_vertex_info_with_schema(
+    const Entry& entry, int64_t vertex_block_size, GAR::FileType file_type,
+    const std::unordered_map<std::string, std::vector<std::string>>&
+        selected_vertex_properties) {
+  bool selected_property = false;
+  if (selected_vertex_properties.find(entry.label) !=
+      selected_vertex_properties.end()) {
+    selected_property = true;
+  }
+  std::vector<GAR::Property> properties;
+  for (const auto& prop : entry.props_) {
+    if (selected_property &&
+        std::find(selected_vertex_properties.at(entry.label).begin(),
+                  selected_vertex_properties.at(entry.label).end(),
+                  prop.name) ==
+            selected_vertex_properties.at(entry.label).end()) {
+      // Skip the property that is not selected.
+      continue;
+    }
+    properties.emplace_back(GAR::Property(
+        prop.name, GAR::DataType::ArrowDataTypeToDataType(prop.type), false));
+  }
+  GAR::PropertyGroupVector property_groups;
+  if (!properties.empty()) {
+    auto pg = GAR::CreatePropertyGroup(properties, file_type);
+    if (pg == nullptr) {
+      RETURN_GS_ERROR(
+          ErrorCode::kGraphArError,
+          "Failed to create property group for vertex " + entry.label);
+    }
+    property_groups.push_back(pg);
+  }
+  return GAR::CreateVertexInfo(entry.label, vertex_block_size, property_groups);
+}
+
+boost::leaf::result<void> generate_edge_infos_with_schema(
+    const Entry& entry, int64_t vertex_block_size, int64_t edge_block_size,
+    GAR::FileType file_type, const std::vector<std::string>& selected_vertices,
+    const std::unordered_map<std::string, std::vector<std::string>>&
+        selected_edge_properties,
+    GAR::EdgeInfoVector& edge_infos) {
+  bool selected_property = false;
+  if (selected_edge_properties.find(entry.label) !=
+      selected_edge_properties.end()) {
+    selected_property = true;
+  }
+  GAR::AdjacentListVector default_adjacent_lists{
+      GAR::CreateAdjacentList(GAR::AdjListType::ordered_by_source, file_type),
+      GAR::CreateAdjacentList(GAR::AdjListType::ordered_by_dest, file_type)};
+  std::vector<GAR::Property> properties;
+  for (const auto& prop : entry.props_) {
+    if (selected_property &&
+        std::find(selected_edge_properties.at(entry.label).begin(),
+                  selected_edge_properties.at(entry.label).end(), prop.name) ==
+            selected_edge_properties.at(entry.label).end()) {
+      // Skip the property that is not selected.
+      continue;
+    }
+    properties.emplace_back(GAR::Property(
+        prop.name, GAR::DataType::ArrowDataTypeToDataType(prop.type), false));
+  }
+  GAR::PropertyGroupVector property_groups;
+  if (!properties.empty()) {
+    auto pg = GAR::CreatePropertyGroup(properties, file_type);
+    if (pg == nullptr) {
+      RETURN_GS_ERROR(
+          ErrorCode::kGraphArError,
+          "Failed to create property group for edge " + entry.label);
+    }
+    property_groups.push_back(pg);
+  }
+
+  for (const auto& relation : entry.relations) {
+    if (!selected_vertices.empty() &&
+        (std::find(selected_vertices.begin(), selected_vertices.end(),
+                   relation.first) == selected_vertices.end() ||
+         std::find(selected_vertices.begin(), selected_vertices.end(),
+                   relation.second) == selected_vertices.end())) {
+      // Skip the relation that source or destination vertex type is not
+      // selected.
+      continue;
+    }
+    auto edge_info = GAR::CreateEdgeInfo(
+        relation.first, entry.label, relation.second, edge_block_size,
+        vertex_block_size, vertex_block_size, true /* directed */,
+        default_adjacent_lists, property_groups);
+    if (edge_info == nullptr) {
+      RETURN_GS_ERROR(ErrorCode::kGraphArError,
+                      "Failed to create edge info for relation " +
+                          relation.first + " " + entry.label + " " +
+                          relation.second);
+    }
+    edge_infos.emplace_back(edge_info);
+  }
+  return {};
+}
+
+boost::leaf::result<std::shared_ptr<GAR::GraphInfo>>
 generate_graph_info_with_schema(
     const PropertyGraphSchema& schema, const std::string& graph_name,
     const std::string& path, int64_t vertex_block_size, int64_t edge_block_size,
@@ -50,45 +148,16 @@ generate_graph_info_with_schema(
       // Skip the vertex type that is not selected.
       continue;
     }
-    bool selected_property = false;
-    if (selected_vertex_properties.find(entry.label) !=
-        selected_vertex_properties.end()) {
-      selected_property = true;
-    }
-    std::vector<GAR::Property> properties;
-    for (const auto& prop : entry.props_) {
-      if (selected_property &&
-          std::find(selected_vertex_properties.at(entry.label).begin(),
-                    selected_vertex_properties.at(entry.label).end(),
-                    prop.name) ==
-              selected_vertex_properties.at(entry.label).end()) {
-        // Skip the property that is not selected.
-        continue;
-      }
-      properties.emplace_back(GAR::Property(
-          prop.name, GAR::DataType::ArrowDataTypeToDataType(prop.type), false));
-    }
-    GAR::PropertyGroupVector property_groups;
-    if (!properties.empty()) {
-      auto pg = GAR::CreatePropertyGroup(properties, file_type);
-      if (pg == nullptr) {
-        RETURN_GS_ERROR(
-            ErrorCode::kGraphArError,
-            "Failed to create property group for vertex " + entry.label);
-      }
-      property_groups.push_back(pg);
-    }
-    auto vertex_info =
-        GAR::CreateVertexInfo(entry.label, vertex_block_size, property_groups);
+    BOOST_LEAF_AUTO(vertex_info, generate_vertex_info_with_schema(
+                                     entry, vertex_block_size, file_type,
+                                     selected_vertex_properties));
     if (vertex_info == nullptr) {
       RETURN_GS_ERROR(ErrorCode::kGraphArError,
                       "Failed to create vertex info for " + entry.label);
     }
     vertex_infos.emplace_back(vertex_info);
   }
-  GAR::AdjacentListVector default_adjacent_lists{
-      GAR::CreateAdjacentList(GAR::AdjListType::ordered_by_source, file_type),
-      GAR::CreateAdjacentList(GAR::AdjListType::ordered_by_dest, file_type)};
+
   for (const auto& entry : schema.edge_entries()) {
     if (!selected_edges.empty() &&
         std::find(selected_edges.begin(), selected_edges.end(), entry.label) ==
@@ -96,57 +165,9 @@ generate_graph_info_with_schema(
       // Skip the edge type that is not selected.
       continue;
     }
-    bool selected_property = false;
-    if (selected_edge_properties.find(entry.label) !=
-        selected_edge_properties.end()) {
-      selected_property = true;
-    }
-    std::vector<GAR::Property> properties;
-    for (const auto& prop : entry.props_) {
-      if (selected_property &&
-          std::find(selected_edge_properties.at(entry.label).begin(),
-                    selected_edge_properties.at(entry.label).end(),
-                    prop.name) ==
-              selected_edge_properties.at(entry.label).end()) {
-        // Skip the property that is not selected.
-        continue;
-      }
-      properties.emplace_back(GAR::Property(
-          prop.name, GAR::DataType::ArrowDataTypeToDataType(prop.type), false));
-    }
-    GAR::PropertyGroupVector property_groups;
-    if (!properties.empty()) {
-      auto pg = GAR::CreatePropertyGroup(properties, file_type);
-      if (pg == nullptr) {
-        RETURN_GS_ERROR(
-            ErrorCode::kGraphArError,
-            "Failed to create property group for edge " + entry.label);
-      }
-      property_groups.push_back(pg);
-    }
-
-    for (const auto& relation : entry.relations) {
-      if (!selected_vertices.empty() &&
-          (std::find(selected_vertices.begin(), selected_vertices.end(),
-                     relation.first) == selected_vertices.end() ||
-           std::find(selected_vertices.begin(), selected_vertices.end(),
-                     relation.second) == selected_vertices.end())) {
-        // Skip the relation that source or destination vertex type is not
-        // selected.
-        continue;
-      }
-      auto edge_info = GAR::CreateEdgeInfo(
-          relation.first, entry.label, relation.second, edge_block_size,
-          vertex_block_size, vertex_block_size, true /* directed */,
-          default_adjacent_lists, property_groups);
-      if (edge_info == nullptr) {
-        RETURN_GS_ERROR(ErrorCode::kGraphArError,
-                        "Failed to create edge info for relation " +
-                            relation.first + " " + entry.label + " " +
-                            relation.second);
-      }
-      edge_infos.emplace_back(edge_info);
-    }
+    BOOST_LEAF_CHECK(generate_edge_infos_with_schema(
+        entry, vertex_block_size, edge_block_size, file_type, selected_vertices,
+        selected_edge_properties, edge_infos));
   }
   std::unordered_map<std::string, std::string> extra_info;
   if (store_in_local) {

--- a/modules/graph/writer/util.h
+++ b/modules/graph/writer/util.h
@@ -20,6 +20,8 @@
 
 #include <memory>
 #include <string>
+#include <unordered_map>
+#include <vector>
 
 #include "gar/graph_info.h"
 #include "gar/util/file_type.h"

--- a/modules/graph/writer/util.h
+++ b/modules/graph/writer/util.h
@@ -32,14 +32,16 @@ namespace vineyard {
 #define LOCAL_METADATA_KEY "local_meta_prefix"
 #define LOCAL_METADATA_VALUE "__local_metadata__"
 
-boost::leaf::result<std::shared_ptr<GraphArchive::GraphInfo>> generate_graph_info_with_schema(
+boost::leaf::result<std::shared_ptr<GraphArchive::GraphInfo>>
+generate_graph_info_with_schema(
     const PropertyGraphSchema& schema, const std::string& graph_name,
     const std::string& path, int64_t vertex_block_size, int64_t edge_block_size,
-    GAR::FileType file_type,
-    const std::vector<std::string>& selected_vertices,
+    GAR::FileType file_type, const std::vector<std::string>& selected_vertices,
     const std::vector<std::string>& selected_edges,
-    const std::unordered_map<std::string, std::vector<std::string>>& selected_vertex_properties,
-    const std::unordered_map<std::string, std::vector<std::string>>& selected_edge_properties,
+    const std::unordered_map<std::string, std::vector<std::string>>&
+        selected_vertex_properties,
+    const std::unordered_map<std::string, std::vector<std::string>>&
+        selected_edge_properties,
     bool store_in_local);
 
 }  // namespace vineyard

--- a/modules/graph/writer/util.h
+++ b/modules/graph/writer/util.h
@@ -32,10 +32,15 @@ namespace vineyard {
 #define LOCAL_METADATA_KEY "local_meta_prefix"
 #define LOCAL_METADATA_VALUE "__local_metadata__"
 
-std::shared_ptr<GraphArchive::GraphInfo> generate_graph_info_with_schema(
+boost::leaf::result<std::shared_ptr<GraphArchive::GraphInfo>> generate_graph_info_with_schema(
     const PropertyGraphSchema& schema, const std::string& graph_name,
     const std::string& path, int64_t vertex_block_size, int64_t edge_block_size,
-    GAR::FileType file_type, bool store_in_local);
+    GAR::FileType file_type,
+    const std::vector<std::string>& selected_vertex_labels,
+    const std::vector<std::vector<std::string>>& selected_edge_relations,
+    const std::unordered_map<std::string, std::vector<std::string>>& selected_vertex_properties,
+    const std::unordered_map<std::string, std::vector<std::string>>& selected_edge_properties,
+    bool store_in_local);
 
 }  // namespace vineyard
 

--- a/modules/graph/writer/util.h
+++ b/modules/graph/writer/util.h
@@ -32,17 +32,54 @@ namespace vineyard {
 #define LOCAL_METADATA_KEY "local_meta_prefix"
 #define LOCAL_METADATA_VALUE "__local_metadata__"
 
+// A simple struct to store the edge triple, which is used to express the edge
+// triple and used as the key of the map.
+class EdgeRelation{
+ public:
+  explicit EdgeRelation(const std::string& src_label, const std::string& edge_label,
+                      const std::string& dst_label)
+      : src_label(src_label),
+        edge_label(edge_label),
+        dst_label(dst_label) {}
+  explicit EdgeRelation(std::string&& src_label, std::string&& edge_label,
+                      std::string&& dst_label)
+      : src_label(std::move(src_label)),
+        edge_label(std::move(edge_label)),
+        dst_label(std::move(dst_label)) {}
+
+  bool operator==(const EdgeRelation& rhs) const {
+    return src_label == rhs.src_label && edge_label == rhs.edge_label &&
+           dst_label == rhs.dst_label;
+  }
+
+  std::string src_label;
+  std::string edge_label;
+  std::string dst_label;
+};
+
 boost::leaf::result<std::shared_ptr<GraphArchive::GraphInfo>> generate_graph_info_with_schema(
     const PropertyGraphSchema& schema, const std::string& graph_name,
     const std::string& path, int64_t vertex_block_size, int64_t edge_block_size,
     GAR::FileType file_type,
-    const std::vector<std::string>& selected_vertex_labels,
-    const std::vector<std::vector<std::string>>& selected_edge_relations,
+    const std::vector<std::string>& selected_vertices,
+    const std::vector<std::string>& selected_edges,
     const std::unordered_map<std::string, std::vector<std::string>>& selected_vertex_properties,
     const std::unordered_map<std::string, std::vector<std::string>>& selected_edge_properties,
     bool store_in_local);
 
 }  // namespace vineyard
+
+namespace std {
+  template <>
+  struct hash<vineyard::EdgeRelation> {
+    std::size_t operator()(const vineyard::EdgeRelation& k) const {
+      std::size_t h1 = std::hash<std::string>{}(k.src_label);
+      std::size_t h2 = std::hash<std::string>{}(k.edge_label);
+      std::size_t h3 = std::hash<std::string>{}(k.dst_label);
+      return h1 ^ (h2 << 1) ^ (h3 << 2);
+    }
+  };
+}  // namespace std
 
 #endif
 

--- a/modules/graph/writer/util.h
+++ b/modules/graph/writer/util.h
@@ -32,31 +32,6 @@ namespace vineyard {
 #define LOCAL_METADATA_KEY "local_meta_prefix"
 #define LOCAL_METADATA_VALUE "__local_metadata__"
 
-// A simple struct to store the edge triple, which is used to express the edge
-// triple and used as the key of the map.
-class EdgeRelation{
- public:
-  explicit EdgeRelation(const std::string& src_label, const std::string& edge_label,
-                      const std::string& dst_label)
-      : src_label(src_label),
-        edge_label(edge_label),
-        dst_label(dst_label) {}
-  explicit EdgeRelation(std::string&& src_label, std::string&& edge_label,
-                      std::string&& dst_label)
-      : src_label(std::move(src_label)),
-        edge_label(std::move(edge_label)),
-        dst_label(std::move(dst_label)) {}
-
-  bool operator==(const EdgeRelation& rhs) const {
-    return src_label == rhs.src_label && edge_label == rhs.edge_label &&
-           dst_label == rhs.dst_label;
-  }
-
-  std::string src_label;
-  std::string edge_label;
-  std::string dst_label;
-};
-
 boost::leaf::result<std::shared_ptr<GraphArchive::GraphInfo>> generate_graph_info_with_schema(
     const PropertyGraphSchema& schema, const std::string& graph_name,
     const std::string& path, int64_t vertex_block_size, int64_t edge_block_size,
@@ -68,18 +43,6 @@ boost::leaf::result<std::shared_ptr<GraphArchive::GraphInfo>> generate_graph_inf
     bool store_in_local);
 
 }  // namespace vineyard
-
-namespace std {
-  template <>
-  struct hash<vineyard::EdgeRelation> {
-    std::size_t operator()(const vineyard::EdgeRelation& k) const {
-      std::size_t h1 = std::hash<std::string>{}(k.src_label);
-      std::size_t h2 = std::hash<std::string>{}(k.edge_label);
-      std::size_t h3 = std::hash<std::string>{}(k.dst_label);
-      return h1 ^ (h2 << 1) ^ (h3 << 2);
-    }
-  };
-}  // namespace std
 
 #endif
 


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------
- Bump up GraphAr to v0.11.3 to support `Date` and `Timestamp` type, make the whole ldbc dataset dumps work
- Refine the `ArrowFragmentWriter` to support write graph with selected vertices/edges and propertices



Related issue number
--------------------


Fixes #1812 

