### PR TITLE
Fix the inconsistent dataframe in the dataframe_resolver

### DIFF
--- a/python/vineyard/data/dataframe.py
+++ b/python/vineyard/data/dataframe.py
@@ -509,7 +509,7 @@ def pandas_dataframe_resolver(obj, resolver):
         elif len(np_value.shape) == 1:
             values = np.expand_dims(np_value, 0).view(ndarray)
             setattr(values, '__vineyard_ref', getattr(np_value, '__vineyard_ref', None))
-            if isinstance(np_value, ndarray):
+            if isinstance(values, ndarray):
                 values = np.asarray(values)
             block = Block(values, placement, ndim=2)
         else:


### PR DESCRIPTION
What do these changes do?
-------------------------

In the following case, the current dataframe_resolver still failed.

```python
import pandas as pd
import vineyard
vineyard_client = vineyard.connect()
df = pd.DataFrame({'a': [1, 2, 3, 4], 'b': ['5', '6', '7', '8']})
df = df.iloc[0:0]
object_id = vineyard_client.put(df)
pd.testing.assert_frame_equal(df, vineyard_client.get(object_id))
```


Related issue number
--------------------

A missing piece of https://github.com/v6d-io/v6d/pull/1931
