### PR TITLE
Remove libfabric.a from VINEYARD_INSTALL_LIBS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -746,7 +746,6 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
                         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/thirdparty/libfabric/include>
                         $<INSTALL_INTERFACE:include/vineyard/contrib>
     )
-    list(APPEND VINEYARD_INSTALL_LIBS ${LIBFABRIC})
 
     set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES
                     ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/libfabric.a)


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

As tittled.


Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1957 

