### PR TITLE
Add the base image pingcap/alpine-glibc:alpine-3.14.6 for releasing vineyardd and bump up etcd to v3.5.13

### DIFF
--- a/docker/Dockerfile.vineyardd
+++ b/docker/Dockerfile.vineyardd
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ARG MODE=release
+
 FROM ghcr.io/v6d-io/v6d/vineyardd-alpine-builder:builder-latest as builder
 
 RUN export arch="$PLATFORM" && \
@@ -26,9 +28,9 @@ RUN export arch="$PLATFORM" && \
     curl -LO https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_$arch && \
     chmod +x dumb-init_1.2.2_$arch && \
     mv /tmp/dumb-init_1.2.2_$arch /usr/bin/dumb-init && \
-    curl -LO https://github.com/etcd-io/etcd/releases/download/v3.5.9/etcd-v3.5.9-linux-$arch.tar.gz && \
-    tar zxf etcd-v3.5.9-linux-$arch.tar.gz && \
-    mv /tmp/etcd-v3.5.9-linux-$arch/etcd /usr/bin/etcd && \
+    curl -LO https://github.com/etcd-io/etcd/releases/download/v3.5.13/etcd-v3.5.13-linux-$arch.tar.gz && \
+    tar zxf etcd-v3.5.13-linux-$arch.tar.gz && \
+    mv /tmp/etcd-v3.5.13-linux-$arch/etcd /usr/bin/etcd && \
     curl -LO https://dl.k8s.io/release/v1.24.0/bin/linux/$arch/kubectl && \
     chmod +x kubectl && \
     mv /tmp/kubectl /usr/bin/kubectl
@@ -73,17 +75,23 @@ RUN cd /work/v6d && \
     make -j`nproc` && \
     strip ./bin/vineyardd
 
-# debug has busybox
-FROM gcr.io/distroless/base:debug
+FROM pingcap/alpine-glibc:alpine-3.14.6 as release
 
-SHELL ["/bin/bash", "-c"]
+FROM gcr.io/distroless/base:debug as debug
+
+FROM ${MODE}
 
 COPY --from=builder /usr/bin/bash-linux /bin/bash
 COPY --from=builder /usr/bin/dumb-init /usr/bin/dumb-init
 COPY --from=builder /usr/bin/etcd /usr/bin/etcd
 COPY --from=builder /usr/bin/kubectl /usr/bin/kubectl
 COPY --from=builder /work/v6d/build/bin/vineyardd /usr/local/bin/vineyardd
-RUN ln -s /busybox/env /usr/bin/env
+
+SHELL ["/bin/bash", "-c"]
+
+RUN if [ "$MODE" = "release" ]; then apk add --no-cache sudo; \
+    elif [ "$MODE" = "debug" ]; then ln -s /busybox/env /usr/bin/env; \
+    fi
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/usr/local/bin/vineyardd"]

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -15,6 +15,7 @@ ALPINE_IMAGE				:= vineyardd
 ALPINE_VERSION 				:= latest
 ALPINE_MANIFEST_TAG			:= alpine-$(ALPINE_VERSION)
 ALPINE_TAG					:= $(ALPINE_MANIFEST_TAG)_$(PLATFORM)
+ALPINE_DEBUG_TAG			:= $(ALPINE_MANIFEST_TAG)_$(PLATFORM)_debug
 
 WHEEL_BUILDER_REGISTRY		:= $(REGISTRY)
 WHEEL_BUILDER_IMAGE			:= vineyard-manylinux2014
@@ -61,15 +62,27 @@ builder-manifest:
 		--amend $(BUILDER_REGISTRY)/$(BUILDER_IMAGE):$(BUILDER_MANIFEST_TAG)_aarch64
 .PHONY: builder-manifest
 
-# building standalone vineyardd
+# building standalone vineyardd in release mode
 vineyardd:
 	docker buildx build ../ \
+		--build-arg MODE=release \
 		--progress=$(BUILD_PROGRESS) \
 		--file ./Dockerfile.vineyardd \
 		-t ghcr.io/v6d-io/v6d/vineyardd:$(ALPINE_TAG) \
 		--load \
 		--platform linux/$(ARCH)
 .PHONY: vineyardd
+
+# building standalone vineyardd in debug mode
+vineyardd-debug:
+	docker buildx build ../ \
+		--build-arg MODE=debug \
+		--progress=$(BUILD_PROGRESS) \
+		--file ./Dockerfile.vineyardd \
+		-t ghcr.io/v6d-io/v6d/vineyardd:$(ALPINE_DEBUG_TAG) \
+		--load \
+		--platform linux/$(ARCH)
+.PHONY: vineyardd-debug
 
 vineyardd-manifest:
 	docker manifest create $(ALPINE_REGISTRY)/$(ALPINE_IMAGE):$(ALPINE_MANIFEST_TAG) \


### PR DESCRIPTION
What do these changes do?
-------------------------

In release mode, the vineyardd image has no security issues.

```bash
$ trivy image ghcr.io/v6d-io/v6d/vineyardd:alpine-latest_x86_64        
2024-04-07T11:28:20.091+0800    INFO    Vulnerability scanning is enabled
2024-04-07T11:28:20.091+0800    INFO    Secret scanning is enabled
2024-04-07T11:28:20.091+0800    INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-04-07T11:28:20.091+0800    INFO    Please see also https://aquasecurity.github.io/trivy/v0.50/docs/scanner/secret/#recommendation for faster secret detection
2024-04-07T11:28:20.095+0800    INFO    Detected OS: alpine
2024-04-07T11:28:20.095+0800    INFO    Detecting Alpine vulnerabilities...
2024-04-07T11:28:20.097+0800    INFO    Number of language-specific files: 1
2024-04-07T11:28:20.097+0800    INFO    Detecting gobinary vulnerabilities...
2024-04-07T11:28:20.098+0800    WARN    This OS version is no longer supported by the distribution: alpine 3.14.6
2024-04-07T11:28:20.098+0800    WARN    The vulnerability detection may be insufficient because security updates are not provided

ghcr.io/v6d-io/v6d/vineyardd:alpine-latest_x86_64 (alpine 3.14.6)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```


Related issue number
--------------------

Fixes https://github.com/v6d-io/v6d/issues/1855

