### PR TITLE
[k8s]: Remove unnecessary time parsing in reconcile functions

### DIFF
--- a/k8s/controllers/k8s/backup_controller.go
+++ b/k8s/controllers/k8s/backup_controller.go
@@ -135,8 +135,7 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	// reconcile every minute
-	duration, _ := time.ParseDuration("1m")
-	return ctrl.Result{RequeueAfter: duration}, nil
+	return ctrl.Result{RequeueAfter: time.Minute}, nil
 }
 
 // UpdateStatus updates the status of the Backup.Running

--- a/k8s/controllers/k8s/csidriver_controller.go
+++ b/k8s/controllers/k8s/csidriver_controller.go
@@ -18,14 +18,13 @@ package k8s
 import (
 	"context"
 	"fmt"
-	"time"
-
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
 
 	"github.com/apache/skywalking-swck/operator/pkg/kubernetes"
 	"github.com/pkg/errors"
@@ -158,8 +157,7 @@ func (r *CSIDriverReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		logger.Error(err, "Failed to update the status", "CSIDriver", csiDriver)
 	}
 	// reconcile every minute
-	duration, _ := time.ParseDuration("1m")
-	return ctrl.Result{RequeueAfter: duration}, nil
+	return ctrl.Result{RequeueAfter: time.Minute}, nil
 }
 
 func (r *CSIDriverReconciler) UpdateStatus(ctx context.Context, csiDriver *k8sv1alpha1.CSIDriver) error {

--- a/k8s/controllers/k8s/csidriver_controller.go
+++ b/k8s/controllers/k8s/csidriver_controller.go
@@ -18,13 +18,14 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"time"
+
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
 
 	"github.com/apache/skywalking-swck/operator/pkg/kubernetes"
 	"github.com/pkg/errors"

--- a/k8s/controllers/k8s/operation_controller.go
+++ b/k8s/controllers/k8s/operation_controller.go
@@ -97,8 +97,7 @@ func (r *OperationReconciler) Reconcile(
 	}
 
 	// reconcile every minute
-	duration, _ := time.ParseDuration("1m")
-	return ctrl.Result{RequeueAfter: duration}, nil
+	return ctrl.Result{RequeueAfter: time.Minute}, nil
 }
 
 // UpdateStatus updates the status of the localobject

--- a/k8s/controllers/k8s/recover_controller.go
+++ b/k8s/controllers/k8s/recover_controller.go
@@ -135,8 +135,7 @@ func (r *RecoverReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	// reconcile every minute
-	duration, _ := time.ParseDuration("1m")
-	return ctrl.Result{RequeueAfter: duration}, nil
+	return ctrl.Result{RequeueAfter: time.Minute}, nil
 }
 
 // UpdateStateStatus updates the state status of the Recover.

--- a/k8s/controllers/k8s/sidecar_controller.go
+++ b/k8s/controllers/k8s/sidecar_controller.go
@@ -18,9 +18,10 @@ package k8s
 
 import (
 	"context"
-	"github.com/pkg/errors"
 	"strings"
 	"time"
+	
+	"github.com/pkg/errors"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/k8s/controllers/k8s/sidecar_controller.go
+++ b/k8s/controllers/k8s/sidecar_controller.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"strings"
 	"time"
-	
+
 	"github.com/pkg/errors"
 
 	v1 "k8s.io/api/core/v1"

--- a/k8s/controllers/k8s/sidecar_controller.go
+++ b/k8s/controllers/k8s/sidecar_controller.go
@@ -18,10 +18,9 @@ package k8s
 
 import (
 	"context"
+	"github.com/pkg/errors"
 	"strings"
 	"time"
-
-	"github.com/pkg/errors"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -117,8 +116,7 @@ func (r *SidecarReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	// reconcile every minute
-	duration, _ := time.ParseDuration("1m")
-	return ctrl.Result{RequeueAfter: duration}, nil
+	return ctrl.Result{RequeueAfter: time.Minute}, nil
 }
 
 // UpdateStatus updates the status of the Sidecar.

--- a/k8s/controllers/k8s/vineyardd_controller.go
+++ b/k8s/controllers/k8s/vineyardd_controller.go
@@ -142,8 +142,7 @@ func (r *VineyarddReconciler) Reconcile(
 	}
 
 	// reconcile every minute
-	duration, _ := time.ParseDuration("1m")
-	return ctrl.Result{RequeueAfter: duration}, nil
+	return ctrl.Result{RequeueAfter: time.Minute}, nil
 }
 
 // UpdateStatus updates the status of the Vineyardd.


### PR DESCRIPTION
What do these changes do?
-------------------------

Removes unnecessary `time.ParseDuration("1m")` from `Reconcile` functions in controllers package and replaces it by using standard constant `time.Minute` from `time` package.