### PR TITLE
Add the glog libraries when build the vineyard llm cache module.

### DIFF
--- a/modules/llm-cache/CMakeLists.txt
+++ b/modules/llm-cache/CMakeLists.txt
@@ -8,7 +8,7 @@ file(GLOB VINEYARD_LLM_CACHE_SRCS "${CMAKE_CURRENT_SOURCE_DIR}"
 )
 
 add_library(vineyard_llm_cache ${VINEYARD_LLM_CACHE_SRCS})
-target_link_libraries(vineyard_llm_cache PRIVATE libzstd_static)
+target_link_libraries(vineyard_llm_cache PRIVATE libzstd_static ${GLOG_LIBRARIES})
 target_link_libraries(vineyard_llm_cache PUBLIC vineyard_client)
 
 # install bundled thirdparty: rax


### PR DESCRIPTION
What do these changes do?
-------------------------

In macos, fix the such following error.

![image](https://github.com/v6d-io/v6d/assets/71587243/09340e63-77fb-4a53-9fd2-3fb90b7fc680)



