### PR TITLE
Fix destructor function bug of RPCServer

### DIFF
--- a/src/server/async/rpc_server.cc
+++ b/src/server/async/rpc_server.cc
@@ -41,7 +41,8 @@ RPCServer::RPCServer(std::shared_ptr<VineyardServer> vs_ptr)
   acceptor_.listen();
 }
 
-RPCServer::~RPCServer() {
+void RPCServer::Stop() {
+  SocketServer::Stop();
   if (acceptor_.is_open()) {
     acceptor_.close();
   }

--- a/src/server/async/rpc_server.h
+++ b/src/server/async/rpc_server.h
@@ -41,7 +41,11 @@ class RPCServer : public SocketServer,
  public:
   explicit RPCServer(std::shared_ptr<VineyardServer> vs_ptr);
 
+  ~RPCServer() override;
+
   void Start() override;
+
+  void Stop() override;
 
   std::string Endpoint() {
     return get_hostname() + ":" + json_to_string(rpc_spec_["port"]);
@@ -57,8 +61,6 @@ class RPCServer : public SocketServer,
 
   Status Register(std::shared_ptr<SocketConnection> conn,
                   const SessionID session_id) override;
-
-  void Stop() override;
 
  private:
   asio::ip::tcp::endpoint getEndpoint(asio::io_context&);
@@ -86,6 +88,8 @@ class RPCServer : public SocketServer,
   const json rpc_spec_;
   asio::ip::tcp::acceptor acceptor_;
   asio::ip::tcp::socket socket_;
+  std::mutex accept_mutex_;
+  bool is_accepting_ = false;
 
   // connection id to rdma server
   std::unordered_map<uint64_t, std::map<void*, RegisterMemInfo>>

--- a/src/server/async/rpc_server.h
+++ b/src/server/async/rpc_server.h
@@ -41,8 +41,6 @@ class RPCServer : public SocketServer,
  public:
   explicit RPCServer(std::shared_ptr<VineyardServer> vs_ptr);
 
-  ~RPCServer() override;
-
   void Start() override;
 
   std::string Endpoint() {
@@ -59,6 +57,8 @@ class RPCServer : public SocketServer,
 
   Status Register(std::shared_ptr<SocketConnection> conn,
                   const SessionID session_id) override;
+
+  void Stop() override;
 
  private:
   asio::ip::tcp::endpoint getEndpoint(asio::io_context&);

--- a/src/server/async/socket_server.h
+++ b/src/server/async/socket_server.h
@@ -236,7 +236,7 @@ class SocketServer {
   /**
    * Call "Stop" on all connections, then clear the connection pool.
    */
-  void Stop();
+  virtual void Stop();
 
   /**
    * Cancel the "async_accept" action on the acceptor to stop accepting


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

Currently vineyard server and RPCServer save each other's shared pointers. This will cause the code in the destructor to not be called when vineyardd exits. The resource release operation is therefore moved to the Stop function.

