### PR TITLE
Clear all migrating locked object when client crashed.

### DIFF
--- a/src/server/async/rpc_server.cc
+++ b/src/server/async/rpc_server.cc
@@ -329,6 +329,9 @@ void RPCServer::doVineyardReleaseMemory(VineyardRecvContext* recv_context,
 
 void RPCServer::doVineyardClose(VineyardRecvContext* recv_context) {
   VLOG(100) << "Receive close msg!";
+  if (recv_context == nullptr) {
+    return;
+  }
   rdma_server_->CloseConnection(recv_context->rdma_conn_id);
 
   std::lock_guard<std::recursive_mutex> scope_lock(this->rdma_mutex_);
@@ -369,6 +372,9 @@ void RPCServer::doRDMARecv() {
         VineyardRecvContext* recv_context =
             reinterpret_cast<VineyardRecvContext*>(context);
         doVineyardClose(recv_context);
+        if (recv_context) {
+          delete recv_context;
+        }
       }
       VLOG(100) << "Get RX completion failed! Error:" << status.message();
       VLOG(100) << "Retry...";

--- a/src/server/async/socket_server.h
+++ b/src/server/async/socket_server.h
@@ -24,6 +24,7 @@ limitations under the License.
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 #include "common/memory/payload.h"
 #include "common/util/asio.h"  // IWYU pragma: keep
@@ -193,6 +194,12 @@ class SocketConnection : public std::enable_shared_from_this<SocketConnection> {
     this->server_ptr_ = session;
   }
 
+  void LockTransmissionObjects(const std::vector<ObjectID>& ids);
+
+  void UnlockTransmissionObjects(const std::vector<ObjectID>& ids);
+
+  void ClearLockedObjects();
+
   // whether the connection has been correctly "registered"
   std::atomic_bool registered_;
 
@@ -215,6 +222,9 @@ class SocketConnection : public std::enable_shared_from_this<SocketConnection> {
 
   size_t read_msg_header_;
   std::string read_msg_body_;
+
+  std::unordered_map<ObjectID, int> locked_objects_;
+  std::mutex locked_objects_mutex_;
 
   friend class IPCServer;
   friend class RPCServer;


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/v6d-io/v6d/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

What do these changes do?
-------------------------

As tittled.


Related issue number
--------------------

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1977 

