### PR TITLE
Defer object migration to avoid blocking the I/O thread.

### DIFF
--- a/python/client.cc
+++ b/python/client.cc
@@ -504,6 +504,10 @@ void bind_client(py::module& mod) {
       .def(
           "migrate",
           [](ClientBase* self, const ObjectID object_id) -> ObjectIDWrapper {
+            // Release GIL to avoid blocking the other threads
+            // See also
+            // https://pybind11.readthedocs.io/en/stable/advanced/misc.html#global-interpreter-lock-gil
+            py::gil_scoped_release release;
             ObjectID target_id = InvalidObjectID();
             throw_on_error(self->MigrateObject(object_id, target_id));
             return target_id;

--- a/src/server/async/socket_server.cc
+++ b/src/server/async/socket_server.cc
@@ -1746,7 +1746,8 @@ bool SocketConnection::doMigrateObject(const json& root) {
   TRY_READ_REQUEST(ReadMigrateObjectRequest, root, object_id);
 
   RESPONSE_ON_ERROR(server_ptr_->MigrateObject(
-      object_id, [self](const Status& status, const ObjectID& target) {
+      object_id, [self]() { return self->running_.load(); },
+      [self](const Status& status, const ObjectID& target) {
         std::string message_out;
         if (status.ok()) {
           WriteMigrateObjectReply(target, message_out);

--- a/src/server/server/vineyard_server.h
+++ b/src/server/server/vineyard_server.h
@@ -174,8 +174,10 @@ class VineyardServer : public std::enable_shared_from_this<VineyardServer> {
 
   Status DropName(const std::string& name, callback_t<> callback);
 
-  Status MigrateObject(const ObjectID object_id,
-                       callback_t<const ObjectID&> callback);
+  Status MigrateObject(
+      const ObjectID object_id,
+      DeferredReq::alive_t alive,  // if connection is still alive
+      callback_t<const ObjectID&> callback);
 
   Status LabelObjects(const ObjectID object_id,
                       const std::vector<std::string>& keys,
@@ -280,8 +282,7 @@ class VineyardServer : public std::enable_shared_from_this<VineyardServer> {
   std::mutex migrations_origin_to_target_mutex_;
   std::mutex migrations_target_to_origin_mutex_;
   // Record the migration status of objects to avoid duplicated migration.
-  std::unordered_map<ObjectID, std::shared_future<std::pair<Status, ObjectID>>>
-      migrations_origin_to_target_;
+  std::unordered_map<ObjectID, ObjectID> migrations_origin_to_target_;
   std::unordered_map<ObjectID, ObjectID> migrations_target_to_origin_;
 };
 


### PR DESCRIPTION
What do these changes do?
-------------------------

A follow-up of https://github.com/v6d-io/v6d/pull/1920

Related issue number
--------------------

Fixes https://github.com/v6d-io/v6d/issues/1924

