### PR TITLE
Fix make vineyard_client_python on macos.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1011,7 +1011,9 @@ if(BUILD_VINEYARD_PYTHON_BINDINGS)
         DEPENDS _C vineyard_internal_registry
         COMMENT "Copying python extensions."
         VERBATIM)
-    set_target_properties(_C PROPERTIES LINK_FLAGS "-Wl,--version-script=${LIBFABRIC_VERSION_SCRIPT}")
+    if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+        set_target_properties(_C PROPERTIES LINK_FLAGS "-Wl,--version-script=${LIBFABRIC_VERSION_SCRIPT}")
+    endif()
 endif()
 
 if(BUILD_VINEYARD_PYTHON_BINDINGS AND BUILD_VINEYARD_LLM_CACHE)
@@ -1027,7 +1029,9 @@ if(BUILD_VINEYARD_PYTHON_BINDINGS AND BUILD_VINEYARD_LLM_CACHE)
         DEPENDS _llm_C
         COMMENT "Copying llm kv cache python extensions."
         VERBATIM)
-    set_target_properties(_llm_C PROPERTIES LINK_FLAGS "-Wl,--version-script=${LIBFABRIC_VERSION_SCRIPT}")
+    if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+        set_target_properties(_llm_C PROPERTIES LINK_FLAGS "-Wl,--version-script=${LIBFABRIC_VERSION_SCRIPT}")
+    endif()
     add_dependencies(vineyard_llm_python vineyard_client_python)
 endif()
 


### PR DESCRIPTION
What do these changes do?
-------------------------

When running `make vineyard_client_python` on macos, get the following error:
```
ld: unknown option: --version-script=
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

