### PR TITLE
build: add macos build patch

### DIFF
--- a/modules/llm-cache/storage/file_storage.cc
+++ b/modules/llm-cache/storage/file_storage.cc
@@ -663,8 +663,8 @@ void FileStorage::PrintFileAccessTime(std::string path) {
 
 std::string FileStorage::GetTimestamp(
     std::chrono::duration<int64_t, std::nano> time) {
-  std::chrono::time_point<std::chrono::system_clock> timestamp =
-      std::chrono::time_point<std::chrono::system_clock>(time);
+  auto duration_since_epoch = std::chrono::duration_cast<std::chrono::system_clock::duration>(time);
+  std::chrono::time_point<std::chrono::system_clock> timestamp = std::chrono::system_clock::time_point(duration_since_epoch);
   time_t t = std::chrono::system_clock::to_time_t(timestamp);
 
   std::tm tm;

--- a/modules/llm-cache/storage/local_file_storage.cc
+++ b/modules/llm-cache/storage/local_file_storage.cc
@@ -192,8 +192,13 @@ Status LocalFileStorage::GetFileAccessTime(
     return Status::IOError("Failed to get file access time: " +
                            formatIOError(path));
   }
-  accessTime = std::chrono::duration<int64_t, std::nano>(
-      statbuf.st_atim.tv_sec * SECOND_TO_NANOSECOND + statbuf.st_atim.tv_nsec);
+  #ifdef __APPLE__
+    accessTime = std::chrono::duration<int64_t, std::nano>(
+        statbuf.st_atimespec.tv_sec * SECOND_TO_NANOSECOND + statbuf.st_atimespec.tv_nsec);
+  #else
+    accessTime = std::chrono::duration<int64_t, std::nano>(
+        statbuf.st_atim.tv_sec * SECOND_TO_NANOSECOND + statbuf.st_atim.tv_nsec);
+  #endif
   return Status::OK();
 }
 


### PR DESCRIPTION


<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

fix the macos build failure, error logs are below:

```
/tmp/vineyard-20240419-52947-c35b1q/v6d-0.22.0/modules/llm-cache/storage/file_storage.cc:667:7: error: no matching conversion for functional-style cast from 'std::chrono::duration<int64_t, std::nano>' (aka 'duration<long long, ratio<1LL, 1000000000LL>>') to 'std::chrono::time_point<std::chrono::system_clock>'
      std::chrono::time_point<std::chrono::system_clock>(time);
      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```


```
/tmp/vineyard-20240419-52947-c35b1q/v6d-0.22.0/modules/llm-cache/storage/local_file_storage.cc:196:15: error: no member named 'st_atim' in 'stat'
      statbuf.st_atim.tv_sec * SECOND_TO_NANOSECOND + statbuf.st_atim.tv_nsec);
      ~~~~~~~ ^
/tmp/vineyard-20240419-52947-c35b1q/v6d-0.22.0/modules/llm-cache/storage/local_file_storage.cc:196:63: error: no member named 'st_atim' in 'stat'
      statbuf.st_atim.tv_sec * SECOND_TO_NANOSECOND + statbuf.st_atim.tv_nsec);
                                                      ~~~~~~~ ^
```




Related issue number
--------------------

fixes #1867


relates to https://github.com/Homebrew/homebrew-core/pull/169388