### PR TITLE
Fix the incompatible google-re2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,3 +22,4 @@ sphinx-copybutton
 sphinx-panels
 sphinxemoji
 sphinxext-opengraph
+google-re2==1.1


### PR DESCRIPTION
What do these changes do?
-------------------------

Fix ci errors:

https://github.com/v6d-io/v6d/actions/runs/9094070695/job/24994345286
https://github.com/v6d-io/v6d/actions/runs/9057457282/job/24882535493

