### PR TITLE
Add the timeout options for vineyard client.

### DIFF
--- a/python/client.cc
+++ b/python/client.cc
@@ -605,6 +605,8 @@ void bind_client(py::module& mod) {
            })
       .def_property("compression", &ClientBase::compression_enabled,
                     &ClientBase::set_compression_enabled)
+      .def_property("timeout_seconds", &ClientBase::get_timeout_seconds,
+                    &ClientBase::set_timeout_seconds)
       .def_property_readonly("ipc_socket", &ClientBase::IPCSocket,
                              doc::ClientBase_ipc_socket)
       .def_property_readonly("rpc_endpoint", &ClientBase::RPCEndpoint,

--- a/python/vineyard/core/client.py
+++ b/python/vineyard/core/client.py
@@ -323,6 +323,21 @@ class Client:
         self._spread = value
 
     @property
+    def timeout_seconds(self) -> int:
+        """
+        The timeout seconds for underlying client.
+        Default is 300 seconds.
+        """
+        return self.default_client().timeout_seconds
+
+    @timeout_seconds.setter
+    def timeout_seconds(self, value: int):
+        if self._ipc_client:
+            self._ipc_client.timeout_seconds = value
+        if self._rpc_client:
+            self._rpc_client.timeout_seconds = value
+
+    @property
     def ipc_client(self) -> IPCClient:
         assert self._ipc_client is not None, "IPC client is not available."
         return self._ipc_client

--- a/src/client/client_base.cc
+++ b/src/client/client_base.cc
@@ -559,7 +559,7 @@ Status ClientBase::doWrite(const std::string& message_out) {
 }
 
 Status ClientBase::doRead(std::string& message_in) {
-  auto status = recv_message(vineyard_conn_, message_in);
+  auto status = recv_message(vineyard_conn_, message_in, timeout_seconds_);
   if (!status.ok()) {
     connected_ = false;
   }

--- a/src/client/client_base.h
+++ b/src/client/client_base.h
@@ -652,6 +652,10 @@ class ClientBase {
     }
   }
 
+  void set_timeout_seconds(int seconds) { timeout_seconds_ = seconds; }
+
+  int get_timeout_seconds() const { return timeout_seconds_; }
+
  protected:
   Status doWrite(const std::string& message_out);
 
@@ -673,6 +677,9 @@ class ClientBase {
 
   // Options
   bool compression_enabled_ = false;
+
+  // The timeout seconds for the client to wait for the server to respond.
+  int timeout_seconds_ = 300;
 };
 
 struct InstanceStatus {

--- a/src/client/io.h
+++ b/src/client/io.h
@@ -36,9 +36,9 @@ Status send_bytes(int fd, const void* data, size_t length);
 
 Status send_message(int fd, const std::string& msg);
 
-Status recv_bytes(int fd, void* data, size_t length);
+Status recv_bytes(int fd, void* data, size_t length, int timeout_seconds);
 
-Status recv_message(int fd, std::string& msg);
+Status recv_message(int fd, std::string& msg, int timeout_seconds);
 
 Status check_fd(int fd);
 


### PR DESCRIPTION
What do these changes do?
-------------------------

Usage
```
client.timeout_seconds = 10

# The underlying operations will respect the timeout seconds
client.get_meta()
client.get()
```


Related issue number
--------------------

Fixes https://github.com/v6d-io/v6d/issues/1973

