### PR TITLE
Add the hash function for batched tokens in llm kv cache.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1196,3 +1196,11 @@ Redistribution and use in source and binary forms, with or without modification,
     * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-------------------------------------------------------------------------------
+
+The files thirdparty/MurmurHash3/{MurmurHash3.cc, MurmurHash3.h} is referred from project aappleby/smhasher
+which has the following license:
+
+// MurmurHash3 was written by Austin Appleby, and is placed in the public
+// domain. The author hereby disclaims copyright to this source code.

--- a/README.rst
+++ b/README.rst
@@ -299,6 +299,7 @@ We thank the following excellent open-source projects:
 - `wyhash <https://github.com/alainesp/wy>`_, C++ wrapper around wyhash and wyrand.
 - `BBHash <https://github.com/rizkg/BBHash>`_, a fast, minimal-memory perfect hash function.
 - `rax <https://github.com/antirez/rax>`_, an ANSI C radix tree implementation.
+- `MurmurHash3 <https://github.com/aappleby/smhasher>`_, a fast non-cryptographic hash function.
 
 License
 -------

--- a/modules/llm-cache/CMakeLists.txt
+++ b/modules/llm-cache/CMakeLists.txt
@@ -1,20 +1,27 @@
 file(GLOB VINEYARD_LLM_CACHE_SRCS "${CMAKE_CURRENT_SOURCE_DIR}"
                                   "ds/*.cc"
                                   "ds/*.h"
+                                  "hash/*.h"
                                   "radix-tree/*.cc"
                                   "radix-tree/*.h"
                                   "storage/*.cc"
                                   "storage/*.h"
                                   "${PROJECT_SOURCE_DIR}/thirdparty/rax/*.cc"
                                   "${PROJECT_SOURCE_DIR}/thirdparty/rax/*.h"
+                                  "${PROJECT_SOURCE_DIR}/thirdparty/MurmurHash3/*.cc"
+                                  "${PROJECT_SOURCE_DIR}/thirdparty/MurmurHash3/*.h"
+                                  "${PROJECT_SOURCE_DIR}/thirdparty/cityhash/*.hpp"
 )
 
 add_library(vineyard_llm_cache ${VINEYARD_LLM_CACHE_SRCS})
 target_link_libraries(vineyard_llm_cache PRIVATE libzstd_static ${GLOG_LIBRARIES})
 target_link_libraries(vineyard_llm_cache PUBLIC vineyard_client)
 
-# install bundled thirdparty: rax
-install(DIRECTORY ${PROJECT_SOURCE_DIR}/thirdparty/rax
+# install bundled thirdparty: rax and MurmurHash3
+install(DIRECTORY
+            ${PROJECT_SOURCE_DIR}/thirdparty/rax
+            ${PROJECT_SOURCE_DIR}/thirdparty/MurmurHash3
+            ${PROJECT_SOURCE_DIR}/thirdparty/cityhash
         DESTINATION include/vineyard/contrib    # target directory
         FILES_MATCHING                          # install only matched files
         PATTERN "*.h"                           # select header files

--- a/modules/llm-cache/hash/hash_algorithm.h
+++ b/modules/llm-cache/hash/hash_algorithm.h
@@ -1,0 +1,52 @@
+/** Copyright 2020-2023 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef MODULES_LLM_CACHE_HASH_HASH_ALGORITHM_H_
+#define MODULES_LLM_CACHE_HASH_HASH_ALGORITHM_H_
+
+#include <string>
+
+#include "MurmurHash3/MurmurHash3.h"
+#include "cityhash/cityhash.hpp"
+
+namespace vineyard {
+
+class IHashAlgorithm {
+ public:
+  virtual ~IHashAlgorithm() {}
+  virtual uint32_t hash(const std::string& input) = 0;
+};
+
+class MurmurHash3Algorithm : public IHashAlgorithm {
+ public:
+  uint32_t hash(const std::string& input) override {
+    uint32_t value;
+    MurmurHash3_x86_32(input.c_str(), input.size(), 0, &value);
+    return value;
+  }
+};
+
+class CityHashAlgorithm : public IHashAlgorithm {
+ public:
+  uint32_t hash(const std::string& input) override {
+    uint32_t value;
+    value = city::detail::CityHash32(input.c_str(), input.size());
+    return value;
+  }
+};
+
+}  // namespace vineyard
+
+#endif  // MODULES_LLM_CACHE_HASH_HASH_ALGORITHM_H_

--- a/modules/llm-cache/hash/hasher.h
+++ b/modules/llm-cache/hash/hasher.h
@@ -1,0 +1,103 @@
+/** Copyright 2020-2023 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef MODULES_LLM_CACHE_HASH_HASHER_H_
+#define MODULES_LLM_CACHE_HASH_HASHER_H_
+
+#include <string>
+#include <vector>
+
+#include "common/util/status.h"
+#include "llm-cache/hash/hash_algorithm.h"
+
+namespace vineyard {
+
+class Hasher {
+ public:
+  explicit Hasher(IHashAlgorithm* algorithm) { hashAlgorithm = algorithm; }
+
+  /**
+   * @brief Compute the path list for the token list
+   *
+   * @param tokenList The list of tokens
+   * @param batchSize The size of the batch
+   * @param splitNumber The number of splits
+   * @param pathList The Relative path list of the token list
+   *
+   * @return Status
+   *
+   * @example
+   *      Assume the token list is [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+   *      and the batch size is 3, the split number is 2.
+   *
+   *      The hash value will be computed for each batch as follows:
+   *      1 2 3 -> hashValue1
+   *      4 5 6 -> hashValue2
+   *      7 8 9 -> hashValue3
+   *      10 -> Abandoned(less than the batch size)
+   *
+   *      Then the hash value will be split into the path as follows:
+   *      hashValue1(3e91df34) -> 3e/91/df/34
+   *      hashValue2(3691d935) -> 36/91/d9/35
+   *      hashValue3(4c90a490) -> 4c/90/a4/90
+   *
+   */
+  Status computePathForTokens(std::vector<int>& tokenList, int batchSize,
+                              int splitNumber,
+                              std::vector<std::string>& pathList) {
+    int hashValue;
+    char hashBuffer[9];
+    int tokenSize = tokenList.size() - tokenList.size() % batchSize;
+    // if the token list (upper_bound) is less than the batch size, then return
+    // directly
+    if (tokenSize < batchSize) {
+      return Status::OK();
+    }
+
+    // reserve the chunk size for the buffer and split by ' '
+    std::vector<char> buffer(batchSize * (sizeof(int) + 1), '\0');
+
+    // split the token list into batches
+    for (int i = 0; i < tokenSize; i += batchSize) {
+      char* buffer_ptr = buffer.data();
+      for (int j = i; j < i + batchSize && j < tokenSize; j++) {
+        size_t renaming_space = buffer.size() - (buffer_ptr - buffer.data());
+        buffer_ptr +=
+            std::snprintf(buffer_ptr, renaming_space, "%d ", tokenList[j]);
+      }
+      hashValue =
+          hashAlgorithm->hash(std::string(buffer.data(), buffer.size()));
+
+      // split the hash value into paths
+      std::snprintf(hashBuffer, sizeof(hashBuffer), "%08x", hashValue);
+      int index = 0;
+      std::string path;
+      while (index + splitNumber < 8) {
+        path += std::string(hashBuffer + index, splitNumber) + "/";
+        index += splitNumber;
+      }
+      path += std::string(hashBuffer + index, 8 - index);
+      pathList.push_back(path);
+    }
+    return Status::OK();
+  }
+
+ private:
+  IHashAlgorithm* hashAlgorithm;
+};
+
+}  // namespace vineyard
+
+#endif  // MODULES_LLM_CACHE_HASH_HASHER_H_

--- a/modules/llm-cache/tests/kv_state_cache_hash_test.cc
+++ b/modules/llm-cache/tests/kv_state_cache_hash_test.cc
@@ -115,7 +115,7 @@ void test_hash_conflict() {
 
   std::map<std::vector<int>, int> tokens_map;
   for (int i = 0; i < TOKENLISTSIZE; i++) {
-    std::vector<int> tokens = generate_random_tokens(10);
+    std::vector<int> tokens = generate_random_tokens(16);
     tokens_map[tokens]++;
     token_size += tokens.size();
     VINEYARD_CHECK_OK(murmur_hasher.computePathForTokens(

--- a/modules/llm-cache/tests/kv_state_cache_hash_test.cc
+++ b/modules/llm-cache/tests/kv_state_cache_hash_test.cc
@@ -1,0 +1,163 @@
+/** Copyright 2020-2023 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <iostream>
+#include <random>
+#include <vector>
+
+#include "common/util/logging.h"
+
+#include "llm-cache/hash/hasher.h"
+
+using namespace vineyard;  //  NOLINT(build/namespaces)
+
+constexpr int BATCHSIZE = 16;
+constexpr int SPLITNUMBER = 2;
+constexpr int TOKENLISTSIZE = 100000;
+
+std::vector<int> generate_random_tokens(size_t max_length) {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<> dist(1, 10000);
+
+  size_t length = max_length;
+  std::vector<int> tokens(length);
+  for (size_t i = 0; i < length; ++i) {
+    tokens[i] = dist(gen);
+  }
+  return tokens;
+}
+
+void test_with_tokens(IHashAlgorithm* hash_algorithm,
+                      const std::string& hash_name) {
+  LOG(INFO) << "start to test the " << hash_name << " with tokens";
+  Hasher hasher(hash_algorithm);
+
+  // test the hash with the tokens less than the batch size
+  std::vector<int> tokens = generate_random_tokens(10);
+  std::vector<std::string> paths;
+  VINEYARD_CHECK_OK(
+      hasher.computePathForTokens(tokens, BATCHSIZE, SPLITNUMBER, paths));
+  VINEYARD_ASSERT(paths.size() == 0);
+
+  // test the hash with the tokens more than the batch size
+  std::vector<std::string> paths1, paths2;
+  std::vector<int> tokens1 = generate_random_tokens(17);
+  std::vector<int> tokens2 = generate_random_tokens(18);
+  VINEYARD_CHECK_OK(
+      hasher.computePathForTokens(tokens1, BATCHSIZE, SPLITNUMBER, paths1));
+  VINEYARD_CHECK_OK(
+      hasher.computePathForTokens(tokens2, BATCHSIZE, SPLITNUMBER, paths2));
+  VINEYARD_ASSERT(paths1.size() == paths1.size());
+
+  paths.clear();
+  tokens = generate_random_tokens(100);
+  VINEYARD_CHECK_OK(
+      hasher.computePathForTokens(tokens, BATCHSIZE, SPLITNUMBER, paths));
+  VINEYARD_ASSERT(paths.size() == size_t(100 / 16));
+  LOG(INFO) << "Passed the " << hash_name << " test of tokens";
+}
+
+void test_accuracy(IHashAlgorithm* hash_algorithm,
+                   const std::string& hash_name) {
+  LOG(INFO) << "start to test the accuracy of the " << hash_name;
+  MurmurHash3Algorithm hash;
+  Hasher hasher(&hash);
+  std::vector<std::string> paths1;
+  std::vector<std::string> paths2;
+  for (int i = 0; i < 100; i++) {
+    std::vector<int> tokens = generate_random_tokens(100);
+    VINEYARD_CHECK_OK(
+        hasher.computePathForTokens(tokens, BATCHSIZE, SPLITNUMBER, paths1));
+    VINEYARD_CHECK_OK(
+        hasher.computePathForTokens(tokens, BATCHSIZE, SPLITNUMBER, paths2));
+  }
+
+  VINEYARD_ASSERT(paths1.size() == paths2.size());
+  for (size_t i = 0; i < paths1.size(); i++) {
+    VINEYARD_ASSERT(paths1[i] == paths2[i]);
+  }
+
+  LOG(INFO) << "Passed the accuracy test of the " << hash_name;
+}
+
+// test the hash conflict of the MurmurHash3Algorithm and CityHashAlgorithm
+void test_hash_conflict() {
+  LOG(INFO) << "start to test the hash conflict of the MurmurHash3Algorithm";
+
+  MurmurHash3Algorithm murmur_hash;
+  Hasher murmur_hasher(&murmur_hash);
+
+  CityHashAlgorithm city_hash;
+  Hasher city_hasher(&city_hash);
+
+  std::map<std::string, int> murmur_hash_paths_map;
+  std::map<std::string, int> city_hash_paths_map;
+
+  std::vector<std::string> murmur_hash_paths;
+  std::vector<std::string> city_hash_paths;
+
+  int murmur_hash_conflict_count = 0;
+  int city_hash_conflict_count = 0;
+  int token_size = 0;
+
+  std::map<std::vector<int>, int> tokens_map;
+  for (int i = 0; i < TOKENLISTSIZE; i++) {
+    std::vector<int> tokens = generate_random_tokens(10);
+    tokens_map[tokens]++;
+    token_size += tokens.size();
+    VINEYARD_CHECK_OK(murmur_hasher.computePathForTokens(
+        tokens, BATCHSIZE, SPLITNUMBER, murmur_hash_paths));
+    VINEYARD_CHECK_OK(city_hasher.computePathForTokens(
+        tokens, BATCHSIZE, SPLITNUMBER, city_hash_paths));
+  }
+
+  for (size_t i = 0; i < murmur_hash_paths.size(); i++) {
+    murmur_hash_paths_map[murmur_hash_paths[i]]++;
+  }
+  for (size_t i = 0; i < city_hash_paths.size(); i++) {
+    city_hash_paths_map[city_hash_paths[i]]++;
+  }
+
+  for (auto iter = murmur_hash_paths_map.begin();
+       iter != murmur_hash_paths_map.end(); iter++) {
+    if (iter->second > 1) {
+      murmur_hash_conflict_count += (iter->second - 1);
+    }
+  }
+
+  for (auto iter = city_hash_paths_map.begin();
+       iter != city_hash_paths_map.end(); iter++) {
+    if (iter->second > 1) {
+      city_hash_conflict_count += (iter->second - 1);
+    }
+  }
+
+  LOG(INFO) << "MurmurHash3Algorithm conflict count is "
+            << murmur_hash_conflict_count << " / " << token_size
+            << "CityHashAlgorithm conflict count is "
+            << city_hash_conflict_count << " / " << token_size;
+}
+
+int main(int argc, char** argv) {
+  MurmurHash3Algorithm murmur_hash;
+  CityHashAlgorithm city_hash;
+  test_with_tokens(&murmur_hash, "murmurhash");
+  test_with_tokens(&city_hash, "cityhash");
+  test_accuracy(&murmur_hash, "murmurhash");
+  test_accuracy(&city_hash, "cityhash");
+  test_hash_conflict();
+  return 0;
+}

--- a/test/runner.py
+++ b/test/runner.py
@@ -475,6 +475,7 @@ def run_vineyard_cpp_tests(meta, allocator, endpoints, tests):
         run_test(tests, 'typename_test')
         run_test(tests, 'version_test')
         run_test(tests, 'kv_state_cache_radix_tree_test')
+        run_test(tests, 'kv_state_cache_hash_test')
 
 
 def run_vineyard_spill_tests(meta, allocator, endpoints, tests):

--- a/thirdparty/MurmurHash3/MurmurHash3.cc
+++ b/thirdparty/MurmurHash3/MurmurHash3.cc
@@ -1,0 +1,334 @@
+//-----------------------------------------------------------------------------
+// MurmurHash3 was written by Austin Appleby, and is placed in the public
+// domain. The author hereby disclaims copyright to this source code.
+
+// Note - The x86 and x64 versions do _not_ produce the same results, as the
+// algorithms are optimized for their respective platforms. You can still
+// compile and run any of them on any platform, but your performance with the
+// non-native version will be less than optimal.
+
+#include "MurmurHash3.h"
+
+//-----------------------------------------------------------------------------
+// Platform-specific functions and macros
+
+// Microsoft Visual Studio
+
+#if defined(_MSC_VER)
+
+#define FORCE_INLINE	__forceinline
+
+#include <stdlib.h>
+
+#define ROTL32(x,y)	_rotl(x,y)
+#define ROTL64(x,y)	_rotl64(x,y)
+
+#define BIG_CONSTANT(x) (x)
+
+// Other compilers
+
+#else	// defined(_MSC_VER)
+
+#define	FORCE_INLINE inline __attribute__((always_inline))
+
+inline uint32_t rotl32 ( uint32_t x, int8_t r )
+{
+  return (x << r) | (x >> (32 - r));
+}
+
+inline uint64_t rotl64 ( uint64_t x, int8_t r )
+{
+  return (x << r) | (x >> (64 - r));
+}
+
+#define	ROTL32(x,y)	rotl32(x,y)
+#define ROTL64(x,y)	rotl64(x,y)
+
+#define BIG_CONSTANT(x) (x##LLU)
+
+#endif // !defined(_MSC_VER)
+
+//-----------------------------------------------------------------------------
+// Block read - if your platform needs to do endian-swapping or can only
+// handle aligned reads, do the conversion here
+
+FORCE_INLINE uint32_t getblock32 ( const uint32_t * p, int i )
+{
+  return p[i];
+}
+
+FORCE_INLINE uint64_t getblock64 ( const uint64_t * p, int i )
+{
+  return p[i];
+}
+
+//-----------------------------------------------------------------------------
+// Finalization mix - force all bits of a hash block to avalanche
+
+FORCE_INLINE uint32_t fmix32 ( uint32_t h )
+{
+  h ^= h >> 16;
+  h *= 0x85ebca6b;
+  h ^= h >> 13;
+  h *= 0xc2b2ae35;
+  h ^= h >> 16;
+
+  return h;
+}
+
+//----------
+
+FORCE_INLINE uint64_t fmix64 ( uint64_t k )
+{
+  k ^= k >> 33;
+  k *= BIG_CONSTANT(0xff51afd7ed558ccd);
+  k ^= k >> 33;
+  k *= BIG_CONSTANT(0xc4ceb9fe1a85ec53);
+  k ^= k >> 33;
+
+  return k;
+}
+
+//-----------------------------------------------------------------------------
+
+void MurmurHash3_x86_32 ( const void * key, int len,
+                          uint32_t seed, void * out )
+{
+  const uint8_t * data = (const uint8_t*)key;
+  const int nblocks = len / 4;
+
+  uint32_t h1 = seed;
+
+  const uint32_t c1 = 0xcc9e2d51;
+  const uint32_t c2 = 0x1b873593;
+
+  //----------
+  // body
+
+  const uint32_t * blocks = (const uint32_t *)(data + nblocks*4);
+
+  for(int i = -nblocks; i; i++)
+  {
+    uint32_t k1 = getblock32(blocks,i);
+
+    k1 *= c1;
+    k1 = ROTL32(k1,15);
+    k1 *= c2;
+
+    h1 ^= k1;
+    h1 = ROTL32(h1,13); 
+    h1 = h1*5+0xe6546b64;
+  }
+
+  //----------
+  // tail
+
+  const uint8_t * tail = (const uint8_t*)(data + nblocks*4);
+
+  uint32_t k1 = 0;
+
+  switch(len & 3)
+  {
+  case 3: k1 ^= tail[2] << 16;
+  case 2: k1 ^= tail[1] << 8;
+  case 1: k1 ^= tail[0];
+          k1 *= c1; k1 = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
+  };
+
+  //----------
+  // finalization
+
+  h1 ^= len;
+
+  h1 = fmix32(h1);
+
+  *(uint32_t*)out = h1;
+} 
+
+//-----------------------------------------------------------------------------
+
+void MurmurHash3_x86_128 ( const void * key, const int len,
+                           uint32_t seed, void * out )
+{
+  const uint8_t * data = (const uint8_t*)key;
+  const int nblocks = len / 16;
+
+  uint32_t h1 = seed;
+  uint32_t h2 = seed;
+  uint32_t h3 = seed;
+  uint32_t h4 = seed;
+
+  const uint32_t c1 = 0x239b961b; 
+  const uint32_t c2 = 0xab0e9789;
+  const uint32_t c3 = 0x38b34ae5; 
+  const uint32_t c4 = 0xa1e38b93;
+
+  //----------
+  // body
+
+  const uint32_t * blocks = (const uint32_t *)(data + nblocks*16);
+
+  for(int i = -nblocks; i; i++)
+  {
+    uint32_t k1 = getblock32(blocks,i*4+0);
+    uint32_t k2 = getblock32(blocks,i*4+1);
+    uint32_t k3 = getblock32(blocks,i*4+2);
+    uint32_t k4 = getblock32(blocks,i*4+3);
+
+    k1 *= c1; k1  = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
+
+    h1 = ROTL32(h1,19); h1 += h2; h1 = h1*5+0x561ccd1b;
+
+    k2 *= c2; k2  = ROTL32(k2,16); k2 *= c3; h2 ^= k2;
+
+    h2 = ROTL32(h2,17); h2 += h3; h2 = h2*5+0x0bcaa747;
+
+    k3 *= c3; k3  = ROTL32(k3,17); k3 *= c4; h3 ^= k3;
+
+    h3 = ROTL32(h3,15); h3 += h4; h3 = h3*5+0x96cd1c35;
+
+    k4 *= c4; k4  = ROTL32(k4,18); k4 *= c1; h4 ^= k4;
+
+    h4 = ROTL32(h4,13); h4 += h1; h4 = h4*5+0x32ac3b17;
+  }
+
+  //----------
+  // tail
+
+  const uint8_t * tail = (const uint8_t*)(data + nblocks*16);
+
+  uint32_t k1 = 0;
+  uint32_t k2 = 0;
+  uint32_t k3 = 0;
+  uint32_t k4 = 0;
+
+  switch(len & 15)
+  {
+  case 15: k4 ^= tail[14] << 16;
+  case 14: k4 ^= tail[13] << 8;
+  case 13: k4 ^= tail[12] << 0;
+           k4 *= c4; k4  = ROTL32(k4,18); k4 *= c1; h4 ^= k4;
+
+  case 12: k3 ^= tail[11] << 24;
+  case 11: k3 ^= tail[10] << 16;
+  case 10: k3 ^= tail[ 9] << 8;
+  case  9: k3 ^= tail[ 8] << 0;
+           k3 *= c3; k3  = ROTL32(k3,17); k3 *= c4; h3 ^= k3;
+
+  case  8: k2 ^= tail[ 7] << 24;
+  case  7: k2 ^= tail[ 6] << 16;
+  case  6: k2 ^= tail[ 5] << 8;
+  case  5: k2 ^= tail[ 4] << 0;
+           k2 *= c2; k2  = ROTL32(k2,16); k2 *= c3; h2 ^= k2;
+
+  case  4: k1 ^= tail[ 3] << 24;
+  case  3: k1 ^= tail[ 2] << 16;
+  case  2: k1 ^= tail[ 1] << 8;
+  case  1: k1 ^= tail[ 0] << 0;
+           k1 *= c1; k1  = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
+  };
+
+  //----------
+  // finalization
+
+  h1 ^= len; h2 ^= len; h3 ^= len; h4 ^= len;
+
+  h1 += h2; h1 += h3; h1 += h4;
+  h2 += h1; h3 += h1; h4 += h1;
+
+  h1 = fmix32(h1);
+  h2 = fmix32(h2);
+  h3 = fmix32(h3);
+  h4 = fmix32(h4);
+
+  h1 += h2; h1 += h3; h1 += h4;
+  h2 += h1; h3 += h1; h4 += h1;
+
+  ((uint32_t*)out)[0] = h1;
+  ((uint32_t*)out)[1] = h2;
+  ((uint32_t*)out)[2] = h3;
+  ((uint32_t*)out)[3] = h4;
+}
+
+//-----------------------------------------------------------------------------
+
+void MurmurHash3_x64_128 ( const void * key, const int len,
+                           const uint32_t seed, void * out )
+{
+  const uint8_t * data = (const uint8_t*)key;
+  const int nblocks = len / 16;
+
+  uint64_t h1 = seed;
+  uint64_t h2 = seed;
+
+  const uint64_t c1 = BIG_CONSTANT(0x87c37b91114253d5);
+  const uint64_t c2 = BIG_CONSTANT(0x4cf5ad432745937f);
+
+  //----------
+  // body
+
+  const uint64_t * blocks = (const uint64_t *)(data);
+
+  for(int i = 0; i < nblocks; i++)
+  {
+    uint64_t k1 = getblock64(blocks,i*2+0);
+    uint64_t k2 = getblock64(blocks,i*2+1);
+
+    k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1;
+
+    h1 = ROTL64(h1,27); h1 += h2; h1 = h1*5+0x52dce729;
+
+    k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; h2 ^= k2;
+
+    h2 = ROTL64(h2,31); h2 += h1; h2 = h2*5+0x38495ab5;
+  }
+
+  //----------
+  // tail
+
+  const uint8_t * tail = (const uint8_t*)(data + nblocks*16);
+
+  uint64_t k1 = 0;
+  uint64_t k2 = 0;
+
+  switch(len & 15)
+  {
+  case 15: k2 ^= ((uint64_t)tail[14]) << 48;
+  case 14: k2 ^= ((uint64_t)tail[13]) << 40;
+  case 13: k2 ^= ((uint64_t)tail[12]) << 32;
+  case 12: k2 ^= ((uint64_t)tail[11]) << 24;
+  case 11: k2 ^= ((uint64_t)tail[10]) << 16;
+  case 10: k2 ^= ((uint64_t)tail[ 9]) << 8;
+  case  9: k2 ^= ((uint64_t)tail[ 8]) << 0;
+           k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; h2 ^= k2;
+
+  case  8: k1 ^= ((uint64_t)tail[ 7]) << 56;
+  case  7: k1 ^= ((uint64_t)tail[ 6]) << 48;
+  case  6: k1 ^= ((uint64_t)tail[ 5]) << 40;
+  case  5: k1 ^= ((uint64_t)tail[ 4]) << 32;
+  case  4: k1 ^= ((uint64_t)tail[ 3]) << 24;
+  case  3: k1 ^= ((uint64_t)tail[ 2]) << 16;
+  case  2: k1 ^= ((uint64_t)tail[ 1]) << 8;
+  case  1: k1 ^= ((uint64_t)tail[ 0]) << 0;
+           k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1;
+  };
+
+  //----------
+  // finalization
+
+  h1 ^= len; h2 ^= len;
+
+  h1 += h2;
+  h2 += h1;
+
+  h1 = fmix64(h1);
+  h2 = fmix64(h2);
+
+  h1 += h2;
+  h2 += h1;
+
+  ((uint64_t*)out)[0] = h1;
+  ((uint64_t*)out)[1] = h2;
+}
+
+//-----------------------------------------------------------------------------

--- a/thirdparty/MurmurHash3/MurmurHash3.h
+++ b/thirdparty/MurmurHash3/MurmurHash3.h
@@ -1,0 +1,37 @@
+//-----------------------------------------------------------------------------
+// MurmurHash3 was written by Austin Appleby, and is placed in the public
+// domain. The author hereby disclaims copyright to this source code.
+
+#ifndef _MURMURHASH3_H_
+#define _MURMURHASH3_H_
+
+//-----------------------------------------------------------------------------
+// Platform-specific functions and macros
+
+// Microsoft Visual Studio
+
+#if defined(_MSC_VER) && (_MSC_VER < 1600)
+
+typedef unsigned char uint8_t;
+typedef unsigned int uint32_t;
+typedef unsigned __int64 uint64_t;
+
+// Other compilers
+
+#else	// defined(_MSC_VER)
+
+#include <stdint.h>
+
+#endif // !defined(_MSC_VER)
+
+//-----------------------------------------------------------------------------
+
+void MurmurHash3_x86_32  ( const void * key, int len, uint32_t seed, void * out );
+
+void MurmurHash3_x86_128 ( const void * key, int len, uint32_t seed, void * out );
+
+void MurmurHash3_x64_128 ( const void * key, int len, uint32_t seed, void * out );
+
+//-----------------------------------------------------------------------------
+
+#endif // _MURMURHASH3_H_


### PR DESCRIPTION
What do these changes do?
-------------------------

I have tested the hash functions `MurmurHash3` and `CityHash` with 100000 different seqs(each seq contains 10 tokens) for multiple times, and the result is as follows.

```
MurmurHash3Algorithm conflict count is 7 / 1600000
CityHashAlgorithm conflict count is 4 / 1600000
```

or

```
MurmurHash3Algorithm conflict count is 1 / 1600000
CityHashAlgorithm conflict count is 3 / 1600000
```

Basically, the conflict rate of the two hash functions is same.

Related issue number
--------------------

Part of https://github.com/v6d-io/v6d/issues/1832

